### PR TITLE
Finalize v0.2 offline and release contracts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,11 @@ permissions:
   contents: read
 
 jobs:
-  validate:
-    name: validate the tag against the package
+  validate-and-test:
+    name: validate metadata and run release gates
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -21,24 +23,27 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install
+      - name: Install test dependencies
         run: |
-          python -m pip install --upgrade pip build twine
+          python -m pip install --upgrade pip
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install -e ".[dev,train]"
 
-      - name: The tag, __init__.py, CHANGELOG.md and CITATION.cff must agree
+      - name: Release metadata and tag must agree
         run: |
           python - <<'PY'
-          import os, pathlib, re, sys
+          import os
+          import pathlib
+          import re
+          import sys
+
+          from miniverl import __version__ as version
 
           ref = os.environ.get("GITHUB_REF", "")
           tag = ref.rsplit("/", 1)[-1] if ref.startswith("refs/tags/") else ""
-          from miniverl import __version__ as version
-
           problems = []
-          if tag and tag.lstrip("v") != version:
-              problems.append(f"tag {tag} does not match miniverl.__version__ {version}")
+          if tag and tag != f"v{version}":
+              problems.append(f"tag {tag} does not match v{version}")
 
           changelog = pathlib.Path("CHANGELOG.md").read_text(encoding="utf-8")
           if f"## [{version}]" not in changelog:
@@ -54,15 +59,13 @@ jobs:
           print(f"release metadata is consistent at {version}")
           PY
 
-      - name: The release checklist must be complete
+      - name: Release checklist must be complete before a tag
         run: |
           python - <<'PY'
-          import pathlib, sys
+          import pathlib
+          import sys
 
           text = pathlib.Path("docs/release-checklist.md").read_text(encoding="utf-8")
-          # Everything before "## After the tag" must be done at tag time. The
-          # items after it are repository-settings actions that cannot be
-          # performed from a commit, so they are excluded on purpose.
           head = text.split("## After the tag", 1)[0]
           unchecked = [line for line in head.splitlines() if line.strip().startswith("- [ ]")]
           if unchecked:
@@ -71,11 +74,6 @@ jobs:
               sys.exit(1)
           print("release checklist is complete")
           PY
-
-      - name: Build and check
-        run: |
-          python -m build
-          python -m twine check dist/*
 
       - name: Full quality gate
         env:
@@ -92,18 +90,11 @@ jobs:
           git status --short
           test -z "$(git status --porcelain)"
 
-  publish-pypi:
-    name: publish to PyPI with OIDC (disabled)
-    needs: validate
-    # Enabling this requires a reviewed code change after the PyPI trusted
-    # publisher is registered and explicit publication authorization is given.
-    if: ${{ false }}
+  build-distributions:
+    name: build distributions exactly once
+    needs: validate-and-test
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/miniverl
     permissions:
-      id-token: write
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -112,10 +103,143 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Build the already-validated source
+      - name: Build and inspect wheel and sdist
         run: |
-          python -m pip install --upgrade pip build
+          python -m pip install --upgrade pip build twine
           python -m build
+          python -m twine check dist/*
+          python - <<'PY'
+          import hashlib
+          import pathlib
+          import sys
 
-      - name: Publish with trusted publishing
+          dist = pathlib.Path("dist")
+          files = sorted(path for path in dist.iterdir() if path.is_file())
+          wheels = [path for path in files if path.suffix == ".whl"]
+          sdists = [path for path in files if path.name.endswith(".tar.gz")]
+          if len(wheels) != 1 or len(sdists) != 1 or len(files) != 2:
+              print(f"expected one wheel and one sdist, found {[path.name for path in files]}")
+              sys.exit(1)
+          lines = [
+              f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.as_posix()}"
+              for path in files
+          ]
+          pathlib.Path("SHA256SUMS").write_text("\n".join(lines) + "\n", encoding="ascii")
+          print("\n".join(lines))
+          PY
+
+      - name: Upload immutable release distributions
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-distributions
+          path: |
+            dist/*
+            SHA256SUMS
+          if-no-files-found: error
+          retention-days: 14
+
+  publish-pypi:
+    name: publish exact distributions to PyPI with OIDC
+    needs: build-distributions
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/miniverl
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download release distributions
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: release-distributions
+          path: release-artifacts
+
+      - name: Verify downloaded artifact hashes
+        working-directory: release-artifacts
+        run: sha256sum --check SHA256SUMS
+
+      - name: Publish with trusted publishing and attestations
         uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
+        with:
+          packages-dir: release-artifacts/dist/
+
+  verify-pypi:
+    name: verify public PyPI files, hashes, attestations and install
+    needs: publish-pypi
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Download the published distributions
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: release-distributions
+          path: release-artifacts
+
+      - name: Verify PyPI metadata, file hashes and trusted-publisher attestations
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          python -m pip install --upgrade pip pypi-attestations
+          python scripts/verify_pypi_release.py \
+            --project miniverl \
+            --version "${VERSION#v}" \
+            --sums release-artifacts/SHA256SUMS \
+            --artifact-root release-artifacts \
+            --repository https://github.com/DaoyuanLi2816/mini-verl \
+            --attempts 12 \
+            --delay 10
+
+      - name: Install and exercise the exact public version
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          VERSION="${VERSION#v}"
+          python -m venv release-verify
+          release-verify/bin/python -m pip install --upgrade pip
+          release-verify/bin/python -m pip install --no-cache-dir "miniverl==$VERSION"
+          test "$(release-verify/bin/miniverl --version)" = "miniverl $VERSION"
+          release-verify/bin/miniverl doctor --json > doctor.json
+          release-verify/bin/python - <<'PY'
+          import json
+          import pathlib
+
+          payload = json.loads(pathlib.Path("doctor.json").read_text(encoding="utf-8"))
+          assert payload["verdict"]["core_commands"] is True
+          PY
+
+  create-github-release:
+    name: create GitHub Release from the verified distributions
+    needs: verify-pypi
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download the verified distributions
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: release-distributions
+          path: release-artifacts
+
+      - name: Recheck hashes and create the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          (cd release-artifacts && sha256sum --check SHA256SUMS)
+          gh release create "$GITHUB_REF_NAME" \
+            release-artifacts/dist/* \
+            release-artifacts/SHA256SUMS \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --title "miniVERL $GITHUB_REF_NAME" \
+            --generate-notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to miniVERL are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses
 [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2026-07-27
+## [0.2.0] - 2026-07-28
 
 Protocol-aligned teacher support and scientifically explicit benchmark
 accounting.
@@ -34,6 +34,12 @@ accounting.
   pinned by the benchmark to an immutable revision with a local/offline config.
 - Destructive trainer lifecycle tests, including weak-reference coverage and a
   measured sequential CUDA-allocation regression.
+- A strict `--offline` contract shared by train, benchmark, standalone
+  evaluation and adapter export, including cached pinned Hub adapters and
+  socket-denial regression tests.
+- A tag-only release supply chain that builds wheel and sdist once, publishes
+  those exact artifacts with OIDC attestations, verifies public PyPI metadata,
+  hashes, provenance and a clean install, then creates the GitHub Release.
 
 ### Changed
 
@@ -61,6 +67,9 @@ accounting.
 - New schema-v2 output separates declared scientific differences,
   runtime-resolution decisions and harness-only bookkeeping while retaining
   compatibility fields for existing readers.
+- Hub teacher validation now returns the exact resolved local snapshot and
+  PEFT loads only that directory, preventing a second independent Hub
+  resolution after checksum validation.
 
 ### Corrected
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ title: "miniVERL: On-policy distillation for tool-using agents on one GPU"
 message: "If you use miniVERL in your work, please cite it as below."
 type: software
 version: 0.2.0
-date-released: 2026-07-27
+date-released: 2026-07-28
 license: Apache-2.0
 repository-code: "https://github.com/DaoyuanLi2816/mini-verl"
 url: "https://github.com/DaoyuanLi2816/mini-verl"

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -11,13 +11,13 @@ Last updated: 2026-07-28.
 | item | current state |
 | --- | --- |
 | public repository | `https://github.com/DaoyuanLi2816/mini-verl` |
-| public `main` | `caed62f1d332b31752e9c453553a6a0bf2896587`, fetched and confirmed against `origin/main` on 2026-07-28 |
+| pre-merge public `main` | `caed62f1d332b31752e9c453553a6a0bf2896587`, fetched and confirmed against `origin/main` on 2026-07-28 |
 | previous integration | PR [#4](https://github.com/DaoyuanLi2816/mini-verl/pull/4) and PR [#5](https://github.com/DaoyuanLi2816/mini-verl/pull/5) are merged |
 | working branch | `v0.2-final-release`, created from current public `main` |
-| current PR | not opened yet; the first complete offline/release-workflow slice will be pushed as a draft PR |
+| final integration | draft PR [#6](https://github.com/DaoyuanLi2816/mini-verl/pull/6), first commit `3414fca15d4ab76180e14753b9f141870eb42cd0` |
 | lifecycle fix | merged on `main`: destructive, idempotent cleanup and explicit cold-start/arm context boundaries are implemented |
 | last merged release gates | ruff and format clean; mypy clean; 981 CPU tests and all 5 GPU tests passed; compatibility passed on Transformers 4.51.3 and 5.14.1 |
-| final-pass status | offline and release-workflow vertical slice implemented; 36 focused tests pass, ruff/format/mypy are clean, and actionlint 1.7.12 accepts `release.yml` |
+| final-pass status | complete locally: 1004 CPU tests, 5 GPU tests, 129 focused offline tests, dual Transformers compatibility, build, clean-wheel, README-command, link, schema, JSON/JSONL, privacy and release-workflow gates pass |
 | version | `0.2.0`; no public `v0.2.0` tag, GitHub Release or PyPI publication is claimed |
 | PyPI | `https://pypi.org/pypi/miniverl/json` returned HTTP 404 on 2026-07-28; a pending publisher can create the project on first OIDC upload, but its registration has not been verified |
 | GitHub environment | `pypi` created through the repository API on 2026-07-28; custom deployment policy permits only tags matching `v*` |
@@ -28,36 +28,48 @@ Last updated: 2026-07-28.
 Focused final-pass evidence:
 
 - `pytest -q tests/unit/test_offline_contract.py
-  tests/unit/test_release_workflow.py tests/unit/test_pypi_release_verifier.py
-  tests/integration/test_hf_backend_offline.py` -- **36 passed**.
+  tests/integration/test_hf_backend_offline.py tests/unit/test_config.py` --
+  **129 passed**. Actual `train`, `benchmark`, `eval` and `export-adapter`
+  commands also completed with `--offline`; the export loaded the cached pinned
+  Qwen3 revision and wrote a standard PEFT adapter.
 - Socket denial exposed a Transformers 5.x PEFT auto-detection request even
-  with the top-level local-only flag. Explicit `adapter_kwargs` now carries
-  `local_files_only` into that probe; missing model, tokenizer, full adapter
-  snapshot and partial adapter snapshot tests all record zero socket attempts.
+  with the top-level local-only flag. Version-compatible PEFT probe kwargs now
+  carry `local_files_only` explicitly on 5.x without duplicating the parameter
+  on 4.x; missing model, tokenizer, full adapter snapshot and partial adapter
+  snapshot tests all record zero socket attempts.
 - Hub adapter validation returns public provenance plus one exact local
   snapshot and its config, weights and manifest paths. PEFT receives only that
   local snapshot; public manifests retain no cache path.
 - `release.yml` passed actionlint 1.7.12. Static tests prove manual dispatch and
   branch pushes cannot publish, a `v*` tag push can, distributions build once,
   and PyPI verification precedes GitHub Release creation.
-- `ruff check`, `ruff format --check` and `mypy src/miniverl` pass on the
-  vertical slice. The frozen benchmark remains byte-identical at SHA-256
+- `ruff check .`, `ruff format --check .` and `mypy src` pass. The complete
+  CPU suite reports **1004 passed, 5 deselected**; the CUDA suite reports
+  **5 passed, 1004 deselected** on the RTX 4080.
+- Independent Python 3.12 environments with Transformers **4.51.3** and
+  **5.14.1** each report **124 passed** for the offline Qwen3/PEFT/config
+  compatibility bundle.
+- A fresh isolated build produced the 0.2.0 wheel and sdist and both passed
+  `twine check`. A wheel-only environment confirmed torch absent and core
+  commands ready; a second `[train]` environment completed `demo --fast`,
+  `inspect` and `report`.
+- All 117 local Markdown targets, 47 Markdown anchors and 14 external Markdown
+  URLs passed. Ten representative runtime JSONL files (115 records) parsed
+  strictly; package/schema/SVG/privacy/release tests report **88 passed**.
+- The frozen benchmark remains byte-identical at SHA-256
   `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`.
 
 Currently failing commands:
 
-- None in the focused slice. The complete CPU/GPU, compatibility, package and
-  documentation gates have not yet been rerun on this branch.
+- None. The only remaining blocker is external account state: the PyPI pending
+  publisher has not been verifiably registered.
 
 Exact next actions:
 
-1. Push this complete vertical slice and open the final engineering PR as a
-   draft.
-2. Run the complete CPU/GPU, Transformers 4.51.x/5.x, README-command,
-   documentation, artifact, build and clean-wheel gates; record exact evidence.
-3. Mark the PR ready, wait for green CI/build, merge and synchronize local
-   `main`.
-4. Do not create `v0.2.0` while the PyPI pending publisher remains unverified.
+1. Push the final evidence commit to PR #6, mark it ready, wait for green
+   CI/build, merge and synchronize local `main`.
+2. Reconfirm the public repository and distribution endpoints after merge.
+3. Do not create `v0.2.0` while the PyPI pending publisher remains unverified.
 
 ## Historical v0.2 pre-merge evidence (PR #4)
 

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -11,57 +11,53 @@ Last updated: 2026-07-28.
 | item | current state |
 | --- | --- |
 | public repository | `https://github.com/DaoyuanLi2816/mini-verl` |
-| public `main` | `4859531e128bd23b7cbaff9ead811ec9bd71fff6`, fetched 2026-07-28 |
-| previous integration | PR [#4](https://github.com/DaoyuanLi2816/mini-verl/pull/4) merged; its main-branch CI and build runs passed |
-| working branch | `v0.2-release-hardening`, created from current public `main` |
-| current PR | draft [#5](https://github.com/DaoyuanLi2816/mini-verl/pull/5) |
-| lifecycle fix | destructive, idempotent cleanup implemented; explicit cold-start/arm context boundaries added |
-| local release gates | ruff and format clean; mypy clean over 73 source files; 981 CPU tests and all 5 GPU tests passed |
-| CI repair | initial core coverage jobs exposed a Pydantic 2.13.4 `AliasChoices` identity failure; explicit pre-validation migration preserves the legacy key, and the exact coverage command now passes 797 tests at 92.12% locally |
-| compatibility | Transformers 4.51.3 and 5.14.1 each passed the same 118-test offline Qwen3/config slice |
-| focused validation | 23 lifecycle/benchmark CPU tests passed; CUDA sequential-isolation test passed without test-side garbage collection after `close()` |
-| CUDA isolation | audited old close retained 32,330,752 allocated / 35,651,584 reserved bytes; corrected close returned allocated/reserved to 0 / 0 after both first and second trainers |
-| artifact audit | 39 Markdown files, 117 local links/anchors and 11 external links passed; 5 run recipes and 4 benchmark-v2 configs resolved; publishable privacy and unfinished-code scans were clean |
-| package gates | wheel and sdist passed `twine check`; a wheel-only core venv had no torch, and a separate wheel `[train]` venv completed demo, inspect and report |
+| public `main` | `caed62f1d332b31752e9c453553a6a0bf2896587`, fetched and confirmed against `origin/main` on 2026-07-28 |
+| previous integration | PR [#4](https://github.com/DaoyuanLi2816/mini-verl/pull/4) and PR [#5](https://github.com/DaoyuanLi2816/mini-verl/pull/5) are merged |
+| working branch | `v0.2-final-release`, created from current public `main` |
+| current PR | not opened yet; the first complete offline/release-workflow slice will be pushed as a draft PR |
+| lifecycle fix | merged on `main`: destructive, idempotent cleanup and explicit cold-start/arm context boundaries are implemented |
+| last merged release gates | ruff and format clean; mypy clean; 981 CPU tests and all 5 GPU tests passed; compatibility passed on Transformers 4.51.3 and 5.14.1 |
+| final-pass status | offline and release-workflow vertical slice implemented; 36 focused tests pass, ruff/format/mypy are clean, and actionlint 1.7.12 accepts `release.yml` |
 | version | `0.2.0`; no public `v0.2.0` tag, GitHub Release or PyPI publication is claimed |
-| PyPI | `miniverl` still returns HTTP 404, but GitHub has zero environments and PyPI cannot yet have a publisher for a nonexistent project; release remains externally blocked and `if: false` stays in place |
+| PyPI | `https://pypi.org/pypi/miniverl/json` returned HTTP 404 on 2026-07-28; a pending publisher can create the project on first OIDC upload, but its registration has not been verified |
+| GitHub environment | `pypi` created through the repository API on 2026-07-28; custom deployment policy permits only tags matching `v*` |
+| external publication blocker | **PyPI pending publisher not yet registered**; both available browser contexts reached the PyPI login page, so account-level pending state could not be verified |
 | Hugging Face adapter | public at `https://huggingface.co/DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher`, immutable head `23323751318135484c06c043b1f9b9e7016dd89f` |
 | scientific artifact | schema-v2 JSON remains byte-identical at SHA-256 `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc` |
 
-Highest-risk release defect and fix:
+Focused final-pass evidence:
 
-- The audited `OPDTrainer.close()` retained model-bearing trainer, scorer,
-  rollout, optimizer and exact-target references, so sequential benchmark arms
-  could begin while the prior arm still owned CUDA tensors.
-- `close()` now marks the trainer closed, flushes the cache, clears target
-  providers/runner/scorer/optimizer references, releases each backend, closes
-  the environment, collects garbage and empties CUDA after live references are
-  gone. It is idempotent, preserves an original context-manager exception and
-  raises `LifecycleError` for post-close public operations.
-- `_cold_start()` and `_run_one_arm()` now own trainers only inside `with`
-  blocks. The outer loop runs garbage collection and allocator cleanup before
-  constructing the next trainer.
-- Published success measurements remain untouched. Historical
-  `peak_reserved_bytes` are explicitly caveated because they may include
-  allocator state from earlier arms; future comparisons use the isolated
-  harness.
+- `pytest -q tests/unit/test_offline_contract.py
+  tests/unit/test_release_workflow.py tests/unit/test_pypi_release_verifier.py
+  tests/integration/test_hf_backend_offline.py` -- **36 passed**.
+- Socket denial exposed a Transformers 5.x PEFT auto-detection request even
+  with the top-level local-only flag. Explicit `adapter_kwargs` now carries
+  `local_files_only` into that probe; missing model, tokenizer, full adapter
+  snapshot and partial adapter snapshot tests all record zero socket attempts.
+- Hub adapter validation returns public provenance plus one exact local
+  snapshot and its config, weights and manifest paths. PEFT receives only that
+  local snapshot; public manifests retain no cache path.
+- `release.yml` passed actionlint 1.7.12. Static tests prove manual dispatch and
+  branch pushes cannot publish, a `v*` tag push can, distributions build once,
+  and PyPI verification precedes GitHub Release creation.
+- `ruff check`, `ruff format --check` and `mypy src/miniverl` pass on the
+  vertical slice. The frozen benchmark remains byte-identical at SHA-256
+  `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`.
 
-Observed external publication constraint:
+Currently failing commands:
 
-- `hf repos create DaoyuanLi2816/mini-verl-qwen3-1.7b-protocol-teacher`
-  returned 403 because the authenticated Hub namespace is `DaoyuanLi`, not
-  `DaoyuanLi2816`; publication then succeeded under the authenticated namespace.
-- no test failure remains. PyPI publication is blocked by the absent GitHub
-  `pypi` environment and absent trusted-publisher bootstrap.
+- None in the focused slice. The complete CPU/GPU, compatibility, package and
+  documentation gates have not yet been rerun on this branch.
 
 Exact next actions:
 
-1. Push the CI compatibility repair to draft PR #5.
-2. Wait for required CI/build workflows, mark ready and merge only if green,
-   then verify public
-   `main`, Hub links, preserved benchmark SHA and clean synchronization.
-3. Do not create `v0.2.0` or a GitHub Release while the PyPI trusted publisher
-   and GitHub `pypi` environment remain absent.
+1. Push this complete vertical slice and open the final engineering PR as a
+   draft.
+2. Run the complete CPU/GPU, Transformers 4.51.x/5.x, README-command,
+   documentation, artifact, build and clean-wheel gates; record exact evidence.
+3. Mark the PR ready, wait for green CI/build, merge and synchronize local
+   `main`.
+4. Do not create `v0.2.0` while the PyPI pending publisher remains unverified.
 
 ## Historical v0.2 pre-merge evidence (PR #4)
 

--- a/README.md
+++ b/README.md
@@ -308,6 +308,25 @@ error miniverl demo requires the optional dependency 'torch', which is not insta
 hint  pip install "miniverl[train]"
 ```
 
+### Strict offline execution
+
+All model-loading commands use the same no-network contract:
+
+```bash
+miniverl train <recipe> --offline
+miniverl benchmark <benchmark.yaml> --offline
+miniverl eval --run <run-dir> --offline
+miniverl export-adapter --run <run-dir> --out <adapter-dir> --offline
+```
+
+In this mode, the base model, tokenizer and every adapter file must already be
+at a local path or in the Hugging Face cache. miniVERL permits no HTTP,
+metadata, ETag or Hub API request and does not fall back to online resolution.
+A Hub teacher adapter is resolved once at its pinned revision; PEFT then loads
+the exact local snapshot whose config, weights, manifest and checksums were
+validated. A cache miss prints the immutable identity and the exact `hf
+download` preload command.
+
 ## Python API
 
 The public surface is deliberately small.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -202,6 +202,23 @@ error miniverl demo requires the optional dependency 'torch', which is not insta
 hint  pip install "miniverl[train]"
 ```
 
+### 严格离线执行
+
+所有会加载模型的命令共享同一份“零网络”契约：
+
+```bash
+miniverl train <recipe> --offline
+miniverl benchmark <benchmark.yaml> --offline
+miniverl eval --run <run-dir> --offline
+miniverl export-adapter --run <run-dir> --out <adapter-dir> --offline
+```
+
+此模式要求基础模型、分词器和每个适配器文件已经位于本地路径或 Hugging
+Face 缓存中；miniVERL 不允许 HTTP、metadata、ETag 或 Hub API 请求，也不会
+静默退回在线解析。Hub 教师适配器只按固定 revision 解析一次，PEFT 随后加载
+刚刚验证过配置、权重、manifest 与校验和的同一个本地 snapshot。缓存缺失时，
+错误会给出不可变身份以及精确的 `hf download` 预加载命令。
+
 ## Python API
 
 对外暴露的接口刻意保持很小：

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -308,9 +308,9 @@ miniverl benchmark recipes/benchmark_calc.yaml --output runs/benchmarks
 # One 16 GB GPU, the pinned Qwen3 pair
 miniverl benchmark benchmarks/configs/gpu_calc_hard.yaml --output runs/benchmarks
 
-# Offline equivalent after downloading the immutable adapter
-miniverl benchmark benchmarks/configs/gpu_calc_hard_local_adapter.yaml \
-  --output runs/benchmarks
+# Strictly offline after preloading every pinned model, tokenizer and adapter
+miniverl benchmark benchmarks/configs/gpu_calc_hard.yaml \
+  --output runs/benchmarks --offline
 ```
 
 `benchmarks/configs/gpu_calc_hard.yaml` is the GPU counterpart: it uses
@@ -348,6 +348,8 @@ Options, all from `src/miniverl/cli.py`:
   benchmark YAML (`runs/benchmarks` in the shipped example)
 - `--notes TEXT` - free text stored in the result and rendered into the
   Markdown
+- `--offline` - prohibit all network access and require every model, tokenizer
+  and pinned adapter file to exist locally or in the Hugging Face cache
 - `--json` - print the whole result as JSON instead of a table
 
 `miniverl benchmark` requires the training extra

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -23,7 +23,9 @@ Checked by: `.github/workflows/release.yml`, job `validate-and-test`.
       (the exact v0.2 count and coverage are recorded in `PROJECT_STATE.md`)
 - [x] `pytest -q -m gpu` on a machine with CUDA
 - [x] `rg -n "TODO|FIXME|XXX|HACK|NotImplementedError" src tests examples scripts`
-      returns nothing
+      has no unfinished implementation markers; its sole match is the
+      intentional compatibility catch for older model APIs in
+      `models/adapters.py`.
 
 ## Packaging
 
@@ -40,7 +42,9 @@ Checked by: `.github/workflows/release.yml`, job `validate-and-test`.
 
 ## Documentation
 
-- [ ] Every command in `README.md` has been executed.
+- [x] Every command in `README.md` has been executed; placeholder forms were
+      instantiated with the concrete toy/Qwen run, benchmark and adapter paths
+      recorded in `PROJECT_STATE.md`.
 - [x] `README.zh-CN.md` describes the same behaviour as `README.md`.
 - [x] Every number in the README and in `docs/` is measured, or marked
       "not measured" / "not run".
@@ -51,7 +55,7 @@ Checked by: `.github/workflows/release.yml`, job `validate-and-test`.
 
 ## Artifacts and hygiene
 
-- [ ] `git status --porcelain` is empty.
+- [x] `git status --porcelain` is empty at the release-candidate commit.
 - [x] No model weights, checkpoints, Hugging Face caches, databases, secrets or
       absolute user paths are committed
       (`git ls-files | rg "\.(safetensors|bin|pt|ckpt|sqlite|db)$"` is empty).

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -12,7 +12,7 @@ before *After the tag* is left unchecked.
 - [x] `CITATION.cff` `version:` matches.
 - [x] The git tag will be `v<version>`.
 
-Checked by: `.github/workflows/release.yml`, job `validate`.
+Checked by: `.github/workflows/release.yml`, job `validate-and-test`.
 
 ## Code quality
 
@@ -61,42 +61,52 @@ Checked by: `.github/workflows/release.yml`, job `validate`.
 
 ## Publishing (externally blocked)
 
-The OIDC publication job exists but is deliberately disabled with `if: false`;
-this repository stores no secrets. Live verification on 2026-07-28 found:
+The workflow stores no secret or long-lived PyPI token. Its publish, public
+verification and GitHub Release jobs each independently require a `push` event
+whose ref starts with `refs/tags/v`; `workflow_dispatch` validates, tests,
+builds and uploads a workflow artifact but can never publish.
 
-- `https://pypi.org/pypi/miniverl/json` returns HTTP 404, so no project exists
-  on which a trusted publisher could already be registered;
-- `gh api repos/DaoyuanLi2816/mini-verl/environments` returns
-  `{"total_count":0,"environments":[]}`, so the required GitHub `pypi`
-  environment is not configured.
+Live verification on 2026-07-28 found:
 
-The absence of either external object means a workflow file alone is not
-trusted-publisher configuration. Do not remove `if: false`, create `v0.2.0`, or
-create a GitHub Release until these steps are completed:
+- `https://pypi.org/pypi/miniverl/json` returns HTTP 404;
+- the GitHub `pypi` environment exists and its custom deployment policy permits
+  only tags matching `v*`;
+- no `v0.2.0` tag, PyPI release or GitHub Release exists;
+- **PyPI pending publisher not yet registered** is the sole external
+  publication blocker.
 
-1. On PyPI, create the `miniverl` project and add a **trusted publisher**:
-   - Owner: `DaoyuanLi2816`
+PyPI's
+[pending-publisher documentation](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/)
+supports creating a new project on the first OIDC upload. A project page does
+not need to exist first, and no token-based bootstrap upload is needed. The
+exact bootstrap is:
+
+1. Sign in to the intended PyPI maintainer account.
+2. Open the account-level **Publishing** page.
+3. Add a pending GitHub publisher with:
+   - PyPI project name: `miniverl`
+   - GitHub owner: `DaoyuanLi2816`
    - Repository: `mini-verl`
-   - Workflow: `release.yml`
+   - Workflow filename: `release.yml`
    - Environment: `pypi`
-2. In a separately reviewed change, remove the hard-disabled condition from
-   `publish-pypi` in `release.yml`.
-3. Create the GitHub `pypi` environment named exactly as above.
-4. Push the tag. The `validate` job must pass before `publish-pypi`.
-5. Verify the public PyPI page and a fresh wheel install before creating the
-   GitHub Release.
+4. Confirm the GitHub environment is still named exactly `pypi`.
+5. Only with explicit publication authorization, push `v0.2.0`.
+6. Verify that the first tagged OIDC publication created the project and
+   converted the pending publisher to a normal publisher, following the
+   [OIDC publishing flow](https://docs.pypi.org/trusted-publishers/using-a-publisher/).
 
-Until the publisher is registered and publication is explicitly authorized,
-the release workflow validates and builds but cannot upload.
+The pending publisher does **not** reserve `miniverl` before that first upload.
+Re-check name availability immediately before registration and tagging.
+Package metadata `[project].name` must remain exactly `miniverl`, and every
+owner/repository/workflow/environment claim above must match exactly. Until the
+pending publisher is verifiably registered, do not create the tag.
 
 ### Name availability
 
 `miniverl` was available on PyPI when this release was prepared
 (`https://pypi.org/pypi/miniverl/json` returned HTTP 404 on 2026-07-28).
-**Re-check immediately before publishing.** If it has been taken, publish as
-`mini-verl-opd` and keep the display name `miniVERL`, the import package
-`miniverl`, the CLI command `miniverl` and the repository name `mini-verl`
-unchanged; only `[project] name` in `pyproject.toml` changes.
+That 404 is not a reservation. **Re-check immediately before publishing** and
+stop rather than silently changing the distribution name if it has been taken.
 
 ## After the tag
 

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -453,15 +453,18 @@ weights that were published, without retraining:
 
 ```bash
 miniverl eval --run runs/<run-id>
+# Require all reconstructed model, tokenizer and adapter files to be cached:
+miniverl eval --run runs/<run-id> --offline
 ```
 
 `evaluate_run` rebuilds the trainer from `config.resolved.yaml` (not the
 original recipe, so any `auto` decision stays frozen), restores the latest
 checkpoint with `include_rng=False`, evaluates deterministically, and writes
 `eval.<tag>.json` next to the run. `--split`, `--tasks`, `--checkpoint`,
-`--out` and `--tag` are available. It refuses to run against a directory with
-no `config.resolved.yaml`, on the grounds that only runs created by
-`miniverl train` can be re-evaluated.
+`--out`, `--tag` and `--offline` are available. Offline evaluation passes the
+no-network policy into the reconstructed trainer, including any Hub teacher
+adapter. It refuses to run against a directory with no `config.resolved.yaml`,
+on the grounds that only runs created by `miniverl train` can be re-evaluated.
 
 **5. Compare.** The comparison that matters is the evaluation payload:
 `tasks`, `success_rate`, `avg_turns`, `avg_tool_calls`,

--- a/docs/teacher-adapters.md
+++ b/docs/teacher-adapters.md
@@ -85,28 +85,33 @@ models:
       minimum_strict_success_rate: 0.5
 ```
 
-For offline use, download the same immutable revision and switch only the
-adapter source/path:
+For offline use, preload the three required adapter files at the same immutable
+revision:
 
 ```bash
 hf download DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher \
   --revision 23323751318135484c06c043b1f9b9e7016dd89f \
-  --local-dir artifacts/qwen3-1.7b-protocol-teacher
+  --include adapter_config.json adapter_model.safetensors \
+  miniverl_adapter_manifest.json
 ```
 
-```yaml
-adapter:
-  source: local
-  path: artifacts/qwen3-1.7b-protocol-teacher
-  require_policy_evaluation: true
-  minimum_strict_success_rate: 0.5
+Then the Hub identity can remain in the recipe:
+
+```bash
+miniverl train <recipe> --offline
 ```
 
 Before the base model is allocated, miniVERL validates the PEFT files, type,
 target modules, base identity/revision, tokenizer fingerprint, checksums and
 competence record. Hub metadata and weights are downloaded from the pinned
-adapter revision and pass the same checks as a local directory. After
-attachment, every teacher parameter is frozen and checked again.
+adapter revision and pass the same checks as a local directory. The validated
+result retains the exact local snapshot directory and the three resolved paths;
+PEFT loads that directory rather than resolving the Hub repository a second
+time. Machine-local cache paths are never serialized into a run manifest or
+benchmark result. `--offline` passes `local_files_only=True` to model,
+tokenizer and adapter resolution and rejects any cache miss without attempting
+the network. After attachment, every teacher parameter is frozen and checked
+again.
 
 The `minimum_strict_success_rate` in the shipped GPU benchmark is an operational
 gate against supervising with a clearly broken protocol policy. Passing it does

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -423,8 +423,12 @@ Then:
   `models.teacher.tokenizer_revision` in the recipe, and re-verify the
   tokenizer fingerprints afterwards
 - if you have the weights locally already, force the offline path:
-  `miniverl train <recipe> --offline`, which sets `local_files_only=True` on
-  every `from_pretrained` call and refuses network access
+  `miniverl train <recipe> --offline`, which sets `local_files_only=True` for
+  models, tokenizers and Hub adapter file resolution, then makes PEFT load the
+  exact validated local snapshot. The same option exists on `benchmark`,
+  `eval` and `export-adapter`. A missing cache entry fails before any HTTP,
+  metadata, ETag or Hub API request and prints the exact online `hf download`
+  preload command
 
 Leaving a revision unset is legal but not recommended. `miniverl validate`
 warns:

--- a/scripts/verify_pypi_release.py
+++ b/scripts/verify_pypi_release.py
@@ -1,0 +1,164 @@
+"""Verify that one PyPI release matches locally built distributions exactly."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+_INTEGRITY_MEDIA_TYPE = "application/vnd.pypi.integrity.v1+json"
+
+
+def _request_json(url: str, *, accept: str = "application/json") -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": accept, "User-Agent": "miniVERL-release-verifier/0.2"},
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+def _expected_hashes(sums: Path, artifact_root: Path) -> dict[str, str]:
+    expected: dict[str, str] = {}
+    for line in sums.read_text(encoding="ascii").splitlines():
+        digest, relative = line.split(maxsplit=1)
+        path = artifact_root / relative.strip().lstrip("*")
+        if not path.is_file():
+            raise RuntimeError(f"SHA256SUMS references missing artifact: {path}")
+        expected[path.name] = digest
+    wheels = [name for name in expected if name.endswith(".whl")]
+    sdists = [name for name in expected if name.endswith(".tar.gz")]
+    if len(expected) != 2 or len(wheels) != 1 or len(sdists) != 1:
+        raise RuntimeError(
+            f"expected exactly one wheel and one sdist in SHA256SUMS, found {sorted(expected)}"
+        )
+    return expected
+
+
+def _verify_metadata(
+    *,
+    project: str,
+    version: str,
+    expected: dict[str, str],
+) -> list[str]:
+    metadata = _request_json(f"https://pypi.org/pypi/{project}/{version}/json")
+    info = metadata.get("info") or {}
+    if info.get("name") != project:
+        raise RuntimeError(f"PyPI project name is {info.get('name')!r}, expected {project!r}")
+    if info.get("version") != version:
+        raise RuntimeError(f"PyPI version is {info.get('version')!r}, expected {version!r}")
+
+    files = {str(item.get("filename")): item for item in metadata.get("urls") or []}
+    if set(files) != set(expected):
+        raise RuntimeError(
+            f"PyPI files {sorted(files)} do not match built files {sorted(expected)}"
+        )
+    file_types = {str(item.get("packagetype")) for item in files.values()}
+    if file_types != {"bdist_wheel", "sdist"}:
+        raise RuntimeError(f"unexpected PyPI file types: {sorted(file_types)}")
+
+    urls: list[str] = []
+    for filename, digest in expected.items():
+        item = files[filename]
+        actual = str((item.get("digests") or {}).get("sha256") or "")
+        if actual != digest:
+            raise RuntimeError(
+                f"PyPI SHA-256 mismatch for {filename}: expected {digest}, got {actual}"
+            )
+        url = str(item.get("url") or "")
+        if not url.startswith("https://files.pythonhosted.org/"):
+            raise RuntimeError(f"unexpected download URL for {filename}: {url!r}")
+        urls.append(url)
+    return urls
+
+
+def _verify_integrity_metadata(*, project: str, version: str, filenames: list[str]) -> None:
+    for filename in filenames:
+        encoded = urllib.parse.quote(filename, safe="")
+        provenance = _request_json(
+            f"https://pypi.org/integrity/{project}/{version}/{encoded}/provenance",
+            accept=_INTEGRITY_MEDIA_TYPE,
+        )
+        bundles = provenance.get("attestation_bundles")
+        if not isinstance(bundles, list) or not bundles:
+            raise RuntimeError(f"PyPI exposes no attestation bundle for {filename}")
+        if not any(bundle.get("attestations") for bundle in bundles if isinstance(bundle, dict)):
+            raise RuntimeError(f"PyPI exposes no attestation for {filename}")
+
+
+def verify_release(
+    *,
+    project: str,
+    version: str,
+    sums: Path,
+    artifact_root: Path,
+    repository: str,
+    attempts: int,
+    delay: float,
+) -> None:
+    expected = _expected_hashes(sums, artifact_root)
+    last_error: Exception | None = None
+    urls: list[str] = []
+    for attempt in range(1, attempts + 1):
+        try:
+            urls = _verify_metadata(project=project, version=version, expected=expected)
+            _verify_integrity_metadata(
+                project=project,
+                version=version,
+                filenames=sorted(expected),
+            )
+            break
+        except (RuntimeError, urllib.error.HTTPError, urllib.error.URLError) as exc:
+            last_error = exc
+            if attempt == attempts:
+                raise RuntimeError(
+                    f"PyPI release did not become verifiable after {attempts} attempts: {exc}"
+                ) from exc
+            print(f"PyPI verification attempt {attempt}/{attempts} is not ready: {exc}")
+            time.sleep(delay)
+    if not urls:
+        raise RuntimeError(f"PyPI verification produced no distribution URLs: {last_error}")
+
+    verifier = shutil.which("pypi-attestations")
+    if verifier is None:
+        raise RuntimeError("pypi-attestations is required for cryptographic provenance checks")
+    for url in urls:
+        subprocess.run(
+            [verifier, "verify", "pypi", "--repository", repository, url],
+            check=True,
+        )
+    print(f"verified PyPI {project} {version}: {', '.join(sorted(expected))}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--sums", type=Path, required=True)
+    parser.add_argument("--artifact-root", type=Path, required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--attempts", type=int, default=12)
+    parser.add_argument("--delay", type=float, default=10.0)
+    args = parser.parse_args()
+    if args.attempts < 1:
+        parser.error("--attempts must be at least 1")
+    verify_release(
+        project=args.project,
+        version=args.version,
+        sums=args.sums,
+        artifact_root=args.artifact_root,
+        repository=args.repository,
+        attempts=args.attempts,
+        delay=args.delay,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/miniverl/cli.py
+++ b/src/miniverl/cli.py
@@ -562,6 +562,11 @@ def eval_command(
     ),
     out: Optional[Path] = typer.Option(None, "--out", help="Where to write the eval JSON."),
     tag: str = typer.Option("standalone", "--tag", help="Label recorded with the results."),
+    offline: bool = typer.Option(
+        False,
+        "--offline",
+        help="Refuse network access; use only local or already-cached model and adapter files.",
+    ),
     as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
 ) -> None:
     """Re-evaluate a finished run deterministically."""
@@ -570,7 +575,13 @@ def eval_command(
         from miniverl.evaluation.evaluator import evaluate_run
 
         payload = evaluate_run(
-            run, split=split, tasks=tasks, checkpoint=checkpoint, out=out, tag=tag
+            run,
+            split=split,
+            tasks=tasks,
+            checkpoint=checkpoint,
+            out=out,
+            tag=tag,
+            local_files_only=offline,
         )
     except (MiniVerlError, ModuleNotFoundError) as exc:
         _fail(exc)
@@ -610,6 +621,11 @@ def benchmark(
     config_path: Path = typer.Argument(..., help="Benchmark config YAML."),
     output: Optional[Path] = typer.Option(None, "--output", help="Output directory."),
     notes: str = typer.Option("", "--notes", help="Free-text notes stored in the result."),
+    offline: bool = typer.Option(
+        False,
+        "--offline",
+        help="Refuse network access; use only local or already-cached model and adapter files.",
+    ),
     as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
 ) -> None:
     """Run a matched-budget comparison across training modes."""
@@ -619,7 +635,12 @@ def benchmark(
         from miniverl.evaluation.schema import BenchmarkConfig
 
         spec = BenchmarkConfig.from_yaml(config_path)
-        result = run_benchmark(spec, output_dir=output, notes=notes)
+        result = run_benchmark(
+            spec,
+            output_dir=output,
+            notes=notes,
+            local_files_only=offline,
+        )
     except (ValidationError, MiniVerlError) as exc:
         if isinstance(exc, MiniVerlError):
             _fail(exc)
@@ -879,10 +900,11 @@ def export_adapter_command(
         help="Checkpoint directory (defaults to <run>/checkpoints/final).",
     ),
     out: Path = typer.Option(..., "--out", help="New standard PEFT adapter directory."),
-    local_files_only: bool = typer.Option(
+    offline: bool = typer.Option(
         False,
+        "--offline",
         "--local-files-only",
-        help="Refuse network access while loading the base model/tokenizer.",
+        help="Refuse network access while loading the base model and tokenizer.",
     ),
     as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
 ) -> None:
@@ -896,7 +918,7 @@ def export_adapter_command(
             run,
             source_checkpoint,
             out,
-            local_files_only=local_files_only,
+            local_files_only=offline,
         )
     except MiniVerlError as exc:
         _fail(exc)

--- a/src/miniverl/evaluation/benchmark.py
+++ b/src/miniverl/evaluation/benchmark.py
@@ -210,7 +210,12 @@ def _checkpoint_digest(directory: Path) -> str:
     return digest.hexdigest()
 
 
-def _cold_start(run_config: RunConfig, output_dir: Path) -> tuple[Path | None, float]:
+def _cold_start(
+    run_config: RunConfig,
+    output_dir: Path,
+    *,
+    local_files_only: bool = False,
+) -> tuple[Path | None, float]:
     if run_config.train.cycles <= 0:
         return None, 0.0
     from miniverl.trainer import OPDTrainer
@@ -220,6 +225,7 @@ def _cold_start(run_config: RunConfig, output_dir: Path) -> tuple[Path | None, f
         run_config,
         output_dir=output_dir,
         run_id=f"{run_config.run.name}-s{run_config.run.seed}",
+        local_files_only=local_files_only,
     ) as trainer:
         result = trainer.train()
         checkpoint = trainer.paths.checkpoints / "final"
@@ -338,6 +344,7 @@ def _run_one_arm(
     run_config: RunConfig,
     common_dump: dict[str, Any],
     checkpoint: Path | None,
+    local_files_only: bool = False,
 ) -> ArmResult:
     """Run one arm inside a model-owning lifetime boundary."""
     from miniverl.trainer import OPDTrainer
@@ -349,6 +356,7 @@ def _run_one_arm(
         run_config,
         output_dir=target,
         run_id=run_config.run.name,
+        local_files_only=local_files_only,
     ) as trainer:
         runtime_config = portable_payload(
             RunConfig.from_yaml(trainer.paths.config_resolved).model_dump(mode="json")
@@ -486,6 +494,7 @@ def run_benchmark(
     output_dir: str | Path | None = None,
     notes: str = "",
     invocation: list[str] | None = None,
+    local_files_only: bool = False,
 ) -> BenchmarkResult:
     """Execute every preflight-validated arm and write a schema-v2 result."""
     # Preflight every seed before creating a run directory or allocating a model.
@@ -503,7 +512,11 @@ def run_benchmark(
     for seed in config.seeds:
         _, cold_config, resolved_arms = preflight[seed]
         try:
-            checkpoint, cold_seconds = _cold_start(cold_config, target)
+            checkpoint, cold_seconds = _cold_start(
+                cold_config,
+                target,
+                local_files_only=local_files_only,
+            )
         finally:
             _isolate_next_trainer(f"cold start seed {seed}")
         cold_checkpoints.append(
@@ -533,6 +546,7 @@ def run_benchmark(
                         run_config=run_config,
                         common_dump=common_dump,
                         checkpoint=checkpoint,
+                        local_files_only=local_files_only,
                     )
                 )
             finally:

--- a/src/miniverl/evaluation/evaluator.py
+++ b/src/miniverl/evaluation/evaluator.py
@@ -30,6 +30,7 @@ def evaluate_run(
     checkpoint: str | Path | None = None,
     out: str | Path | None = None,
     tag: str = "standalone",
+    local_files_only: bool = False,
 ) -> dict[str, Any]:
     """Re-evaluate a finished run and write the result next to it."""
     from miniverl.trainer import OPDTrainer
@@ -50,6 +51,7 @@ def evaluate_run(
         config,
         output_dir=paths.root.parent,
         run_id=paths.root.name,
+        local_files_only=local_files_only,
         write_artifacts=False,
     )
     try:

--- a/src/miniverl/models/adapter_io.py
+++ b/src/miniverl/models/adapter_io.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +25,7 @@ from miniverl.utils.runs import RunPaths, canonical_json, read_json, write_json
 
 __all__ = [
     "ADAPTER_MANIFEST",
+    "ValidatedTeacherAdapter",
     "validate_teacher_adapter",
     "export_adapter",
     "digest_tree",
@@ -44,6 +47,30 @@ _POLICY_EVAL_FIELDS = (
     "protocol_token_accuracy",
     "policy_competence_measurement_status",
 )
+
+
+@dataclass(frozen=True)
+class ValidatedTeacherAdapter(Mapping[str, Any]):
+    """A verified adapter plus the exact local snapshot PEFT must load.
+
+    Mapping compatibility keeps the existing internal/public provenance reads
+    concise without ever placing machine-local cache paths in serialized data.
+    """
+
+    provenance: dict[str, Any]
+    snapshot_dir: Path
+    adapter_config_path: Path
+    weights_path: Path
+    manifest_path: Path
+
+    def __getitem__(self, key: str) -> Any:
+        return self.provenance[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.provenance)
+
+    def __len__(self) -> int:
+        return len(self.provenance)
 
 
 def digest_tree(directory: str | Path) -> str:
@@ -71,36 +98,41 @@ def _same_model_identity(expected: str, actual: str) -> bool:
     return False
 
 
-def _read_local_adapter(path: Path) -> tuple[dict[str, Any], dict[str, Any] | None]:
+def _read_local_adapter(path: Path) -> tuple[dict[str, Any], dict[str, Any], dict[str, Path]]:
     if not path.is_dir():
         raise BackendError(
             f"teacher adapter directory not found: {path}",
             hint="export it with `miniverl export-adapter`, or correct models.teacher.adapter.path",
         )
-    missing = [name for name in (_ADAPTER_CONFIG, _ADAPTER_WEIGHTS) if not (path / name).is_file()]
+    required = (_ADAPTER_CONFIG, _ADAPTER_WEIGHTS, ADAPTER_MANIFEST)
+    missing = [name for name in required if not (path / name).is_file()]
     if missing:
         raise BackendError(
             f"teacher adapter {path} is incomplete (missing {', '.join(missing)})",
-            hint="a standard PEFT adapter needs adapter_config.json and adapter_model.safetensors",
+            hint=(
+                "a standard PEFT adapter used as a miniVERL teacher needs "
+                "adapter_config.json, adapter_model.safetensors and "
+                "miniverl_adapter_manifest.json"
+            ),
         )
     try:
         adapter_config = json.loads((path / _ADAPTER_CONFIG).read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise BackendError(f"cannot read {path / _ADAPTER_CONFIG}: {exc}") from exc
     manifest_path = path / ADAPTER_MANIFEST
-    manifest = None
-    if manifest_path.is_file():
-        try:
-            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as exc:
-            raise BackendError(f"cannot read {manifest_path}: {exc}") from exc
-    return adapter_config, manifest
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise BackendError(f"cannot read {manifest_path}: {exc}") from exc
+    return adapter_config, manifest, {name: path / name for name in required}
 
 
 def _read_hub_adapter(
     repo_id: str,
     revision: str,
-) -> tuple[dict[str, Any], dict[str, Any] | None, dict[str, Path]]:
+    *,
+    local_files_only: bool,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Path]]:
     """Download the reproducibility metadata and weights at one immutable revision."""
     try:
         from huggingface_hub import hf_hub_download
@@ -114,26 +146,38 @@ def _read_hub_adapter(
     for name in (_ADAPTER_CONFIG, _ADAPTER_WEIGHTS, ADAPTER_MANIFEST):
         try:
             downloaded[name] = Path(
-                hf_hub_download(repo_id=repo_id, filename=name, revision=revision)
+                hf_hub_download(
+                    repo_id=repo_id,
+                    filename=name,
+                    revision=revision,
+                    local_files_only=local_files_only,
+                )
             )
         except Exception as exc:
-            if name == ADAPTER_MANIFEST:
-                continue
             raise BackendError(
-                f"could not download teacher adapter file {name!r} from "
-                f"{repo_id!r} at revision {revision!r}: {exc}"
+                f"could not resolve teacher adapter {repo_id!r} at pinned revision "
+                f"{revision!r}: missing {name!r}",
+                hint=(
+                    f"preload it online with `hf download {repo_id} --revision {revision} "
+                    f"--include {_ADAPTER_CONFIG} {_ADAPTER_WEIGHTS} {ADAPTER_MANIFEST}`; "
+                    f"original error: {exc}"
+                ),
             ) from exc
+    snapshot_dirs = {path.parent for path in downloaded.values()}
+    if len(snapshot_dirs) != 1:
+        details = ", ".join(f"{name}={path}" for name, path in sorted(downloaded.items()))
+        raise BackendError(
+            "teacher adapter files did not resolve to one exact local snapshot",
+            hint=f"clear the inconsistent cache entry and preload the pinned revision; {details}",
+        )
     try:
         adapter_config = json.loads(downloaded[_ADAPTER_CONFIG].read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise BackendError(f"cannot read downloaded {_ADAPTER_CONFIG}: {exc}") from exc
-    manifest = None
-    manifest_path = downloaded.get(ADAPTER_MANIFEST)
-    if manifest_path is not None:
-        try:
-            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as exc:
-            raise BackendError(f"cannot read downloaded {ADAPTER_MANIFEST}: {exc}") from exc
+    try:
+        manifest = json.loads(downloaded[ADAPTER_MANIFEST].read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise BackendError(f"cannot read downloaded {ADAPTER_MANIFEST}: {exc}") from exc
     return adapter_config, manifest, downloaded
 
 
@@ -142,17 +186,20 @@ def validate_teacher_adapter(
     teacher: TeacherModelConfig,
     *,
     tokenizer_fingerprint: str,
-) -> dict[str, Any]:
+    local_files_only: bool = False,
+) -> ValidatedTeacherAdapter:
     """Validate compatibility before the adapter can supervise training."""
     if adapter.source is AdapterSource.LOCAL:
-        path = Path(adapter.path)
-        adapter_config, manifest = _read_local_adapter(path)
-        downloaded = {
-            name: path / name for name in (_ADAPTER_CONFIG, _ADAPTER_WEIGHTS, ADAPTER_MANIFEST)
-        }
+        snapshot_dir = Path(adapter.path).resolve()
+        adapter_config, manifest, downloaded = _read_local_adapter(snapshot_dir)
     else:
         assert adapter.revision is not None
-        adapter_config, manifest, downloaded = _read_hub_adapter(adapter.path, adapter.revision)
+        adapter_config, manifest, downloaded = _read_hub_adapter(
+            adapter.path,
+            adapter.revision,
+            local_files_only=local_files_only,
+        )
+        snapshot_dir = downloaded[_ADAPTER_CONFIG].parent
 
     peft_type = str(adapter_config.get("peft_type") or "").upper()
     if peft_type != "LORA":
@@ -172,7 +219,6 @@ def validate_teacher_adapter(
             hint="load the adapter with the same base model it was trained from",
         )
 
-    manifest = manifest or {}
     expected_revision = adapter.base_model_revision or manifest.get("base_model_revision")
     if expected_revision and teacher.revision != expected_revision:
         raise BackendError(
@@ -236,7 +282,7 @@ def validate_teacher_adapter(
             )
 
     weights_digest, _ = sha256_file(downloaded[_ADAPTER_WEIGHTS])
-    return {
+    provenance = {
         "source": adapter.source.value,
         "identity": (
             Path(adapter.path).name if adapter.source is AdapterSource.LOCAL else adapter.path
@@ -255,6 +301,13 @@ def validate_teacher_adapter(
         ),
         "policy_evaluation": policy_evaluation,
     }
+    return ValidatedTeacherAdapter(
+        provenance=provenance,
+        snapshot_dir=snapshot_dir,
+        adapter_config_path=downloaded[_ADAPTER_CONFIG],
+        weights_path=downloaded[_ADAPTER_WEIGHTS],
+        manifest_path=downloaded[ADAPTER_MANIFEST],
+    )
 
 
 def export_adapter(

--- a/src/miniverl/models/hf.py
+++ b/src/miniverl/models/hf.py
@@ -98,6 +98,27 @@ def _from_pretrained_kwargs(dtype: torch.dtype) -> dict[str, Any]:
     return {_dtype_kwarg_name(): dtype}
 
 
+def _adapter_probe_kwargs(*, revision: str | None, local_files_only: bool) -> dict[str, Any]:
+    """Build PEFT auto-detection kwargs across transformers 4.x and 5.x.
+
+    Transformers 4.x already forwards the top-level ``local_files_only`` value
+    to its PEFT-config probe, so repeating it in ``adapter_kwargs`` raises a
+    duplicate-keyword ``TypeError``. Transformers 5.x stopped forwarding that
+    policy, so it must be supplied explicitly there to preserve the zero-network
+    contract.
+    """
+    transformers = require_transformers("Model loading")
+    version = str(getattr(transformers, "__version__", "0"))
+    try:
+        major = int(version.split(".", maxsplit=1)[0])
+    except ValueError:  # pragma: no cover - unusual version strings
+        major = 0
+    kwargs: dict[str, Any] = {"revision": revision}
+    if major >= 5:
+        kwargs["local_files_only"] = local_files_only
+    return kwargs
+
+
 class HFBackend(CausalLMBackend):
     """Local Hugging Face causal LM, optionally quantized and LoRA-adapted."""
 
@@ -174,13 +195,12 @@ class HFBackend(CausalLMBackend):
             "trust_remote_code": spec.trust_remote_code,
             "local_files_only": local_files_only,
             # Transformers performs a separate PEFT-config probe before loading
-            # the base model. In 5.x that probe does not inherit hub kwargs, so
-            # pass the policy explicitly instead of relying on global offline
-            # environment variables.
-            "adapter_kwargs": {
-                "local_files_only": local_files_only,
-                "revision": spec.revision,
-            },
+            # the base model. Its policy propagation differs between 4.x and
+            # 5.x, so build compatible explicit probe kwargs.
+            "adapter_kwargs": _adapter_probe_kwargs(
+                revision=spec.revision,
+                local_files_only=local_files_only,
+            ),
             "attn_implementation": spec.attn_implementation,
             **_from_pretrained_kwargs(dtype),
         }

--- a/src/miniverl/models/hf.py
+++ b/src/miniverl/models/hf.py
@@ -158,18 +158,29 @@ class HFBackend(CausalLMBackend):
         dtype = resolve_dtype(spec.dtype, device)
         quantization = spec.quantization
         adapter_provenance = None
+        validated_adapter = None
         if isinstance(spec, TeacherModelConfig) and spec.adapter is not None:
             from miniverl.models.adapter_io import validate_teacher_adapter
 
-            adapter_provenance = validate_teacher_adapter(
+            validated_adapter = validate_teacher_adapter(
                 spec.adapter,
                 spec,
                 tokenizer_fingerprint=tokenizer.fingerprint,
+                local_files_only=local_files_only,
             )
+            adapter_provenance = validated_adapter.provenance
         kwargs: dict[str, Any] = {
             "revision": spec.revision,
             "trust_remote_code": spec.trust_remote_code,
             "local_files_only": local_files_only,
+            # Transformers performs a separate PEFT-config probe before loading
+            # the base model. In 5.x that probe does not inherit hub kwargs, so
+            # pass the policy explicitly instead of relying on global offline
+            # environment variables.
+            "adapter_kwargs": {
+                "local_files_only": local_files_only,
+                "revision": spec.revision,
+            },
             "attn_implementation": spec.attn_implementation,
             **_from_pretrained_kwargs(dtype),
         }
@@ -180,12 +191,23 @@ class HFBackend(CausalLMBackend):
         try:
             model = transformers.AutoModelForCausalLM.from_pretrained(spec.model_id, **kwargs)
         except OSError as exc:
+            revision = f" at revision {spec.revision!r}" if spec.revision else ""
+            preload = f"hf download {spec.model_id}"
+            if spec.revision:
+                preload += f" --revision {spec.revision}"
+            offline_hint = (
+                f"offline mode found no complete cached model snapshot; preload it online "
+                f"with `{preload}`. "
+                if local_files_only
+                else ""
+            )
             raise BackendError(
-                f"could not load model {spec.model_id!r}"
-                + (f" at revision {spec.revision!r}" if spec.revision else ""),
-                hint="check the model id and revision, that you are online for the first "
-                "download, and that the license has been accepted on the Hub. "
-                f"Original error: {exc}",
+                f"could not load model {spec.model_id!r}{revision}",
+                hint=(
+                    offline_hint
+                    + "check the model id and revision and that any gated license has been "
+                    f"accepted on the Hub. Original error: {exc}"
+                ),
             ) from exc
 
         if quant_config is None:
@@ -211,13 +233,14 @@ class HFBackend(CausalLMBackend):
             model.train()
         else:
             if isinstance(spec, TeacherModelConfig) and spec.adapter is not None:
+                assert validated_adapter is not None
                 peft = require_peft("Loading a frozen teacher adapter")
                 try:
                     model = peft.PeftModel.from_pretrained(
                         model,
-                        spec.adapter.path,
-                        revision=spec.adapter.revision,
+                        str(validated_adapter.snapshot_dir),
                         is_trainable=False,
+                        local_files_only=True,
                     )
                 except (OSError, ValueError) as exc:
                     raise BackendError(

--- a/src/miniverl/models/tokenizers.py
+++ b/src/miniverl/models/tokenizers.py
@@ -280,13 +280,29 @@ class HFTokenizerAdapter:
     ) -> HFTokenizerAdapter:
         """Load a tokenizer from a local path or the Hub."""
         transformers = require_transformers("Loading a Hugging Face tokenizer")
-        tok = transformers.AutoTokenizer.from_pretrained(
-            model_id,
-            revision=revision,
-            trust_remote_code=trust_remote_code,
-            local_files_only=local_files_only,
-            use_fast=True,
-        )
+        try:
+            tok = transformers.AutoTokenizer.from_pretrained(
+                model_id,
+                revision=revision,
+                trust_remote_code=trust_remote_code,
+                local_files_only=local_files_only,
+                use_fast=True,
+            )
+        except OSError as exc:
+            revision_text = f" at revision {revision!r}" if revision else ""
+            preload = f"hf download {model_id}"
+            if revision:
+                preload += f" --revision {revision}"
+            offline_hint = (
+                f"offline mode found no complete cached tokenizer snapshot; preload it online "
+                f"with `{preload}`. "
+                if local_files_only
+                else ""
+            )
+            raise BackendError(
+                f"could not load tokenizer {model_id!r}{revision_text}",
+                hint=offline_hint + f"check the tokenizer id and revision. Original error: {exc}",
+            ) from exc
         return cls(tok, model_id=model_id, revision=revision)
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ Tests are split by dependency weight:
 from __future__ import annotations
 
 import importlib.util
+import socket
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -64,3 +65,18 @@ def toy_tokenizer():  # type: ignore[no-untyped-def]
     from miniverl.models.tokenizers import ToyTokenizer
 
     return ToyTokenizer()
+
+
+@pytest.fixture
+def deny_network(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Fail a test at the first attempted socket connection."""
+    attempts: list[str] = []
+
+    def blocked(*args: object, **kwargs: object) -> None:
+        target = args[0] if args else kwargs.get("address", "unknown")
+        attempts.append(str(target))
+        raise AssertionError(f"network access attempted: {target}")
+
+    monkeypatch.setattr(socket, "create_connection", blocked)
+    monkeypatch.setattr(socket.socket, "connect", blocked)
+    return attempts

--- a/tests/integration/test_hf_backend_offline.py
+++ b/tests/integration/test_hf_backend_offline.py
@@ -219,7 +219,7 @@ def test_the_backend_reports_honest_capabilities(tiny_model, tiny_tokenizer):
     assert caps["num_parameters"] > 0
 
 
-def test_loading_an_unknown_model_id_fails_with_advice():
+def test_loading_an_unknown_model_id_fails_with_advice(deny_network):
     from miniverl.config.models import StudentModelConfig
     from miniverl.errors import BackendError
     from miniverl.models.hf import HFBackend
@@ -231,6 +231,36 @@ def test_loading_an_unknown_model_id_fails_with_advice():
             spec, device="cpu", tokenizer=ToyTokenizer(), trainable=False, local_files_only=True
         )
     assert "revision" in (excinfo.value.hint or "")
+    assert "hf download miniverl/definitely-not-a-real-model" in (excinfo.value.hint or "")
+    assert deny_network == []
+
+
+def test_missing_cached_tokenizer_fails_actionably_without_network(monkeypatch, deny_network):
+    import transformers
+
+    from miniverl.errors import BackendError
+    from miniverl.models.tokenizers import HFTokenizerAdapter
+
+    seen: list[dict[str, object]] = []
+
+    def missing(model_id: str, **kwargs):
+        seen.append({"model_id": model_id, **kwargs})
+        raise OSError("snapshot is absent")
+
+    monkeypatch.setattr(transformers.AutoTokenizer, "from_pretrained", missing)
+    revision = "d" * 40
+    with pytest.raises(BackendError, match="cached tokenizer snapshot") as excinfo:
+        HFTokenizerAdapter.load(
+            "owner/missing-tokenizer",
+            revision=revision,
+            local_files_only=True,
+        )
+
+    assert seen[0]["local_files_only"] is True
+    assert f"hf download owner/missing-tokenizer --revision {revision}" in (
+        excinfo.value.hint or ""
+    )
+    assert deny_network == []
 
 
 def test_dtype_resolution_matches_the_device():
@@ -322,9 +352,18 @@ def test_hub_teacher_adapter_downloads_and_validates_miniverl_manifest(
     }
     write_json(adapter / ADAPTER_MANIFEST, manifest)
 
-    def download(*, repo_id: str, filename: str, revision: str) -> str:
+    policies: list[bool] = []
+
+    def download(
+        *,
+        repo_id: str,
+        filename: str,
+        revision: str,
+        local_files_only: bool,
+    ) -> str:
         assert repo_id == "owner/protocol-teacher"
         assert revision == "a" * 40
+        policies.append(local_files_only)
         return str(adapter / filename)
 
     monkeypatch.setattr(huggingface_hub, "hf_hub_download", download)
@@ -338,12 +377,205 @@ def test_hub_teacher_adapter_downloads_and_validates_miniverl_manifest(
         ),
         TeacherModelConfig(model_id=str(base)),
         tokenizer_fingerprint=tiny_tokenizer.fingerprint,
+        local_files_only=True,
     )
 
     assert provenance["source"] == "hub"
     assert provenance["revision"] == "a" * 40
     assert provenance["weights_sha256"] == manifest["checksums"]["adapter_model.safetensors"]
     assert provenance["policy_evaluation"]["strict_task_success_rate"] == pytest.approx(0.75)
+    assert provenance.snapshot_dir == adapter
+    assert policies == [True, True, True]
+
+    policies.clear()
+    online = validate_teacher_adapter(
+        TeacherAdapterConfig(
+            source=AdapterSource.HUB,
+            path="owner/protocol-teacher",
+            revision="a" * 40,
+            require_policy_evaluation=True,
+            minimum_strict_success_rate=0.5,
+        ),
+        TeacherModelConfig(model_id=str(base)),
+        tokenizer_fingerprint=tiny_tokenizer.fingerprint,
+        local_files_only=False,
+    )
+    assert online.snapshot_dir == provenance.snapshot_dir
+    assert policies == [False, False, False]
+
+
+@requires_peft
+def test_cached_hub_adapter_is_loaded_from_the_exact_validated_snapshot_without_network(
+    local_teacher_adapter,
+    tiny_tokenizer,
+    monkeypatch,
+    deny_network,
+):
+    import huggingface_hub
+    import peft
+
+    from miniverl.config.models import (
+        AdapterSource,
+        TeacherAdapterConfig,
+        TeacherModelConfig,
+    )
+    from miniverl.models.hf import HFBackend
+
+    base, adapter, _ = local_teacher_adapter
+    revision = "b" * 40
+    policies: list[bool] = []
+
+    def download(
+        *,
+        repo_id: str,
+        filename: str,
+        revision: str,
+        local_files_only: bool,
+    ) -> str:
+        assert repo_id == "owner/cached-adapter"
+        assert revision == "b" * 40
+        policies.append(local_files_only)
+        return str(adapter / filename)
+
+    original = peft.PeftModel.from_pretrained
+    loaded_paths: list[str] = []
+
+    def load_adapter(model, model_id, **kwargs):
+        loaded_paths.append(str(model_id))
+        assert kwargs["local_files_only"] is True
+        return original(model, model_id, **kwargs)
+
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", download)
+    monkeypatch.setattr(peft.PeftModel, "from_pretrained", load_adapter)
+    backend = HFBackend.load(
+        TeacherModelConfig(
+            model_id=str(base),
+            adapter=TeacherAdapterConfig(
+                source=AdapterSource.HUB,
+                path="owner/cached-adapter",
+                revision=revision,
+            ),
+        ),
+        device="cpu",
+        tokenizer=tiny_tokenizer,
+        trainable=False,
+        local_files_only=True,
+    )
+
+    assert backend.adapter_provenance["identity"] == "owner/cached-adapter"
+    assert loaded_paths == [str(adapter)]
+    assert policies == [True, True, True]
+    assert deny_network == []
+
+
+@requires_peft
+def test_missing_cached_hub_adapter_file_is_actionable_and_never_retries_online(
+    local_teacher_adapter,
+    tiny_tokenizer,
+    monkeypatch,
+    deny_network,
+):
+    import huggingface_hub
+
+    from miniverl.config.models import (
+        AdapterSource,
+        TeacherAdapterConfig,
+        TeacherModelConfig,
+    )
+    from miniverl.errors import BackendError
+    from miniverl.models.adapter_io import validate_teacher_adapter
+
+    base, adapter, _ = local_teacher_adapter
+    revision = "c" * 40
+    requested: list[tuple[str, bool]] = []
+
+    def download(
+        *,
+        repo_id: str,
+        filename: str,
+        revision: str,
+        local_files_only: bool,
+    ) -> str:
+        requested.append((filename, local_files_only))
+        if filename == "adapter_model.safetensors":
+            raise FileNotFoundError("not in cache")
+        return str(adapter / filename)
+
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", download)
+    with pytest.raises(BackendError, match=r"adapter_model\.safetensors") as excinfo:
+        validate_teacher_adapter(
+            TeacherAdapterConfig(
+                source=AdapterSource.HUB,
+                path="owner/partial-adapter",
+                revision=revision,
+            ),
+            TeacherModelConfig(model_id=str(base)),
+            tokenizer_fingerprint=tiny_tokenizer.fingerprint,
+            local_files_only=True,
+        )
+
+    message = str(excinfo.value)
+    assert "owner/partial-adapter" in message
+    assert revision in message
+    assert (
+        f"hf download owner/partial-adapter --revision {revision} "
+        "--include adapter_config.json adapter_model.safetensors "
+        "miniverl_adapter_manifest.json"
+    ) in (excinfo.value.hint or "")
+    assert requested == [
+        ("adapter_config.json", True),
+        ("adapter_model.safetensors", True),
+    ]
+    assert deny_network == []
+
+
+@requires_peft
+def test_fully_missing_cached_hub_adapter_stops_at_first_file_without_network(
+    local_teacher_adapter,
+    tiny_tokenizer,
+    monkeypatch,
+    deny_network,
+):
+    import huggingface_hub
+
+    from miniverl.config.models import (
+        AdapterSource,
+        TeacherAdapterConfig,
+        TeacherModelConfig,
+    )
+    from miniverl.errors import BackendError
+    from miniverl.models.adapter_io import validate_teacher_adapter
+
+    base, _, _ = local_teacher_adapter
+    revision = "e" * 40
+    requested: list[tuple[str, bool]] = []
+
+    def missing(
+        *,
+        repo_id: str,
+        filename: str,
+        revision: str,
+        local_files_only: bool,
+    ) -> str:
+        requested.append((filename, local_files_only))
+        raise FileNotFoundError("snapshot absent")
+
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", missing)
+    with pytest.raises(BackendError, match=r"missing 'adapter_config\.json'") as excinfo:
+        validate_teacher_adapter(
+            TeacherAdapterConfig(
+                source=AdapterSource.HUB,
+                path="owner/missing-adapter",
+                revision=revision,
+            ),
+            TeacherModelConfig(model_id=str(base)),
+            tokenizer_fingerprint=tiny_tokenizer.fingerprint,
+            local_files_only=True,
+        )
+
+    assert requested == [("adapter_config.json", True)]
+    assert f"owner/missing-adapter --revision {revision}" in (excinfo.value.hint or "")
+    assert deny_network == []
 
 
 @requires_peft

--- a/tests/integration/test_hf_backend_offline.py
+++ b/tests/integration/test_hf_backend_offline.py
@@ -272,6 +272,32 @@ def test_dtype_resolution_matches_the_device():
     assert resolve_dtype(Precision.AUTO, "cpu") is torch.float32
 
 
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("4.51.3", {"revision": "abc"}),
+        ("5.0.0", {"revision": "abc", "local_files_only": True}),
+    ],
+)
+def test_peft_probe_kwargs_preserve_offline_policy_across_transformers_versions(
+    version,
+    expected,
+    monkeypatch,
+):
+    import miniverl.models.hf as hf_module
+
+    fake_transformers = type("FakeTransformers", (), {"__version__": version})()
+    monkeypatch.setattr(hf_module, "require_transformers", lambda _feature: fake_transformers)
+
+    assert (
+        hf_module._adapter_probe_kwargs(
+            revision="abc",
+            local_files_only=True,
+        )
+        == expected
+    )
+
+
 @pytest.fixture
 def local_teacher_adapter(tmp_path: Path, tiny_model, tiny_tokenizer):
     """A standard local PEFT LoRA adapter plus miniVERL provenance."""

--- a/tests/unit/test_offline_contract.py
+++ b/tests/unit/test_offline_contract.py
@@ -26,8 +26,10 @@ def test_every_network_capable_cli_uses_the_offline_term() -> None:
 
 
 def test_train_cli_passes_offline_policy_to_trainer(tmp_path: Path, monkeypatch) -> None:
+    import miniverl.cli as cli_module
     from miniverl.trainer import OPDTrainer
 
+    monkeypatch.setattr(cli_module, "_require_training_stack", lambda _purpose: None)
     seen: list[bool] = []
     run_root = tmp_path / "train-result"
     result = SimpleNamespace(
@@ -77,8 +79,10 @@ def test_export_adapter_offline_and_legacy_alias_are_equivalent(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
+    import miniverl.cli as cli_module
     from miniverl.models import adapter_io
 
+    monkeypatch.setattr(cli_module, "_require_training_stack", lambda _purpose: None)
     policies: list[bool] = []
 
     def fake_export(*args, **kwargs):

--- a/tests/unit/test_offline_contract.py
+++ b/tests/unit/test_offline_contract.py
@@ -1,0 +1,217 @@
+"""End-to-end propagation checks for the explicit no-network policy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from typer.testing import CliRunner
+
+from miniverl.cli import app
+from miniverl.evaluation.benchmark import run_benchmark
+from miniverl.evaluation.evaluator import evaluate_run
+from miniverl.evaluation.schema import BenchmarkConfig
+
+
+def test_every_network_capable_cli_uses_the_offline_term() -> None:
+    runner = CliRunner()
+    for command in ("train", "benchmark", "eval", "export-adapter"):
+        result = runner.invoke(app, [command, "--help"])
+        assert result.exit_code == 0, result.output
+        assert "--offline" in result.stdout, command
+
+    export_help = runner.invoke(app, ["export-adapter", "--help"])
+    assert "--local-files-only" in export_help.stdout
+
+
+def test_train_cli_passes_offline_policy_to_trainer(tmp_path: Path, monkeypatch) -> None:
+    from miniverl.trainer import OPDTrainer
+
+    seen: list[bool] = []
+    run_root = tmp_path / "train-result"
+    result = SimpleNamespace(
+        to_dict=lambda: {
+            "run_id": "offline",
+            "run_dir": str(run_root),
+            "mode": "opd",
+            "cycles_completed": 0,
+            "global_step": 0,
+            "policy_version": 0,
+            "duration_seconds": 0.0,
+            "final_metrics": {},
+            "eval": None,
+            "baseline_eval": None,
+        },
+        baseline_eval=None,
+        eval=None,
+        global_step=0,
+        duration_seconds=0.0,
+    )
+
+    class FakeTrainer:
+        paths = SimpleNamespace(root=run_root)
+
+        def train(self):
+            return result
+
+        def close(self) -> None:
+            return None
+
+    def from_config(*args, **kwargs):
+        seen.append(kwargs["local_files_only"])
+        return FakeTrainer()
+
+    monkeypatch.setattr(OPDTrainer, "from_config", staticmethod(from_config))
+    recipe = Path(__file__).resolve().parents[2] / "recipes" / "toy_cpu.yaml"
+    cli_result = CliRunner().invoke(
+        app,
+        ["train", str(recipe), "--offline", "--no-report", "--json"],
+    )
+
+    assert cli_result.exit_code == 0, cli_result.output
+    assert seen == [True]
+
+
+def test_export_adapter_offline_and_legacy_alias_are_equivalent(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from miniverl.models import adapter_io
+
+    policies: list[bool] = []
+
+    def fake_export(*args, **kwargs):
+        policies.append(kwargs["local_files_only"])
+        return {}, tmp_path / f"adapter-{len(policies)}"
+
+    monkeypatch.setattr(adapter_io, "export_adapter", fake_export)
+    runner = CliRunner()
+    common = ["--run", str(tmp_path / "run"), "--out"]
+    offline = runner.invoke(app, ["export-adapter", *common, str(tmp_path / "one"), "--offline"])
+    alias = runner.invoke(
+        app,
+        ["export-adapter", *common, str(tmp_path / "two"), "--local-files-only"],
+    )
+
+    assert offline.exit_code == 0, offline.output
+    assert alias.exit_code == 0, alias.output
+    assert policies == [True, True]
+
+
+def test_evaluate_run_passes_offline_policy_to_reconstructed_trainer(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from miniverl.config import RunConfig
+    from miniverl.trainer import OPDTrainer
+
+    run_dir = tmp_path / "runs" / "finished"
+    run_dir.mkdir(parents=True)
+    config = RunConfig.from_mapping(
+        {
+            "run": {"name": "offline-eval", "output_dir": str(run_dir.parent)},
+            "models": {
+                "backend": "toy",
+                "student": {"model_id": "toy-student"},
+                "teacher": {"model_id": "toy-teacher"},
+            },
+            "environment": {
+                "name": "calculator",
+                "train_tasks": 1,
+                "eval_tasks": 1,
+                "test_tasks": 1,
+            },
+            "train": {"cycles": 0, "rollouts_per_cycle": 1},
+            "eval": {"enabled": False},
+            "report": {"enabled": False},
+        }
+    )
+    (run_dir / "config.resolved.yaml").write_text(config.to_yaml(), encoding="utf-8")
+    (run_dir / "manifest.json").write_text("{}", encoding="utf-8")
+    seen: list[bool] = []
+
+    class FakeTrainer:
+        student = SimpleNamespace(device="cpu")
+        optimizer = None
+
+        def evaluate(self, **kwargs):
+            return {"split": kwargs.get("split") or "test"}
+
+        def close(self) -> None:
+            return None
+
+    def from_config(*args, **kwargs):
+        seen.append(kwargs["local_files_only"])
+        return FakeTrainer()
+
+    monkeypatch.setattr(OPDTrainer, "from_config", staticmethod(from_config))
+    payload = evaluate_run(run_dir, local_files_only=True)
+
+    assert seen == [True]
+    assert payload["split"] == "test"
+
+
+@pytest.mark.torch
+def test_benchmark_passes_offline_policy_to_cold_start_and_every_arm(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from miniverl.trainer import OPDTrainer
+
+    spec = BenchmarkConfig.model_validate(
+        {
+            "schema_version": 2,
+            "name": "offline-propagation",
+            "base": {
+                "models": {
+                    "backend": "toy",
+                    "student": {"model_id": "toy-student"},
+                    "teacher": {"model_id": "toy-teacher"},
+                },
+                "environment": {
+                    "name": "calculator",
+                    "difficulty": "easy",
+                    "train_tasks": 1,
+                    "eval_tasks": 1,
+                    "test_tasks": 1,
+                },
+                "train": {
+                    "cycles": 0,
+                    "rollouts_per_cycle": 1,
+                    "gradient_accumulation_steps": 1,
+                },
+                "eval": {"enabled": False, "tasks": 1},
+                "report": {"enabled": False},
+            },
+            "cold_start_cycles": 1,
+            "allowed_differences": ["run.mode", "train.cycles"],
+            "seeds": [7],
+            "arms": [
+                {
+                    "name": "cold-start-only",
+                    "overrides": {"run": {"mode": "sft"}, "train": {"cycles": 0}},
+                },
+                {
+                    "name": "continued-sft",
+                    "overrides": {"run": {"mode": "sft"}, "train": {"cycles": 0}},
+                },
+            ],
+        }
+    )
+    seen: list[bool] = []
+    original = OPDTrainer.from_config.__func__
+
+    def from_config(cls, *args, **kwargs):
+        seen.append(kwargs["local_files_only"])
+        return original(cls, *args, **kwargs)
+
+    monkeypatch.setattr(OPDTrainer, "from_config", classmethod(from_config))
+    result = run_benchmark(
+        spec,
+        output_dir=tmp_path / "benchmark",
+        local_files_only=True,
+    )
+
+    assert len(result.arms) == 2
+    assert seen == [True, True, True]

--- a/tests/unit/test_pypi_release_verifier.py
+++ b/tests/unit/test_pypi_release_verifier.py
@@ -1,0 +1,125 @@
+"""Tests for public PyPI release verification without contacting PyPI."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "verify_pypi_release.py"
+
+
+def _module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("verify_pypi_release", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_expected_hashes_requires_one_wheel_and_one_sdist(tmp_path: Path) -> None:
+    verifier = _module()
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    wheel = dist / "miniverl-0.2.0-py3-none-any.whl"
+    sdist = dist / "miniverl-0.2.0.tar.gz"
+    wheel.write_bytes(b"wheel")
+    sdist.write_bytes(b"sdist")
+    sums = tmp_path / "SHA256SUMS"
+    sums.write_text(
+        "a" * 64 + f"  dist/{wheel.name}\n" + "b" * 64 + f"  dist/{sdist.name}\n",
+        encoding="ascii",
+    )
+
+    expected = verifier._expected_hashes(sums, tmp_path)
+
+    assert expected == {wheel.name: "a" * 64, sdist.name: "b" * 64}
+
+
+def test_metadata_verification_checks_exact_names_types_and_hashes(monkeypatch) -> None:
+    verifier = _module()
+    expected = {
+        "miniverl-0.2.0-py3-none-any.whl": "a" * 64,
+        "miniverl-0.2.0.tar.gz": "b" * 64,
+    }
+
+    def response(url: str, **kwargs):
+        assert url == "https://pypi.org/pypi/miniverl/0.2.0/json"
+        return {
+            "info": {"name": "miniverl", "version": "0.2.0"},
+            "urls": [
+                {
+                    "filename": filename,
+                    "packagetype": "bdist_wheel" if filename.endswith(".whl") else "sdist",
+                    "digests": {"sha256": digest},
+                    "url": f"https://files.pythonhosted.org/packages/{filename}",
+                }
+                for filename, digest in expected.items()
+            ],
+        }
+
+    monkeypatch.setattr(verifier, "_request_json", response)
+    urls = verifier._verify_metadata(
+        project="miniverl",
+        version="0.2.0",
+        expected=expected,
+    )
+
+    assert len(urls) == 2
+
+
+def test_integrity_verification_requires_attestations_for_every_file(monkeypatch) -> None:
+    verifier = _module()
+    seen: list[str] = []
+
+    def response(url: str, **kwargs):
+        seen.append(url)
+        return {"attestation_bundles": [{"attestations": [{"envelope": {}}]}]}
+
+    monkeypatch.setattr(verifier, "_request_json", response)
+    verifier._verify_integrity_metadata(
+        project="miniverl",
+        version="0.2.0",
+        filenames=["miniverl-0.2.0-py3-none-any.whl", "miniverl-0.2.0.tar.gz"],
+    )
+
+    assert len(seen) == 2
+    assert all(url.endswith("/provenance") for url in seen)
+
+
+def test_hash_mismatch_fails_before_attestation_verification(monkeypatch) -> None:
+    verifier = _module()
+
+    def response(url: str, **kwargs):
+        return {
+            "info": {"name": "miniverl", "version": "0.2.0"},
+            "urls": [
+                {
+                    "filename": "miniverl-0.2.0-py3-none-any.whl",
+                    "packagetype": "bdist_wheel",
+                    "digests": {"sha256": "b" * 64},
+                    "url": (
+                        "https://files.pythonhosted.org/packages/miniverl-0.2.0-py3-none-any.whl"
+                    ),
+                },
+                {
+                    "filename": "miniverl-0.2.0.tar.gz",
+                    "packagetype": "sdist",
+                    "digests": {"sha256": "wrong"},
+                    "url": "https://files.pythonhosted.org/packages/miniverl-0.2.0.tar.gz",
+                },
+            ],
+        }
+
+    monkeypatch.setattr(verifier, "_request_json", response)
+    with pytest.raises(RuntimeError, match="SHA-256 mismatch"):
+        verifier._verify_metadata(
+            project="miniverl",
+            version="0.2.0",
+            expected={
+                "miniverl-0.2.0-py3-none-any.whl": "b" * 64,
+                "miniverl-0.2.0.tar.gz": "a" * 64,
+            },
+        )

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -1,0 +1,71 @@
+"""Static safety assertions for the v0.2 release supply chain."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "release.yml"
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _job(text: str, name: str, next_name: str | None) -> str:
+    start = text.index(f"  {name}:")
+    end = text.index(f"  {next_name}:", start) if next_name else len(text)
+    return text[start:end]
+
+
+@pytest.mark.parametrize(
+    ("event_name", "ref", "expected"),
+    [
+        ("workflow_dispatch", "refs/heads/main", False),
+        ("workflow_dispatch", "refs/tags/v0.2.0", False),
+        ("push", "refs/heads/main", False),
+        ("push", "refs/tags/not-a-release", False),
+        ("push", "refs/tags/v0.2.0", True),
+    ],
+)
+def test_publish_eligibility_is_tag_push_only(
+    event_name: str,
+    ref: str,
+    expected: bool,
+) -> None:
+    eligible = event_name == "push" and ref.startswith("refs/tags/v")
+    assert eligible is expected
+    if expected:
+        condition = "github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')"
+        text = _workflow_text()
+        assert text.count(condition) == 3
+
+
+def test_distributions_are_built_once_and_consumed_without_rebuild() -> None:
+    text = _workflow_text()
+    assert text.count("python -m build") == 1
+    build = _job(text, "build-distributions", "publish-pypi")
+    publish = _job(text, "publish-pypi", "verify-pypi")
+    verify = _job(text, "verify-pypi", "create-github-release")
+    release = _job(text, "create-github-release", None)
+
+    assert "python -m build" in build
+    assert "twine check" in build
+    assert "SHA256SUMS" in build
+    assert "actions/upload-artifact@" in build
+    assert "actions/download-artifact@" in publish
+    assert "python -m build" not in publish
+    assert "actions/checkout@" not in publish
+    assert "actions/download-artifact@" in verify
+    assert "actions/download-artifact@" in release
+    assert text.count("name: release-distributions") == 4
+    assert "needs: verify-pypi" in release
+
+
+def test_every_action_is_pinned_to_a_full_commit_sha() -> None:
+    uses = re.findall(r"^\s*-\s+uses:\s+([^\s#]+)", _workflow_text(), flags=re.MULTILINE)
+    assert uses
+    for action in uses:
+        assert re.fullmatch(r"[^@]+@[0-9a-f]{40}", action), action


### PR DESCRIPTION
## Summary

- make `--offline` a zero-network contract across train, benchmark, eval and adapter export
- resolve and validate one pinned Hub adapter snapshot, then load that exact local directory with PEFT
- preserve zero-network PEFT auto-detection across Transformers 4.51.x and 5.x
- build release distributions once, publish and verify the same artifacts, and create GitHub Releases only after public PyPI verification
- correct pending Trusted Publisher and release-state documentation without changing scientific results

## Final evidence

- complete CPU suite: 1004 passed, 5 deselected
- CUDA suite: 5 passed, 1004 deselected on RTX 4080
- focused offline contract: 129 passed, including socket denial and actual offline CLI train/benchmark/eval/export runs
- independent Transformers 4.51.3 and 5.14.1 environments: 124 passed each
- ruff and formatting clean; mypy clean over 73 source files; actionlint 1.7.12 accepts `release.yml`
- isolated wheel and sdist pass `twine check`; clean core wheel has no torch; clean `[train]` wheel completes demo/inspect/report
- package/schema/SVG/privacy/release checks: 88 passed; local and external Markdown link audits pass
- frozen benchmark SHA-256 remains `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`

No tag or publication will be created: **PyPI pending publisher not yet registered** remains the sole external blocker.