### PR TITLE
Sync published v0.2 state

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
           PY
 
       - name: Upload immutable release distributions
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-distributions
           path: |
@@ -151,7 +151,7 @@ jobs:
       contents: read
     steps:
       - name: Download release distributions
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-distributions
           path: release-artifacts
@@ -180,7 +180,7 @@ jobs:
           python-version: "3.12"
 
       - name: Download the published distributions
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-distributions
           path: release-artifacts
@@ -226,7 +226,7 @@ jobs:
       contents: write
     steps:
       - name: Download the verified distributions
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-distributions
           path: release-artifacts

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -11,17 +11,19 @@ Last updated: 2026-07-28.
 | item | current state |
 | --- | --- |
 | public repository | `https://github.com/DaoyuanLi2816/mini-verl` |
-| release-code merge | public `main` advanced to `4287682873e3e1f4858827822befc714f5478296` through PR #6; local `main`, `origin/main` and `ls-remote` matched after the merge |
+| release-code merge | PR [#6](https://github.com/DaoyuanLi2816/mini-verl/pull/6) and the final state sync in PR [#7](https://github.com/DaoyuanLi2816/mini-verl/pull/7) are merged; release commit `6092706b4a4e750c4571d7d6a7decbc26af851b2` is recorded as annotated tag `v0.2.0` |
 | previous integration | PR [#4](https://github.com/DaoyuanLi2816/mini-verl/pull/4) and PR [#5](https://github.com/DaoyuanLi2816/mini-verl/pull/5) are merged |
 | release branch | `v0.2-final-release` was merged and deleted |
-| final integration | PR [#6](https://github.com/DaoyuanLi2816/mini-verl/pull/6) merged on 2026-07-28; all eight PR checks and both post-merge `main` workflows passed |
+| final integration | PR #6 and PR #7 merged on 2026-07-28; all eight checks on each PR and both post-merge `main` workflows passed |
 | lifecycle fix | merged on `main`: destructive, idempotent cleanup and explicit cold-start/arm context boundaries are implemented |
-| public default-branch health | post-merge `ci` run `30417663806` and `build` run `30417663821` completed successfully |
+| public default-branch health | final pre-tag `ci` run [`30417912194`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30417912194) and `build` run [`30417912198`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30417912198) completed successfully |
 | final-pass status | complete locally: 1004 CPU tests, 5 GPU tests, 129 focused offline tests, dual Transformers compatibility, build, clean-wheel, README-command, link, schema, JSON/JSONL, privacy and release-workflow gates pass |
-| version | `0.2.0`; no public `v0.2.0` tag, GitHub Release or PyPI publication is claimed |
-| PyPI | `https://pypi.org/pypi/miniverl/json` returned HTTP 404 on 2026-07-28; a pending publisher can create the project on first OIDC upload, but its registration has not been verified |
+| version | `0.2.0` published on 2026-07-28 (2026-07-29 UTC); tag `v0.2.0` resolves to `6092706b4a4e750c4571d7d6a7decbc26af851b2` |
+| release workflow | tag run [`30421231859`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30421231859) passed metadata, full tests, single-build, OIDC publish, public verification and GitHub Release jobs |
+| PyPI | [`miniverl 0.2.0`](https://pypi.org/project/miniverl/0.2.0/) was created by Trusted Publishing; wheel SHA-256 `cf850a6333483a3ee22c0c0e98df1e1b2e6faa184480573e0666658b53a29262`, sdist SHA-256 `3d5107b4f6351204335f800ce924208843f08f54441378bd9f25c3c6fa17456b` |
+| GitHub Release | [`miniVERL v0.2.0`](https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.2.0) is public and contains the same wheel, sdist and `SHA256SUMS` |
 | GitHub environment | `pypi` created through the repository API on 2026-07-28; custom deployment policy permits only tags matching `v*` |
-| external publication blocker | **PyPI pending publisher not yet registered**; both available browser contexts reached the PyPI login page, so account-level pending state could not be verified |
+| external publication blocker | none; the exact pending publisher was registered, the first OIDC upload succeeded, and PyPI records `release.yml` on `DaoyuanLi2816/mini-verl` as the publisher |
 | Hugging Face adapter | public at `https://huggingface.co/DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher`, immutable head `23323751318135484c06c043b1f9b9e7016dd89f` |
 | scientific artifact | schema-v2 JSON remains byte-identical at SHA-256 `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc` |
 
@@ -61,17 +63,15 @@ Focused final-pass evidence:
 
 Currently failing commands:
 
-- None. The only remaining blocker is external account state: the PyPI pending
-  publisher has not been verifiably registered.
+- None. The tag release, public artifact verification and clean public install
+  all pass.
 
-Exact next actions:
+Post-release follow-up:
 
-1. Register and verify the exact PyPI pending publisher documented in
-   `docs/release-checklist.md`.
-2. Re-check PyPI name availability immediately before publication.
-3. Do not create `v0.2.0` while the pending publisher remains unverified; once
-   verified and publication is explicitly authorized, the tag-only workflow
-   publishes and verifies PyPI before creating the GitHub Release.
+1. Upload `docs/banner.svg`, rendered at 1280×640 PNG, as the repository social
+   preview through the authenticated repository settings page.
+2. Keep `v0.2.0` immutable. Future package changes require a new version and tag;
+   never move or replace the published tag.
 
 ## Historical v0.2 pre-merge evidence (PR #4)
 
@@ -186,7 +186,7 @@ complete; PR #4 contains the integration state.
 | transformers | 5.14.1 | `importlib.metadata.version` |
 | peft | 0.19.1 | idem |
 | bitsandbytes | 0.50.0, `bnb.nn.Linear4bit` present | idem |
-| PyPI name `miniverl` | AVAILABLE (HTTP 404 on `/pypi/miniverl/json`, 2026-07-27) | `Invoke-WebRequest` |
+| PyPI project `miniverl` | PUBLISHED (`0.2.0`, Trusted Publishing, 2026-07-28) | public PyPI JSON, Integrity API and clean install |
 
 ## Verified model pair (pinned in the recipes)
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![CI](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/ci.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/ci.yml)
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
+[![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,6 +6,7 @@
 
 [![CI](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/ci.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/ci.yml)
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
+[![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,9 +1,9 @@
 # Release checklist
 
-This is the release-candidate gate for `v0.2.0`. A checked box means the command
-was executed on the v0.2 source or the named invariant was inspected. The
-`release` workflow re-runs the mechanical gates and fails a tag if any item
-before *After the tag* is left unchecked.
+This is the release gate and publication record for `v0.2.0`. A checked box
+means the command was executed on the v0.2 source or the named invariant was
+inspected. The `release` workflow re-runs the mechanical gates and fails a tag
+if any item before *After the tag* is left unchecked.
 
 ## Version consistency
 
@@ -49,8 +49,8 @@ Checked by: `.github/workflows/release.yml`, job `validate-and-test`.
 - [x] Every number in the README and in `docs/` is measured, or marked
       "not measured" / "not run".
 - [x] The verl disclaimer is present and accurate.
-- [x] Badges point at workflows that exist. **No PyPI badge until the package is
-      actually published.**
+- [x] Badges point at workflows that exist. The PyPI badge was added only after
+      the public `0.2.0` publication was independently verified.
 - [x] `docs/limitations.md` is current and does not undersell anything.
 
 ## Artifacts and hygiene
@@ -63,65 +63,55 @@ Checked by: `.github/workflows/release.yml`, job `validate-and-test`.
       `miniverl schema`.
 - [x] Every file in `benchmarks/results/` validates against that schema.
 
-## Publishing (externally blocked)
+## Publishing (completed)
 
 The workflow stores no secret or long-lived PyPI token. Its publish, public
 verification and GitHub Release jobs each independently require a `push` event
 whose ref starts with `refs/tags/v`; `workflow_dispatch` validates, tests,
 builds and uploads a workflow artifact but can never publish.
 
-Live verification on 2026-07-28 found:
+The exact pending publisher was registered with project `miniverl`, owner
+`DaoyuanLi2816`, repository `mini-verl`, workflow `release.yml` and environment
+`pypi`. The tag was pushed only after that account-side registration was
+confirmed.
 
-- `https://pypi.org/pypi/miniverl/json` returns HTTP 404;
-- the GitHub `pypi` environment exists and its custom deployment policy permits
-  only tags matching `v*`;
-- no `v0.2.0` tag, PyPI release or GitHub Release exists;
-- **PyPI pending publisher not yet registered** is the sole external
-  publication blocker.
+Tag run
+[`30421231859`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30421231859)
+completed successfully on 2026-07-28 (2026-07-29 UTC):
 
-PyPI's
-[pending-publisher documentation](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/)
-supports creating a new project on the first OIDC upload. A project page does
-not need to exist first, and no token-based bootstrap upload is needed. The
-exact bootstrap is:
+1. `v0.2.0` resolved to release commit
+   `6092706b4a4e750c4571d7d6a7decbc26af851b2`.
+2. The full quality gate passed and the wheel and sdist were built exactly once.
+3. OIDC Trusted Publishing created
+   [`miniverl 0.2.0`](https://pypi.org/project/miniverl/0.2.0/) without a token.
+4. Public PyPI metadata, file hashes and repository-identity attestations passed,
+   followed by a clean public install and CLI exercise.
+5. Only then did the workflow create
+   [`miniVERL v0.2.0`](https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.2.0)
+   with the verified wheel, sdist and `SHA256SUMS`.
 
-1. Sign in to the intended PyPI maintainer account.
-2. Open the account-level **Publishing** page.
-3. Add a pending GitHub publisher with:
-   - PyPI project name: `miniverl`
-   - GitHub owner: `DaoyuanLi2816`
-   - Repository: `mini-verl`
-   - Workflow filename: `release.yml`
-   - Environment: `pypi`
-4. Confirm the GitHub environment is still named exactly `pypi`.
-5. Only with explicit publication authorization, push `v0.2.0`.
-6. Verify that the first tagged OIDC publication created the project and
-   converted the pending publisher to a normal publisher, following the
-   [OIDC publishing flow](https://docs.pypi.org/trusted-publishers/using-a-publisher/).
+### Published artifact identity
 
-The pending publisher does **not** reserve `miniverl` before that first upload.
-Re-check name availability immediately before registration and tagging.
-Package metadata `[project].name` must remain exactly `miniverl`, and every
-owner/repository/workflow/environment claim above must match exactly. Until the
-pending publisher is verifiably registered, do not create the tag.
+- `miniverl-0.2.0-py3-none-any.whl`:
+  SHA-256 `cf850a6333483a3ee22c0c0e98df1e1b2e6faa184480573e0666658b53a29262`
+- `miniverl-0.2.0.tar.gz`:
+  SHA-256 `3d5107b4f6351204335f800ce924208843f08f54441378bd9f25c3c6fa17456b`
 
-### Name availability
-
-`miniverl` was available on PyPI when this release was prepared
-(`https://pypi.org/pypi/miniverl/json` returned HTTP 404 on 2026-07-28).
-That 404 is not a reservation. **Re-check immediately before publishing** and
-stop rather than silently changing the distribution name if it has been taken.
+Independent downloads from both PyPI and the GitHub Release reproduced those
+digests. PyPI reports Trusted Publishing and an attestation publisher of
+`release.yml` on `DaoyuanLi2816/mini-verl`.
 
 ## After the tag
 
-- [ ] Set the GitHub repository description to
+- [x] Set the GitHub repository description to
       `On-policy distillation for tool-using LLM agents on one consumer GPU.`
-- [ ] Set the topics: `llm`, `on-policy-distillation`, `knowledge-distillation`,
+- [x] Set the topics: `llm`, `on-policy-distillation`, `knowledge-distillation`,
       `agentic-rl`, `tool-use`, `qlora`, `consumer-gpu`, `post-training`, `qwen`,
       `llm-agents`, `verl`.
 - [ ] Upload `docs/banner.svg` (rendered to PNG) as the social preview image.
-- [ ] Create the GitHub release from `CHANGELOG.md`.
+- [x] Create the GitHub release from the verified release distributions and
+      generated notes.
 
-These four are repository-settings actions that cannot be performed from a
-commit, so they stay unchecked here on purpose; the `release` workflow only
-inspects the sections above.
+The remaining social-preview upload is a repository-settings action. A
+1280×640 PNG was rendered and inspected; the `release` workflow only inspects
+the sections above.


### PR DESCRIPTION
## Summary

- record the successful `v0.2.0` PyPI and GitHub Release publication, public
  artifact hashes, and release run
- add the verified PyPI badge to both READMEs and close completed post-tag
  checklist items
- refresh the pinned artifact actions to their Node.js 24 generations to remove
  the deprecation warning seen in the release run

## Validation

- `python -m pytest -q tests/unit/test_release_workflow.py
  tests/unit/test_pypi_release_verifier.py tests/unit/test_packaging.py`
  (`88 passed`)
- `ruff check .`
- `ruff format --check .`
- `actionlint 1.7.12 .github/workflows/release.yml`
- public PyPI, badge, release, and Actions links returned HTTP 200
- frozen benchmark SHA-256 remains
  `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`
