### PR TITLE
Polish README visuals and benchmark chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,49 +14,30 @@
 
 **On-policy distillation for tool-using agents on one GPU.**
 
-miniVERL trains a small tool-using language model on its own multi-turn
-trajectories using teacher distributional targets, without requiring Ray, a GPU
-cluster, or a 40 GB accelerator.
+miniVERL is a compact, auditable training lab for teaching a small language
+model from its own multi-turn tool trajectories. It runs real tools, keeps
+token provenance explicit, and applies teacher distributional targets only
+where they belong — without Ray, a GPU cluster, or a 40 GB accelerator.
 
 ```bash
-git clone https://github.com/DaoyuanLi2816/mini-verl.git
-cd mini-verl
-python -m pip install ".[train]"
+python -m pip install "miniverl[train]"
+miniverl doctor
 miniverl demo --output runs/demo        # no network, no GPU, ~50 s on a laptop CPU
 ```
 
-> [!IMPORTANT]
-> **Protocol alignment prevents the observed OPD collapse, but does not beat
-> supervised fine-tuning here.** The primary schema-v2 comparison uses two
-> prespecified seeds, equal optimizer updates, and the saturated `hard`
-> calculator split:
+**What it makes inspectable**
 
-| arm | seed 1234 | seed 20260727 |
-| --- | ---: | ---: |
-| cold start | 75.0% | 75.0% |
-| raw-teacher OPD | 0.0% | 0.0% |
-| privileged-teacher OPD | 0.0% | 0.0% |
-| protocol-teacher OPD | **100.0%** | **100.0%** |
-| continued SFT | **100.0%** | **100.0%** |
+- **Policy truth:** every OPD batch is sampled from the policy version it
+  updates; stale teacher targets are rejected.
+- **Token truth:** tool output stays context, while only typed assistant spans
+  can enter the loss.
+- **Budget truth:** exact full-vocabulary objectives and compressed
+  `top-k + tail` objectives are named and reported separately.
 
-The [public, immutable protocol-teacher adapter](https://huggingface.co/DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher)
-prevents the collapse caused by protocol-naive supervision, but OPD ties SFT
-and takes about 6x as much training time here (523.8 s versus 86.4 s on
-average). The task saturates; two seeds do not support a significance claim,
-and no general OPD advantage is claimed. See the
-[full result and legacy transcript diagnosis](docs/rtx4080-baselines.md).
-
-![Two-seed protocol-teacher benchmark](docs/gpu-calc-hard-equal-update-v2.svg)
-
-An older RTX 4080 pipeline smoke run trained **Qwen3-0.6B** from
-**Qwen3-1.7B** in **481 s / 16 optimizer steps**, peaking at **4.25 GiB
-allocated / 4.76 GiB reserved**, and moved held-out greedy success from
-**0.0% to 100.0%** on 12 tasks. The 8-cycle supervised cold start did most of
-that work: the first OPD rollout batch already scored 83.3%. It demonstrates
-the pipeline end to end, not an OPD-over-SFT result. Every number is traceable
-to [`docs/rtx4080-baselines.md`](docs/rtx4080-baselines.md).
-
----
+[Run the local demo](#local-toy-demo) ·
+[Train on a consumer GPU](#consumer-gpu-quickstart) ·
+[Inspect the measured result](#measured-result-protocol-alignment-prevents-collapse) ·
+[Read the math](docs/math.md)
 
 ## Why miniVERL exists
 
@@ -96,6 +77,39 @@ keeps the whole thing on one 16 GB card.
 | Exact checkpoint/resume | yes, asserted parameter-for-parameter |
 | Self-contained offline HTML report with token-level divergence | yes |
 | Ray, FSDP, DeepSpeed, vLLM, VLMs, cross-tokenizer, PPO/GRPO | **no** — see [limitations](docs/limitations.md) |
+
+## Measured result: protocol alignment prevents collapse
+
+> [!IMPORTANT]
+> **Protocol alignment prevents the observed OPD collapse, but does not beat
+> supervised fine-tuning here.** The primary schema-v2 comparison uses two
+> prespecified seeds, equal optimizer updates, and the saturated `hard`
+> calculator split:
+
+| arm | seed 1234 | seed 20260727 |
+| --- | ---: | ---: |
+| cold start | 75.0% | 75.0% |
+| raw-teacher OPD | 0.0% | 0.0% |
+| privileged-teacher OPD | 0.0% | 0.0% |
+| protocol-teacher OPD | **100.0%** | **100.0%** |
+| continued SFT | **100.0%** | **100.0%** |
+
+The [public, immutable protocol-teacher adapter](https://huggingface.co/DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher)
+prevents the collapse caused by protocol-naive supervision, but OPD ties SFT
+and takes about 6x as much training time here (523.8 s versus 86.4 s on
+average). The task saturates; two seeds do not support a significance claim,
+and no general OPD advantage is claimed. See the
+[full result and legacy transcript diagnosis](docs/rtx4080-baselines.md).
+
+![Two-seed protocol-teacher benchmark](docs/gpu-calc-hard-equal-update-v2.svg)
+
+An older RTX 4080 pipeline smoke run trained **Qwen3-0.6B** from
+**Qwen3-1.7B** in **481 s / 16 optimizer steps**, peaking at **4.25 GiB
+allocated / 4.76 GiB reserved**, and moved held-out greedy success from
+**0.0% to 100.0%** on 12 tasks. The 8-cycle supervised cold start did most of
+that work: the first OPD rollout batch already scored 83.3%. It demonstrates
+the pipeline end to end, not an OPD-over-SFT result. Every number is traceable
+to [`docs/rtx4080-baselines.md`](docs/rtx4080-baselines.md).
 
 ## Local toy demo
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,45 +16,26 @@
 
 **单卡上的工具调用智能体在线策略蒸馏（on-policy distillation）。**
 
-miniVERL 让一个小型的、会调用工具的语言模型在**它自己生成的多轮轨迹**上学习，监督信号来自教师模型的分布式目标。不需要 Ray，不需要 GPU 集群，也不需要 40 GB 显存的加速卡。
+miniVERL 是一个紧凑、可审计的训练实验室，让小型语言模型从**它自己生成的
+多轮工具轨迹**中学习。它会真实执行工具、显式记录 token 来源，并且只在正确
+的位置使用教师分布目标——不需要 Ray、GPU 集群或 40 GB 显存的加速卡。
 
 ```bash
-git clone https://github.com/DaoyuanLi2816/mini-verl.git
-cd mini-verl
-python -m pip install ".[train]"
+python -m pip install "miniverl[train]"
+miniverl doctor
 miniverl demo --output runs/demo        # 无需联网、无需 GPU，笔记本 CPU 上约 50 秒
 ```
 
-> [!IMPORTANT]
-> **协议对齐避免了已经观察到的 OPD 崩溃，但在这里没有超过监督微调。**
-> 主要的 schema-v2 对照使用两个预先指定的种子、相同的优化步数，以及已经
-> 饱和的 `hard` 计算器划分：
+**它让三件事可以被检查**
 
-| 实验臂 | seed 1234 | seed 20260727 |
-| --- | ---: | ---: |
-| 冷启动 | 75.0% | 75.0% |
-| 原始教师 OPD | 0.0% | 0.0% |
-| 特权上下文教师 OPD | 0.0% | 0.0% |
-| 协议教师 OPD | **100.0%** | **100.0%** |
-| 继续 SFT | **100.0%** | **100.0%** |
+- **策略真实：** 每个 OPD 批次都来自它要更新的策略版本；过期教师目标会被拒绝。
+- **Token 真实：** 工具输出只作为上下文，只有带类型的 assistant span 能进入 loss。
+- **预算真实：** 精确全词表目标与压缩的 `top-k + tail` 目标分开命名、分开报告。
 
-[公开且固定版本的协议教师适配器](https://huggingface.co/DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher)
-避免了协议不匹配监督造成的崩溃，但 OPD 只追平 SFT，而且这里的平均训练时间
-约为 SFT 的 6 倍（523.8 秒对 86.4 秒）。任务已经饱和；两个种子不足以支持
-显著性结论，也不构成 OPD 普遍更优的证据。完整结果和旧实验的逐轨迹诊断见
-[`docs/rtx4080-baselines.md`](docs/rtx4080-baselines.md)。
-
-![双种子协议教师对照](docs/gpu-calc-hard-equal-update-v2.svg)
-
-更早的一次 RTX 4080 流水线 smoke 运行用 **Qwen3-1.7B** 蒸馏
-**Qwen3-0.6B**，耗时 **481 秒 / 16 个优化步**，显存峰值为
-**4.25 GiB 已分配 / 4.76 GiB 已保留**，并在 12 个留出任务上把贪心成功率
-从 **0.0% 提升到 100.0%**。其中 8 个 cycle 的监督冷启动完成了大部分工作：
-第一批 OPD rollout 已经达到 83.3%。它证明流水线能端到端运行，而不是证明
-OPD 优于 SFT。所有数字都可追溯到
-[`docs/rtx4080-baselines.md`](docs/rtx4080-baselines.md)。
-
----
+[运行本地 demo](#本地玩具演示) ·
+[在消费级 GPU 上训练](#消费级-gpu-快速上手) ·
+[查看实测结果](#实测结果协议对齐避免崩溃) ·
+[阅读数学说明](docs/math.md)
 
 ## 为什么需要 miniVERL
 
@@ -85,6 +66,37 @@ miniVERL 把上面每一条都变成**被代码检查的性质**，而不是注�
 | 精确的断点续训 | 支持，逐参数断言 |
 | 完全自包含、可离线打开的 HTML 报告 | 支持 |
 | Ray、FSDP、DeepSpeed、vLLM、VLM、跨词表、PPO/GRPO | **不支持**，见[局限](docs/limitations.md) |
+
+## 实测结果：协议对齐避免崩溃
+
+> [!IMPORTANT]
+> **协议对齐避免了已经观察到的 OPD 崩溃，但在这里没有超过监督微调。**
+> 主要的 schema-v2 对照使用两个预先指定的种子、相同的优化步数，以及已经
+> 饱和的 `hard` 计算器划分：
+
+| 实验臂 | seed 1234 | seed 20260727 |
+| --- | ---: | ---: |
+| 冷启动 | 75.0% | 75.0% |
+| 原始教师 OPD | 0.0% | 0.0% |
+| 特权上下文教师 OPD | 0.0% | 0.0% |
+| 协议教师 OPD | **100.0%** | **100.0%** |
+| 继续 SFT | **100.0%** | **100.0%** |
+
+[公开且固定版本的协议教师适配器](https://huggingface.co/DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher)
+避免了协议不匹配监督造成的崩溃，但 OPD 只追平 SFT，而且这里的平均训练时间
+约为 SFT 的 6 倍（523.8 秒对 86.4 秒）。任务已经饱和；两个种子不足以支持
+显著性结论，也不构成 OPD 普遍更优的证据。完整结果和旧实验的逐轨迹诊断见
+[`docs/rtx4080-baselines.md`](docs/rtx4080-baselines.md)。
+
+![双种子协议教师对照](docs/gpu-calc-hard-equal-update-v2.svg)
+
+更早的一次 RTX 4080 流水线 smoke 运行用 **Qwen3-1.7B** 蒸馏
+**Qwen3-0.6B**，耗时 **481 秒 / 16 个优化步**，显存峰值为
+**4.25 GiB 已分配 / 4.76 GiB 已保留**，并在 12 个留出任务上把贪心成功率
+从 **0.0% 提升到 100.0%**。其中 8 个 cycle 的监督冷启动完成了大部分工作：
+第一批 OPD rollout 已经达到 83.3%。它证明流水线能端到端运行，而不是证明
+OPD 优于 SFT。所有数字都可追溯到
+[`docs/rtx4080-baselines.md`](docs/rtx4080-baselines.md)。
 
 ## 本地玩具演示
 

--- a/docs/banner.svg
+++ b/docs/banner.svg
@@ -1,72 +1,102 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 260" width="880" height="260" role="img"
-     aria-label="miniVERL - on-policy distillation for tool-using agents on one GPU">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 250" width="880" height="250"
+     role="img" aria-labelledby="banner-title banner-desc">
+  <title id="banner-title">miniVERL</title>
+  <desc id="banner-desc">A one-GPU lab for reliable on-policy distillation of tool-using agents.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#10141a"/>
-      <stop offset="55%" stop-color="#161c25"/>
-      <stop offset="100%" stop-color="#1d2530"/>
+      <stop offset="0%" stop-color="#080d1f"/>
+      <stop offset="52%" stop-color="#172554"/>
+      <stop offset="100%" stop-color="#312e81"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#5aa9f0"/>
-      <stop offset="100%" stop-color="#63c48d"/>
+    <linearGradient id="brand" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#67e8f9"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
     </linearGradient>
-    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6"
-            orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#7d8794"/>
-    </marker>
+    <linearGradient id="card" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity=".12"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity=".055"/>
+    </linearGradient>
+    <filter id="blur">
+      <feGaussianBlur stdDeviation="34"/>
+    </filter>
   </defs>
 
-  <rect width="880" height="260" rx="14" fill="url(#bg)"/>
-  <rect x="0" y="0" width="880" height="3" rx="1.5" fill="url(#accent)"/>
+  <rect width="880" height="250" rx="18" fill="url(#bg)"/>
+  <circle cx="760" cy="14" r="118" fill="#7c3aed" opacity=".20" filter="url(#blur)"/>
+  <circle cx="390" cy="246" r="105" fill="#0891b2" opacity=".16" filter="url(#blur)"/>
+  <path d="M0 249 C190 207 307 266 472 225 S730 197 880 220 V250 H0Z"
+        fill="#38bdf8" opacity=".055"/>
+  <rect x=".75" y=".75" width="878.5" height="248.5" rx="17.25"
+        fill="none" stroke="#ffffff" stroke-opacity=".12" stroke-width="1.5"/>
 
-  <!-- wordmark -->
-  <text x="48" y="82" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
-        font-size="46" font-weight="700" letter-spacing="-1.2" fill="#e8ecf1">mini<tspan
-        fill="#5aa9f0">VERL</tspan></text>
+  <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif">
+    <text x="46" y="34" font-size="11" font-weight="700" letter-spacing="2.2" fill="#a5f3fc">
+      ONE-GPU OPD LAB
+    </text>
+    <text x="46" y="84" font-size="46" font-weight="780" letter-spacing="-1.8" fill="#f8fafc">
+      mini<tspan fill="url(#brand)">VERL</tspan>
+    </text>
+    <text x="46" y="113" font-size="17" font-weight="550" fill="#e2e8f0">
+      On-policy distillation for tool-using agents.
+    </text>
+    <text x="46" y="139" font-size="13" fill="#aebbd2">
+      Reproducible training, typed token provenance, and exact
+    </text>
+    <text x="46" y="158" font-size="13" fill="#aebbd2">
+      or budgeted divergence — without a cluster.
+    </text>
 
-  <text x="48" y="116" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif"
-        font-size="18" fill="#c3cbd6">On-policy distillation for tool-using agents on one GPU.</text>
+    <g font-size="11.5" font-weight="650">
+      <rect x="46" y="177" width="88" height="24" rx="12" fill="#22d3ee" fill-opacity=".13"
+            stroke="#67e8f9" stroke-opacity=".32"/>
+      <text x="90" y="193.5" text-anchor="middle" fill="#cffafe">strict OPD</text>
+      <rect x="143" y="177" width="102" height="24" rx="12" fill="#818cf8" fill-opacity=".14"
+            stroke="#a5b4fc" stroke-opacity=".32"/>
+      <text x="194" y="193.5" text-anchor="middle" fill="#e0e7ff">offline-safe</text>
+      <rect x="254" y="177" width="92" height="24" rx="12" fill="#a78bfa" fill-opacity=".14"
+            stroke="#c4b5fd" stroke-opacity=".32"/>
+      <text x="300" y="193.5" text-anchor="middle" fill="#ede9fe">16 GB first</text>
+    </g>
 
-  <text x="48" y="142" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif"
-        font-size="13" fill="#7d8794">A readable, reproducible, 16GB-first post-training lab for
-        exact and budgeted on-policy distillation.</text>
+    <rect x="46" y="211" width="300" height="25" rx="7" fill="#020617" fill-opacity=".64"
+          stroke="#94a3b8" stroke-opacity=".22"/>
+    <circle cx="61" cy="223.5" r="3" fill="#67e8f9"/>
+    <text x="72" y="228" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+          font-size="11.5" fill="#dbeafe">pip install "miniverl[train]"</text>
 
-  <!-- pipeline schematic -->
-  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="11.5">
-    <!-- student -->
-    <rect x="48" y="176" width="126" height="46" rx="8" fill="#1f2833" stroke="#33404f"/>
-    <text x="111" y="195" text-anchor="middle" fill="#e8ecf1">student pi_theta</text>
-    <text x="111" y="211" text-anchor="middle" fill="#7d8794">QLoRA, 16 GB</text>
+    <line x1="405" y1="28" x2="405" y2="222" stroke="#ffffff" stroke-opacity=".12"/>
 
-    <!-- env -->
-    <rect x="204" y="176" width="132" height="46" rx="8" fill="#1f2833" stroke="#33404f"/>
-    <text x="270" y="195" text-anchor="middle" fill="#e8ecf1">tools + verifier</text>
-    <text x="270" y="211" text-anchor="middle" fill="#7d8794">calc / json / sqlite</text>
+    <g>
+      <rect x="437" y="28" width="397" height="56" rx="12" fill="url(#card)"
+            stroke="#ffffff" stroke-opacity=".12"/>
+      <circle cx="467" cy="56" r="15" fill="#06b6d4" fill-opacity=".18"
+              stroke="#67e8f9" stroke-opacity=".44"/>
+      <path d="M461 56h12M467 50v12" stroke="#a5f3fc" stroke-width="1.8"
+            stroke-linecap="round"/>
+      <text x="494" y="51" font-size="14" font-weight="700" fill="#f8fafc">Sample</text>
+      <text x="494" y="70" font-size="12" fill="#b9c5d8">Student trajectories with real tool execution</text>
+    </g>
 
-    <!-- trajectory -->
-    <rect x="366" y="176" width="150" height="46" rx="8" fill="#1f2833" stroke="#33404f"/>
-    <text x="441" y="195" text-anchor="middle" fill="#e8ecf1">typed token spans</text>
-    <text x="441" y="211" text-anchor="middle" fill="#7d8794">tool output = context</text>
+    <g>
+      <rect x="437" y="97" width="397" height="56" rx="12" fill="url(#card)"
+            stroke="#ffffff" stroke-opacity=".12"/>
+      <circle cx="467" cy="125" r="15" fill="#6366f1" fill-opacity=".20"
+              stroke="#a5b4fc" stroke-opacity=".44"/>
+      <path d="M460 121h14M460 125h9M460 129h12" stroke="#c7d2fe" stroke-width="1.8"
+            stroke-linecap="round"/>
+      <text x="494" y="120" font-size="14" font-weight="700" fill="#f8fafc">Align</text>
+      <text x="494" y="139" font-size="12" fill="#b9c5d8">Typed spans keep tool output as context</text>
+    </g>
 
-    <!-- teacher -->
-    <rect x="546" y="176" width="134" height="46" rx="8" fill="#1f2833" stroke="#33404f"/>
-    <text x="613" y="195" text-anchor="middle" fill="#e8ecf1">teacher scores</text>
-    <text x="613" y="211" text-anchor="middle" fill="#7d8794">those exact states</text>
-
-    <!-- update -->
-    <rect x="710" y="176" width="122" height="46" rx="8" fill="#1f2833" stroke="#5aa9f0"/>
-    <text x="771" y="195" text-anchor="middle" fill="#e8ecf1">masked KL</text>
-    <text x="771" y="211" text-anchor="middle" fill="#7d8794">top-k + tail</text>
-
-    <line x1="176" y1="199" x2="200" y2="199" stroke="#7d8794" stroke-width="1.4" marker-end="url(#arrow)"/>
-    <line x1="338" y1="199" x2="362" y2="199" stroke="#7d8794" stroke-width="1.4" marker-end="url(#arrow)"/>
-    <line x1="518" y1="199" x2="542" y2="199" stroke="#7d8794" stroke-width="1.4" marker-end="url(#arrow)"/>
-    <line x1="682" y1="199" x2="706" y2="199" stroke="#7d8794" stroke-width="1.4" marker-end="url(#arrow)"/>
-
-    <!-- feedback edge -->
-    <path d="M 771 226 L 771 242 L 111 242 L 111 226" fill="none" stroke="#3d4a5a"
-          stroke-width="1.4" stroke-dasharray="4 4" marker-end="url(#arrow)"/>
-    <text x="441" y="255" text-anchor="middle" fill="#5b6674" font-size="10.5">policy version + 1;
-      the next batch is resampled from the updated student</text>
+    <g>
+      <rect x="437" y="166" width="397" height="56" rx="12" fill="url(#card)"
+            stroke="#ffffff" stroke-opacity=".12"/>
+      <circle cx="467" cy="194" r="15" fill="#8b5cf6" fill-opacity=".20"
+              stroke="#c4b5fd" stroke-opacity=".44"/>
+      <path d="M460 198l5-7 5 4 5-8" fill="none" stroke="#ddd6fe" stroke-width="1.8"
+            stroke-linecap="round" stroke-linejoin="round"/>
+      <text x="494" y="189" font-size="14" font-weight="700" fill="#f8fafc">Distill</text>
+      <text x="494" y="208" font-size="12" fill="#b9c5d8">Exact or top-k KL on one consumer GPU</text>
+    </g>
   </g>
 </svg>

--- a/docs/gpu-calc-hard-equal-update-v2.svg
+++ b/docs/gpu-calc-hard-equal-update-v2.svg
@@ -1,78 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="584" viewBox="0 0 1120 584" role="img" aria-labelledby="benchmark-title benchmark-desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="581" viewBox="0 0 1120 581" role="img" aria-labelledby="benchmark-title benchmark-desc">
 <title id="benchmark-title">miniVERL protocol-teacher benchmark</title>
-<desc id="benchmark-desc">Strict held-out success and training time for five equal-optimizer-update arms over two prespecified seeds.</desc>
-<style>text{font-family:ui-sans-serif,system-ui,sans-serif;fill:#111827}.title{font-size:25px;font-weight:600}.sub{font-size:14px;fill:#4b5563}.head{font-size:15px;font-weight:600}.label{font-size:15px}.value{font-size:14px;font-weight:600}.axis{font-size:12px;fill:#6b7280}.grid{stroke:#d1d5db;stroke-width:1}.dot{fill:#fff;stroke-width:2}</style>
-<rect width="100%" height="100%" fill="#ffffff"/>
-<text class="title" x="28" y="40">Protocol alignment prevents collapse</text>
-<text class="sub" x="28" y="66">schema v2 | 2 prespecified seeds | budget axis: optimizer_steps</text>
-<text class="head" x="300" y="110">Strict held-out success</text>
-<text class="head" x="730" y="110">Training time (seconds)</text>
-<line class="grid" x1="300.0" y1="124" x2="300.0" y2="536"/>
-<text class="axis" x="300.0" y="144" text-anchor="middle">0%</text>
-<line class="grid" x1="450.0" y1="124" x2="450.0" y2="536"/>
-<text class="axis" x="450.0" y="144" text-anchor="middle">50%</text>
-<line class="grid" x1="600.0" y1="124" x2="600.0" y2="536"/>
-<text class="axis" x="600.0" y="144" text-anchor="middle">100%</text>
-<line class="grid" x1="730.0" y1="124" x2="730.0" y2="536"/>
-<text class="axis" x="730.0" y="144" text-anchor="middle">0</text>
-<line class="grid" x1="880.0" y1="124" x2="880.0" y2="536"/>
-<text class="axis" x="880.0" y="144" text-anchor="middle">300</text>
-<line class="grid" x1="1030.0" y1="124" x2="1030.0" y2="536"/>
-<text class="axis" x="1030.0" y="144" text-anchor="middle">600</text>
+<desc id="benchmark-desc">Strict held-out success and training time for equal-optimizer-update arms over 2 prespecified seeds. 2 zero-success arms are labeled collapsed. The cold-start baseline is labeled no training.</desc>
+<style>text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,Segoe UI,sans-serif;fill:#172033}.title{font-size:25px;font-weight:750;letter-spacing:-.3px}.sub{font-size:13px;fill:#64748b}.head{font-size:14px;font-weight:700}.label{font-size:14px;font-weight:560}.value{font-size:13px;font-weight:700}.axis{font-size:11.5px;fill:#718096}.note{font-size:11.5px;fill:#64748b}.panel{fill:#f8fafc;stroke:#e2e8f0}.track{fill:#e9eef5}.grid{stroke:#cbd5e1;stroke-width:1}.separator{stroke:#e8edf3;stroke-width:1}.dot{fill:#fff;stroke-width:2}.pill{fill:#fff;stroke-width:1.4}</style>
+<rect width="100%" height="100%" rx="16" fill="#ffffff"/>
+<rect x=".75" y=".75" width="1118.5" height="579.5" rx="15.25" fill="none" stroke="#e2e8f0" stroke-width="1.5"/>
+<text class="title" x="36" y="42">Protocol alignment prevents collapse</text>
+<text class="sub" x="36" y="68">schema v2  ·  2 prespecified seeds  ·  budget axis: optimizer_steps</text>
+<rect class="panel" x="282" y="91" width="380" height="433" rx="12"/>
+<rect class="panel" x="702" y="91" width="380" height="433" rx="12"/>
+<text class="head" x="315" y="119">Strict held-out success</text>
+<text class="head" x="735" y="119">Training time</text>
+<line class="grid" x1="315.0" y1="139" x2="315.0" y2="519"/>
+<text class="axis" x="315.0" y="153" text-anchor="middle">0%</text>
+<line class="grid" x1="457.5" y1="139" x2="457.5" y2="519"/>
+<text class="axis" x="457.5" y="153" text-anchor="middle">50%</text>
+<line class="grid" x1="600.0" y1="139" x2="600.0" y2="519"/>
+<text class="axis" x="600.0" y="153" text-anchor="middle">100%</text>
+<line class="grid" x1="735.0" y1="139" x2="735.0" y2="519"/>
+<text class="axis" x="735.0" y="153" text-anchor="middle">0s</text>
+<line class="grid" x1="870.0" y1="139" x2="870.0" y2="519"/>
+<text class="axis" x="870.0" y="153" text-anchor="middle">300s</text>
+<line class="grid" x1="1005.0" y1="139" x2="1005.0" y2="519"/>
+<text class="axis" x="1005.0" y="153" text-anchor="middle">600s</text>
 <g data-arm="cold-start-only" data-success-mean="0.750000" data-train-seconds-mean="0.061326">
-<text class="label" x="28" y="185">cold-start-only</text>
-<rect x="300" y="167" width="225.0" height="26" rx="3" fill="#6b7280" opacity="0.78"/>
-<circle class="dot" cx="525.0" cy="174" r="4" stroke="#6b7280"/>
-<circle class="dot" cx="525.0" cy="186" r="4" stroke="#6b7280"/>
-<text class="value" x="612" y="185">75%</text>
-<rect x="730" y="167" width="0.0" height="26" rx="3" fill="#6b7280" opacity="0.78"/>
-<circle class="dot" cx="730.0" cy="174" r="4" stroke="#6b7280"/>
-<circle class="dot" cx="730.0" cy="186" r="4" stroke="#6b7280"/>
-<text class="value" x="1042" y="185">0s</text>
+<text class="label" x="36" y="195">Cold start</text>
+<rect class="track" x="315" y="180" width="285" height="20" rx="5"/>
+<rect x="315" y="180" width="213.8" height="20" rx="5" fill="#64748b" opacity=".84"/>
+<circle class="dot" cx="528.8" cy="185" r="3.5" stroke="#64748b"/>
+<circle class="dot" cx="528.8" cy="195" r="3.5" stroke="#64748b"/>
+<text class="value" x="612" y="195">75%</text>
+<rect class="pill" x="747" y="177" width="104" height="26" rx="13" stroke="#94a3b8"/>
+<text class="value" x="799" y="194" text-anchor="middle" fill="#64748b">NO TRAINING</text>
 </g>
+<line class="separator" x1="36" y1="227" x2="1082" y2="227"/>
 <g data-arm="sft-continued" data-success-mean="1.000000" data-train-seconds-mean="86.439230">
-<text class="label" x="28" y="267">sft-continued</text>
-<rect x="300" y="249" width="300.0" height="26" rx="3" fill="#3b82f6" opacity="0.78"/>
-<circle class="dot" cx="600.0" cy="256" r="4" stroke="#3b82f6"/>
-<circle class="dot" cx="600.0" cy="268" r="4" stroke="#3b82f6"/>
-<text class="value" x="612" y="267">100%</text>
-<rect x="730" y="249" width="43.2" height="26" rx="3" fill="#3b82f6" opacity="0.78"/>
-<circle class="dot" cx="770.3" cy="256" r="4" stroke="#3b82f6"/>
-<circle class="dot" cx="776.2" cy="268" r="4" stroke="#3b82f6"/>
-<text class="value" x="1042" y="267">86s</text>
+<text class="label" x="36" y="270">Continued SFT</text>
+<rect class="track" x="315" y="255" width="285" height="20" rx="5"/>
+<rect x="315" y="255" width="285.0" height="20" rx="5" fill="#3b82f6" opacity=".84"/>
+<circle class="dot" cx="600.0" cy="260" r="3.5" stroke="#3b82f6"/>
+<circle class="dot" cx="600.0" cy="270" r="3.5" stroke="#3b82f6"/>
+<text class="value" x="612" y="270">100%</text>
+<rect class="track" x="735" y="255" width="270" height="20" rx="5"/>
+<rect x="735" y="255" width="38.9" height="20" rx="5" fill="#3b82f6" opacity=".84"/>
+<circle class="dot" cx="771.2" cy="260" r="3.5" stroke="#3b82f6"/>
+<circle class="dot" cx="776.6" cy="270" r="3.5" stroke="#3b82f6"/>
+<text class="value" x="1017" y="270">86s</text>
 </g>
+<line class="separator" x1="36" y1="302" x2="1082" y2="302"/>
 <g data-arm="opd-raw-teacher" data-success-mean="0.000000" data-train-seconds-mean="443.953792">
-<text class="label" x="28" y="349">opd-raw-teacher</text>
-<rect x="300" y="331" width="0.0" height="26" rx="3" fill="#dc2626" opacity="0.78"/>
-<circle class="dot" cx="300.0" cy="338" r="4" stroke="#dc2626"/>
-<circle class="dot" cx="300.0" cy="350" r="4" stroke="#dc2626"/>
-<text class="value" x="612" y="349">0%</text>
-<rect x="730" y="331" width="222.0" height="26" rx="3" fill="#dc2626" opacity="0.78"/>
-<circle class="dot" cx="964.3" cy="338" r="4" stroke="#dc2626"/>
-<circle class="dot" cx="939.6" cy="350" r="4" stroke="#dc2626"/>
-<text class="value" x="1042" y="349">444s</text>
+<text class="label" x="36" y="345">OPD · raw teacher</text>
+<rect class="pill" x="327" y="327" width="92" height="26" rx="13" stroke="#ef4444"/>
+<text class="value" x="373" y="344" text-anchor="middle" fill="#ef4444">COLLAPSED</text>
+<rect class="track" x="735" y="330" width="270" height="20" rx="5"/>
+<rect x="735" y="330" width="199.8" height="20" rx="5" fill="#ef4444" opacity=".84"/>
+<circle class="dot" cx="945.9" cy="335" r="3.5" stroke="#ef4444"/>
+<circle class="dot" cx="923.7" cy="345" r="3.5" stroke="#ef4444"/>
+<text class="value" x="1017" y="345">444s</text>
 </g>
+<line class="separator" x1="36" y1="377" x2="1082" y2="377"/>
 <g data-arm="opd-privileged-context" data-success-mean="0.000000" data-train-seconds-mean="531.523058">
-<text class="label" x="28" y="431">opd-privileged-context</text>
-<rect x="300" y="413" width="0.0" height="26" rx="3" fill="#f97316" opacity="0.78"/>
-<circle class="dot" cx="300.0" cy="420" r="4" stroke="#f97316"/>
-<circle class="dot" cx="300.0" cy="432" r="4" stroke="#f97316"/>
-<text class="value" x="612" y="431">0%</text>
-<rect x="730" y="413" width="265.8" height="26" rx="3" fill="#f97316" opacity="0.78"/>
-<circle class="dot" cx="1011.6" cy="420" r="4" stroke="#f97316"/>
-<circle class="dot" cx="979.9" cy="432" r="4" stroke="#f97316"/>
-<text class="value" x="1042" y="431">532s</text>
+<text class="label" x="36" y="420">OPD · privileged context</text>
+<rect class="pill" x="327" y="402" width="92" height="26" rx="13" stroke="#f59e0b"/>
+<text class="value" x="373" y="419" text-anchor="middle" fill="#f59e0b">COLLAPSED</text>
+<rect class="track" x="735" y="405" width="270" height="20" rx="5"/>
+<rect x="735" y="405" width="239.2" height="20" rx="5" fill="#f59e0b" opacity=".84"/>
+<circle class="dot" cx="988.5" cy="410" r="3.5" stroke="#f59e0b"/>
+<circle class="dot" cx="959.9" cy="420" r="3.5" stroke="#f59e0b"/>
+<text class="value" x="1017" y="420">532s</text>
 </g>
+<line class="separator" x1="36" y1="452" x2="1082" y2="452"/>
 <g data-arm="opd-protocol-sft-teacher" data-success-mean="1.000000" data-train-seconds-mean="523.820241">
-<text class="label" x="28" y="513">opd-protocol-sft-teacher</text>
-<rect x="300" y="495" width="300.0" height="26" rx="3" fill="#16a34a" opacity="0.78"/>
-<circle class="dot" cx="600.0" cy="502" r="4" stroke="#16a34a"/>
-<circle class="dot" cx="600.0" cy="514" r="4" stroke="#16a34a"/>
-<text class="value" x="612" y="513">100%</text>
-<rect x="730" y="495" width="261.9" height="26" rx="3" fill="#16a34a" opacity="0.78"/>
-<circle class="dot" cx="991.9" cy="502" r="4" stroke="#16a34a"/>
-<circle class="dot" cx="992.0" cy="514" r="4" stroke="#16a34a"/>
-<text class="value" x="1042" y="513">524s</text>
+<text class="label" x="36" y="495">OPD · protocol-aligned teacher</text>
+<rect class="track" x="315" y="480" width="285" height="20" rx="5"/>
+<rect x="315" y="480" width="285.0" height="20" rx="5" fill="#10b981" opacity=".84"/>
+<circle class="dot" cx="600.0" cy="485" r="3.5" stroke="#10b981"/>
+<circle class="dot" cx="600.0" cy="495" r="3.5" stroke="#10b981"/>
+<text class="value" x="612" y="495">100%</text>
+<rect class="track" x="735" y="480" width="270" height="20" rx="5"/>
+<rect x="735" y="480" width="235.7" height="20" rx="5" fill="#10b981" opacity=".84"/>
+<circle class="dot" cx="970.7" cy="485" r="3.5" stroke="#10b981"/>
+<circle class="dot" cx="970.8" cy="495" r="3.5" stroke="#10b981"/>
+<text class="value" x="1017" y="495">524s</text>
 </g>
-<text class="axis" x="28" y="566">Bars are seed means; hollow dots are individual seeds [1234, 20260727]. Source JSON SHA-256 53fc1d4d5b7adee0</text>
+<text class="note" x="36" y="546">Collapsed = 0% strict success in every recorded seed; cold start records setup only (0.06s), not a training phase.</text>
+<text class="note" x="36" y="564">Bars are seed means; hollow dots are individual seeds [1234, 20260727]. Source JSON SHA-256 53fc1d4d5b7adee0</text>
 </svg>

--- a/scripts/publish_benchmark_artifacts.py
+++ b/scripts/publish_benchmark_artifacts.py
@@ -93,22 +93,34 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
                 "seconds_mean": sum(seconds) / len(seconds),
             }
         )
+    collapsed_count = sum(row["success_mean"] == 0.0 for row in rows)
+    cold_start_seconds = next(
+        (row["seconds_mean"] for row in rows if row["name"] == "cold-start-only"),
+        None,
+    )
 
     width = 1120
-    height = 174 + len(rows) * 82
-    label_x = 28
-    success_x = 300
-    success_w = 300
-    time_x = 730
-    time_w = 300
+    height = 206 + len(rows) * 75
+    label_x = 36
+    success_x = 315
+    success_w = 285
+    time_x = 735
+    time_w = 270
     max_seconds = max(row["seconds_mean"] for row in rows)
     time_ceiling = max(100, int(math.ceil(max_seconds / 100.0) * 100))
     colors = {
-        "cold-start-only": "#6b7280",
+        "cold-start-only": "#64748b",
         "sft-continued": "#3b82f6",
-        "opd-raw-teacher": "#dc2626",
-        "opd-privileged-context": "#f97316",
-        "opd-protocol-sft-teacher": "#16a34a",
+        "opd-raw-teacher": "#ef4444",
+        "opd-privileged-context": "#f59e0b",
+        "opd-protocol-sft-teacher": "#10b981",
+    }
+    labels = {
+        "cold-start-only": "Cold start",
+        "sft-continued": "Continued SFT",
+        "opd-raw-teacher": "OPD · raw teacher",
+        "opd-privileged-context": "OPD · privileged context",
+        "opd-protocol-sft-teacher": "OPD · protocol-aligned teacher",
     }
 
     def line(text: str) -> str:
@@ -120,89 +132,150 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
         'aria-labelledby="benchmark-title benchmark-desc">'
     )
     svg += line('<title id="benchmark-title">miniVERL protocol-teacher benchmark</title>')
-    svg += line(
-        '<desc id="benchmark-desc">Strict held-out success and training time for five '
-        "equal-optimizer-update arms over two prespecified seeds.</desc>"
+    desc = (
+        "Strict held-out success and training time for equal-optimizer-update arms "
+        f"over {len(result.seeds)} prespecified seeds."
     )
+    if collapsed_count:
+        desc += f" {collapsed_count} zero-success arms are labeled collapsed."
+    if cold_start_seconds is not None:
+        desc += " The cold-start baseline is labeled no training."
+    svg += line(f'<desc id="benchmark-desc">{desc}</desc>')
     svg += line(
         "<style>"
-        "text{font-family:ui-sans-serif,system-ui,sans-serif;fill:#111827}"
-        ".title{font-size:25px;font-weight:600}.sub{font-size:14px;fill:#4b5563}"
-        ".head{font-size:15px;font-weight:600}.label{font-size:15px}"
-        ".value{font-size:14px;font-weight:600}.axis{font-size:12px;fill:#6b7280}"
-        ".grid{stroke:#d1d5db;stroke-width:1}.dot{fill:#fff;stroke-width:2}"
+        "text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,Segoe UI,sans-serif;"
+        "fill:#172033}.title{font-size:25px;font-weight:750;letter-spacing:-.3px}"
+        ".sub{font-size:13px;fill:#64748b}.head{font-size:14px;font-weight:700}"
+        ".label{font-size:14px;font-weight:560}.value{font-size:13px;font-weight:700}"
+        ".axis{font-size:11.5px;fill:#718096}.note{font-size:11.5px;fill:#64748b}"
+        ".panel{fill:#f8fafc;stroke:#e2e8f0}.track{fill:#e9eef5}"
+        ".grid{stroke:#cbd5e1;stroke-width:1}.separator{stroke:#e8edf3;stroke-width:1}"
+        ".dot{fill:#fff;stroke-width:2}.pill{fill:#fff;stroke-width:1.4}"
         "</style>"
     )
-    svg += line('<rect width="100%" height="100%" fill="#ffffff"/>')
-    svg += line('<text class="title" x="28" y="40">Protocol alignment prevents collapse</text>')
+    svg += line('<rect width="100%" height="100%" rx="16" fill="#ffffff"/>')
     svg += line(
-        f'<text class="sub" x="28" y="66">schema v{result.schema_version} | '
-        f"{len(result.seeds)} prespecified seeds | budget axis: "
+        f'<rect x=".75" y=".75" width="{width - 1.5}" height="{height - 1.5}" rx="15.25" '
+        'fill="none" stroke="#e2e8f0" stroke-width="1.5"/>'
+    )
+    svg += line('<text class="title" x="36" y="42">Protocol alignment prevents collapse</text>')
+    svg += line(
+        f'<text class="sub" x="36" y="68">schema v{result.schema_version}  ·  '
+        f"{len(result.seeds)} prespecified seeds  ·  budget axis: "
         f"{html.escape(result.budget_axis or 'unreported')}</text>"
     )
-    svg += line(f'<text class="head" x="{success_x}" y="110">Strict held-out success</text>')
-    svg += line(f'<text class="head" x="{time_x}" y="110">Training time (seconds)</text>')
+    panel_y = 91
+    panel_h = height - 148
+    svg += line(
+        f'<rect class="panel" x="282" y="{panel_y}" width="380" height="{panel_h}" rx="12"/>'
+    )
+    svg += line(
+        f'<rect class="panel" x="702" y="{panel_y}" width="380" height="{panel_h}" rx="12"/>'
+    )
+    svg += line(f'<text class="head" x="{success_x}" y="119">Strict held-out success</text>')
+    svg += line(f'<text class="head" x="{time_x}" y="119">Training time</text>')
     for fraction in (0.0, 0.5, 1.0):
         x = success_x + success_w * fraction
-        svg += line(f'<line class="grid" x1="{x:.1f}" y1="124" x2="{x:.1f}" y2="{height - 48}"/>')
+        svg += line(f'<line class="grid" x1="{x:.1f}" y1="139" x2="{x:.1f}" y2="{height - 62}"/>')
         svg += line(
-            f'<text class="axis" x="{x:.1f}" y="144" text-anchor="middle">'
+            f'<text class="axis" x="{x:.1f}" y="153" text-anchor="middle">'
             f"{fraction * 100:.0f}%</text>"
         )
     for fraction in (0.0, 0.5, 1.0):
         x = time_x + time_w * fraction
-        svg += line(f'<line class="grid" x1="{x:.1f}" y1="124" x2="{x:.1f}" y2="{height - 48}"/>')
+        svg += line(f'<line class="grid" x1="{x:.1f}" y1="139" x2="{x:.1f}" y2="{height - 62}"/>')
         svg += line(
-            f'<text class="axis" x="{x:.1f}" y="144" text-anchor="middle">'
-            f"{time_ceiling * fraction:.0f}</text>"
+            f'<text class="axis" x="{x:.1f}" y="153" text-anchor="middle">'
+            f"{time_ceiling * fraction:.0f}s</text>"
         )
 
     for index, row in enumerate(rows):
-        y = 180 + index * 82
+        y = 190 + index * 75
         color = colors.get(row["name"], "#4b5563")
         escaped_name = html.escape(row["name"])
+        display_name = html.escape(labels.get(row["name"], row["name"]))
+        if index:
+            svg += line(f'<line class="separator" x1="36" y1="{y - 38}" x2="1082" y2="{y - 38}"/>')
         svg += line(
             f'<g data-arm="{escaped_name}" '
             f'data-success-mean="{row["success_mean"]:.6f}" '
             f'data-train-seconds-mean="{row["seconds_mean"]:.6f}">'
         )
-        svg += line(f'<text class="label" x="{label_x}" y="{y + 5}">{escaped_name}</text>')
+        svg += line(f'<text class="label" x="{label_x}" y="{y + 5}">{display_name}</text>')
 
-        success_end = success_x + success_w * row["success_mean"]
-        svg += line(
-            f'<rect x="{success_x}" y="{y - 13}" width="{success_end - success_x:.1f}" '
-            f'height="26" rx="3" fill="{color}" opacity="0.78"/>'
-        )
-        for seed_index, value in enumerate(row["success"]):
-            dot_x = success_x + success_w * value
-            dot_y = y - 6 + seed_index * 12
+        if row["success_mean"] == 0.0:
             svg += line(
-                f'<circle class="dot" cx="{dot_x:.1f}" cy="{dot_y}" r="4" stroke="{color}"/>'
+                f'<rect class="pill" x="{success_x + 12}" y="{y - 13}" width="92" '
+                f'height="26" rx="13" stroke="{color}"/>'
             )
-        svg += line(
-            f'<text class="value" x="{success_x + success_w + 12}" y="{y + 5}">'
-            f"{row['success_mean'] * 100:.0f}%</text>"
-        )
+            svg += line(
+                f'<text class="value" x="{success_x + 58}" y="{y + 4}" '
+                f'text-anchor="middle" fill="{color}">COLLAPSED</text>'
+            )
+        else:
+            success_end = success_x + success_w * row["success_mean"]
+            svg += line(
+                f'<rect class="track" x="{success_x}" y="{y - 10}" '
+                f'width="{success_w}" height="20" rx="5"/>'
+            )
+            svg += line(
+                f'<rect x="{success_x}" y="{y - 10}" width="{success_end - success_x:.1f}" '
+                f'height="20" rx="5" fill="{color}" opacity=".84"/>'
+            )
+            for seed_index, value in enumerate(row["success"]):
+                dot_x = success_x + success_w * value
+                dot_y = y - 5 + seed_index * 10
+                svg += line(
+                    f'<circle class="dot" cx="{dot_x:.1f}" cy="{dot_y}" r="3.5" stroke="{color}"/>'
+                )
+            svg += line(
+                f'<text class="value" x="{success_x + success_w + 12}" y="{y + 5}">'
+                f"{row['success_mean'] * 100:.0f}%</text>"
+            )
 
-        time_end = time_x + time_w * row["seconds_mean"] / time_ceiling
-        svg += line(
-            f'<rect x="{time_x}" y="{y - 13}" width="{time_end - time_x:.1f}" '
-            f'height="26" rx="3" fill="{color}" opacity="0.78"/>'
-        )
-        for seed_index, value in enumerate(row["seconds"]):
-            dot_x = time_x + time_w * value / time_ceiling
-            dot_y = y - 6 + seed_index * 12
+        if row["name"] == "cold-start-only":
             svg += line(
-                f'<circle class="dot" cx="{dot_x:.1f}" cy="{dot_y}" r="4" stroke="{color}"/>'
+                f'<rect class="pill" x="{time_x + 12}" y="{y - 13}" width="104" '
+                'height="26" rx="13" stroke="#94a3b8"/>'
             )
-        svg += line(
-            f'<text class="value" x="{time_x + time_w + 12}" y="{y + 5}">'
-            f"{row['seconds_mean']:.0f}s</text>"
-        )
+            svg += line(
+                f'<text class="value" x="{time_x + 64}" y="{y + 4}" '
+                'text-anchor="middle" fill="#64748b">NO TRAINING</text>'
+            )
+        else:
+            time_end = time_x + time_w * row["seconds_mean"] / time_ceiling
+            svg += line(
+                f'<rect class="track" x="{time_x}" y="{y - 10}" '
+                f'width="{time_w}" height="20" rx="5"/>'
+            )
+            svg += line(
+                f'<rect x="{time_x}" y="{y - 10}" width="{time_end - time_x:.1f}" '
+                f'height="20" rx="5" fill="{color}" opacity=".84"/>'
+            )
+            for seed_index, value in enumerate(row["seconds"]):
+                dot_x = time_x + time_w * value / time_ceiling
+                dot_y = y - 5 + seed_index * 10
+                svg += line(
+                    f'<circle class="dot" cx="{dot_x:.1f}" cy="{dot_y}" r="3.5" stroke="{color}"/>'
+                )
+            svg += line(
+                f'<text class="value" x="{time_x + time_w + 12}" y="{y + 5}">'
+                f"{row['seconds_mean']:.0f}s</text>"
+            )
         svg += line("</g>")
 
+    notes = []
+    if collapsed_count:
+        notes.append("Collapsed = 0% strict success in every recorded seed")
+    if cold_start_seconds is not None:
+        notes.append(
+            f"cold start records setup only ({cold_start_seconds:.2f}s), not a training phase"
+        )
     svg += line(
-        f'<text class="axis" x="28" y="{height - 18}">Bars are seed means; hollow '
+        f'<text class="note" x="36" y="{height - 35}">{html.escape("; ".join(notes))}.</text>'
+    )
+    svg += line(
+        f'<text class="note" x="36" y="{height - 17}">Bars are seed means; hollow '
         f"dots are individual seeds {html.escape(str(result.seeds))}. "
         f"Source JSON SHA-256 {source_sha256[:16]}</text>"
     )

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -266,9 +266,24 @@ def test_published_gpu_visualization_matches_its_source_result():
         )
 
     digest = hashlib.sha256(json_path.read_bytes()).hexdigest()
-    visible_text = " ".join(text for text in root.itertext() if text)
+    text_nodes = [text.strip() for text in root.itertext() if text.strip()]
+    visible_text = " ".join(text_nodes)
     assert f"Source JSON SHA-256 {digest[:16]}" in visible_text
+    assert "Collapsed = 0% strict success in every recorded seed" in visible_text
+    cold_text = [text.strip() for text in groups["cold-start-only"].itertext() if text.strip()]
+    assert "NO TRAINING" in cold_text
+    assert "0s" not in cold_text
+    for name in ("opd-raw-teacher", "opd-privileged-context"):
+        arm_text = [text.strip() for text in groups[name].itertext() if text.strip()]
+        assert "COLLAPSED" in arm_text
+        assert "0%" not in arm_text
     assert "\ufffd" not in visible_text
+
+    from miniverl.evaluation.schema import BenchmarkResult
+    from scripts.publish_benchmark_artifacts import render_svg
+
+    result = BenchmarkResult.model_validate(document)
+    assert svg_path.read_text(encoding="utf-8") == render_svg(result, digest)
 
 
 def test_the_committed_json_schema_matches_the_pydantic_model():


### PR DESCRIPTION
## Summary

- redesign the project banner around three readable product pillars: Sample, Align, and Distill
- make the English and Chinese README introductions product-first, with a PyPI quickstart and direct navigation
- move the scientific comparison into a dedicated measured-result section without changing any claims or negative results
- replace repeated zero-length marks in the benchmark SVG with `COLLAPSED` and `NO TRAINING` states
- keep the visualization generated from the frozen result JSON and test exact generator/artifact agreement

## Why

The previous README opened with a dense experiment table and the banner compressed a five-stage pipeline into small text. The benchmark also rendered zero-success arms and the cold-start setup time as repeated zero bars, dots, and labels. This made the first impression harder to scan than the underlying project warranted.

## Validation

- `ruff check .`
- `ruff format --check .`
- `mypy src/miniverl`
- `pytest -q -m "not torch and not gpu and not network" -ra` — 812 passed
- `HF_HUB_OFFLINE=1 pytest -q -m "not gpu and not network" -ra` — 1003 passed
- package build plus `twine check`
- browser-rendered visual QA for both SVGs
- frozen benchmark JSON SHA-256 unchanged: `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`
