### PR TITLE
Align quickstart with verified protocol teacher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to miniVERL are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses
 [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- The default consumer-GPU recipe now uses the pinned, competence-gated
+  protocol-teacher adapter; the previous raw-teacher payload is preserved
+  byte-for-byte as an explicitly labeled diagnostic-control recipe.
+- The primary benchmark figure leads with the supported OPD/SFT comparison and
+  separates protocol-incompatible controls instead of labeling their measured
+  0% strict success as a generic collapse.
+- Installation examples distinguish the torch-free `miniverl` core from the
+  `miniverl[train]` extra required for local optimization.
+
 ## [0.2.0] - 2026-07-28
 
 Protocol-aligned teacher support and scientifically explicit benchmark
@@ -159,7 +172,7 @@ one consumer GPU.
 
 ### Measured
 
-- RTX 4080 (16 GB), `recipes/qwen_consumer_gpu_calc.yaml`: 16 optimizer steps in
+- RTX 4080 (16 GB), `recipes/qwen_consumer_gpu_calc_raw_teacher.yaml`: 16 optimizer steps in
   481.1 s; peak 4.251 GiB allocated / 4.762 GiB reserved; held-out greedy task
   success 0.0% to 100.0% on 12 tasks. The supervised cold start does most of that
   work; see `docs/rtx4080-baselines.md`.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -283,7 +283,8 @@ whitelist), two statements in one call.
 
 ### Real hardware
 
-* **Full recipe**, `recipes/qwen_consumer_gpu_calc.yaml`, run id
+* **Historical raw-teacher recipe**,
+  `recipes/qwen_consumer_gpu_calc_raw_teacher.yaml`, run id
   `rtx4080-calc-opd`: 16 optimizer steps in **481.1 s**; held-out greedy success
   **0.0% -> 100.0%** on 12 tasks. The 8-cycle SFT cold start did most of that:
   the first OPD rollout batch already scored 83.3%.

--- a/README.md
+++ b/README.md
@@ -20,10 +20,15 @@ token provenance explicit, and applies teacher distributional targets only
 where they belong — without Ray, a GPU cluster, or a 40 GB accelerator.
 
 ```bash
-python -m pip install "miniverl[train]"
+python -m pip install miniverl            # lightweight core
 miniverl doctor
+python -m pip install "miniverl[train]"   # add the local training stack
 miniverl demo --output runs/demo        # no network, no GPU, ~50 s on a laptop CPU
 ```
+
+The base install is the torch-free core (`doctor`, `validate`, `inspect`,
+`report`, schemas and the Python API). The `train` extra adds torch,
+Transformers and PEFT because `demo` performs real optimization.
 
 **What it makes inspectable**
 
@@ -36,7 +41,7 @@ miniverl demo --output runs/demo        # no network, no GPU, ~50 s on a laptop 
 
 [Run the local demo](#local-toy-demo) ·
 [Train on a consumer GPU](#consumer-gpu-quickstart) ·
-[Inspect the measured result](#measured-result-protocol-alignment-prevents-collapse) ·
+[Inspect the measured result](#measured-result-protocol-aligned-opd-matches-sft) ·
 [Read the math](docs/math.md)
 
 ## Why miniVERL exists
@@ -78,33 +83,41 @@ keeps the whole thing on one 16 GB card.
 | Self-contained offline HTML report with token-level divergence | yes |
 | Ray, FSDP, DeepSpeed, vLLM, VLMs, cross-tokenizer, PPO/GRPO | **no** — see [limitations](docs/limitations.md) |
 
-## Measured result: protocol alignment prevents collapse
+## Measured result: protocol-aligned OPD matches SFT
 
 > [!IMPORTANT]
-> **Protocol alignment prevents the observed OPD collapse, but does not beat
-> supervised fine-tuning here.** The primary schema-v2 comparison uses two
+> **The supported protocol-aligned OPD path reached 100% in both seeds and
+> matched continued SFT.** The primary schema-v2 comparison uses two
 > prespecified seeds, equal optimizer updates, and the saturated `hard`
-> calculator split:
+> calculator split. The protocol-naive rows are diagnostic negative controls,
+> not recommended configurations:
 
-| arm | seed 1234 | seed 20260727 |
-| --- | ---: | ---: |
-| cold start | 75.0% | 75.0% |
-| raw-teacher OPD | 0.0% | 0.0% |
-| privileged-teacher OPD | 0.0% | 0.0% |
-| protocol-teacher OPD | **100.0%** | **100.0%** |
-| continued SFT | **100.0%** | **100.0%** |
+| role | arm | seed 1234 | seed 20260727 |
+| --- | --- | ---: | ---: |
+| starting point | cold start | 75.0% | 75.0% |
+| baseline | continued SFT | **100.0%** | **100.0%** |
+| supported OPD | protocol-aligned teacher | **100.0%** | **100.0%** |
+| diagnostic control | raw teacher without tool-protocol training | 0.0% | 0.0% |
+| diagnostic control | answer-privileged, protocol-naive teacher | 0.0% | 0.0% |
 
 The [public, immutable protocol-teacher adapter](https://huggingface.co/DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher)
-prevents the collapse caused by protocol-naive supervision, but OPD ties SFT
-and takes about 6x as much training time here (523.8 s versus 86.4 s on
-average). The task saturates; two seeds do not support a significance claim,
-and no general OPD advantage is claimed. See the
+is the default in the consumer-GPU recipe. It passed an independently
+prespecified policy-competence gate before this benchmark was inspected. The
+two controls intentionally remove that guarantee: their loss decreased
+normally, but they taught the student an incompatible tool policy. This is a
+measured teacher-competence failure, not a trainer crash.
+
+OPD still only ties SFT and takes about 6x as much training time here
+(523.8 s versus 86.4 s on average). The task saturates; two seeds do not support
+a significance claim, and no general OPD advantage is claimed. See the
 [full result and legacy transcript diagnosis](docs/rtx4080-baselines.md).
 
 ![Two-seed protocol-teacher benchmark](docs/gpu-calc-hard-equal-update-v2.svg)
 
-An older RTX 4080 pipeline smoke run trained **Qwen3-0.6B** from
-**Qwen3-1.7B** in **481 s / 16 optimizer steps**, peaking at **4.25 GiB
+An older RTX 4080 pipeline smoke run used the now-preserved
+[raw-teacher control recipe](recipes/qwen_consumer_gpu_calc_raw_teacher.yaml)
+to train **Qwen3-0.6B** from **Qwen3-1.7B** in **481 s / 16 optimizer steps**,
+peaking at **4.25 GiB
 allocated / 4.76 GiB reserved**, and moved held-out greedy success from
 **0.0% to 100.0%** on 12 tasks. The 8-cycle supervised cold start did most of
 that work: the first OPD rollout batch already scored 83.3%. It demonstrates
@@ -201,7 +214,10 @@ The recipe pins both revisions:
 Their `tokenizer.json` files are byte-identical
 (`sha256 aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4`),
 which is what makes the same-tokenizer contract hold. miniVERL verifies it at
-load time by behavioural fingerprint and refuses to run otherwise.
+load time by behavioural fingerprint and refuses to run otherwise. The recipe
+also pins the [protocol-teacher adapter](https://huggingface.co/DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher)
+at revision `23323751318135484c06c043b1f9b9e7016dd89f` and requires its recorded
+strict policy success to be at least 50% before allocating the teacher.
 
 ## Architecture
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,10 +21,15 @@ miniVERL 是一个紧凑、可审计的训练实验室，让小型语言模型�
 的位置使用教师分布目标——不需要 Ray、GPU 集群或 40 GB 显存的加速卡。
 
 ```bash
-python -m pip install "miniverl[train]"
+python -m pip install miniverl            # 轻量核心层
 miniverl doctor
+python -m pip install "miniverl[train]"   # 添加本地训练依赖
 miniverl demo --output runs/demo        # 无需联网、无需 GPU，笔记本 CPU 上约 50 秒
 ```
+
+基础安装是不含 torch 的核心层（`doctor`、`validate`、`inspect`、`report`、
+schema 与 Python API）。`train` extra 会添加 torch、Transformers 与 PEFT，
+因为 `demo` 会执行真实优化。
 
 **它让三件事可以被检查**
 
@@ -34,7 +39,7 @@ miniverl demo --output runs/demo        # 无需联网、无需 GPU，笔记本 
 
 [运行本地 demo](#本地玩具演示) ·
 [在消费级 GPU 上训练](#消费级-gpu-快速上手) ·
-[查看实测结果](#实测结果协议对齐避免崩溃) ·
+[查看实测结果](#实测结果协议对齐的-opd-追平-sft) ·
 [阅读数学说明](docs/math.md)
 
 ## 为什么需要 miniVERL
@@ -67,31 +72,38 @@ miniVERL 把上面每一条都变成**被代码检查的性质**，而不是注�
 | 完全自包含、可离线打开的 HTML 报告 | 支持 |
 | Ray、FSDP、DeepSpeed、vLLM、VLM、跨词表、PPO/GRPO | **不支持**，见[局限](docs/limitations.md) |
 
-## 实测结果：协议对齐避免崩溃
+## 实测结果：协议对齐的 OPD 追平 SFT
 
 > [!IMPORTANT]
-> **协议对齐避免了已经观察到的 OPD 崩溃，但在这里没有超过监督微调。**
+> **受支持的协议对齐 OPD 在两个种子上都达到 100%，与继续 SFT 持平。**
 > 主要的 schema-v2 对照使用两个预先指定的种子、相同的优化步数，以及已经
-> 饱和的 `hard` 计算器划分：
+> 饱和的 `hard` 计算器划分。两个不懂工具协议的实验臂是诊断性负对照，
+> 不是推荐配置：
 
-| 实验臂 | seed 1234 | seed 20260727 |
-| --- | ---: | ---: |
-| 冷启动 | 75.0% | 75.0% |
-| 原始教师 OPD | 0.0% | 0.0% |
-| 特权上下文教师 OPD | 0.0% | 0.0% |
-| 协议教师 OPD | **100.0%** | **100.0%** |
-| 继续 SFT | **100.0%** | **100.0%** |
+| 角色 | 实验臂 | seed 1234 | seed 20260727 |
+| --- | --- | ---: | ---: |
+| 起点 | 冷启动 | 75.0% | 75.0% |
+| 基线 | 继续 SFT | **100.0%** | **100.0%** |
+| 受支持的 OPD | 协议对齐教师 | **100.0%** | **100.0%** |
+| 诊断对照 | 未经工具协议训练的原始教师 | 0.0% | 0.0% |
+| 诊断对照 | 获知答案但不懂协议的教师 | 0.0% | 0.0% |
 
 [公开且固定版本的协议教师适配器](https://huggingface.co/DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher)
-避免了协议不匹配监督造成的崩溃，但 OPD 只追平 SFT，而且这里的平均训练时间
-约为 SFT 的 6 倍（523.8 秒对 86.4 秒）。任务已经饱和；两个种子不足以支持
-显著性结论，也不构成 OPD 普遍更优的证据。完整结果和旧实验的逐轨迹诊断见
+现在是消费级 GPU 配方的默认教师。它在下游 benchmark 被查看之前，已经通过
+预先指定、独立评估的策略能力门槛。两个负对照故意去掉了这个保证：loss 正常
+下降，但教师把不兼容的工具策略教给了学生。这是实测的教师能力问题，不是
+trainer 崩溃。
+
+OPD 在这里仍然只是追平 SFT，而且平均训练时间约为 SFT 的 6 倍
+（523.8 秒对 86.4 秒）。任务已经饱和；两个种子不足以支持显著性结论，也不
+构成 OPD 普遍更优的证据。完整结果和旧实验的逐轨迹诊断见
 [`docs/rtx4080-baselines.md`](docs/rtx4080-baselines.md)。
 
 ![双种子协议教师对照](docs/gpu-calc-hard-equal-update-v2.svg)
 
-更早的一次 RTX 4080 流水线 smoke 运行用 **Qwen3-1.7B** 蒸馏
-**Qwen3-0.6B**，耗时 **481 秒 / 16 个优化步**，显存峰值为
+更早的一次 RTX 4080 流水线 smoke 运行使用了现在保留的
+[原始教师对照配方](recipes/qwen_consumer_gpu_calc_raw_teacher.yaml)，用
+**Qwen3-1.7B** 蒸馏 **Qwen3-0.6B**，耗时 **481 秒 / 16 个优化步**，显存峰值为
 **4.25 GiB 已分配 / 4.76 GiB 已保留**，并在 12 个留出任务上把贪心成功率
 从 **0.0% 提升到 100.0%**。其中 8 个 cycle 的监督冷启动完成了大部分工作：
 第一批 OPD rollout 已经达到 83.3%。它证明流水线能端到端运行，而不是证明
@@ -172,6 +184,10 @@ miniverl report   runs/<run-id> --out runs/<run-id>/report.html
 | 教师 | `Qwen/Qwen3-1.7B` | `70d244cc86ccca08cf5af4e1e306ecf908b1ad5e` | Apache-2.0 |
 
 两者的 `tokenizer.json` **逐字节相同**（`sha256 aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4`），这正是"同一分词器"契约成立的依据。miniVERL 在加载时用行为指纹核对，不一致就直接报错退出。
+
+配方还把[协议教师适配器](https://huggingface.co/DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher)
+锁定在 revision `23323751318135484c06c043b1f9b9e7016dd89f`，并在分配教师模型
+之前要求其已记录的严格策略成功率至少达到 50%。
 
 ## 精确 vs. top-k + tail
 

--- a/benchmarks/configs/gpu_calc_hard.yaml
+++ b/benchmarks/configs/gpu_calc_hard.yaml
@@ -27,7 +27,7 @@ description: >-
   fine-tuning and on-policy distillation from raw, privileged-answer and
   protocol-SFT Qwen3-1.7B teachers on the chained calculator split.
 
-base: ../../recipes/qwen_consumer_gpu_calc.yaml
+base: ../../recipes/qwen_consumer_gpu_calc_raw_teacher.yaml
 common_overrides:
   environment: {difficulty: hard, test_tasks: 24}
   train:

--- a/benchmarks/configs/gpu_calc_hard_legacy_v1.yaml
+++ b/benchmarks/configs/gpu_calc_hard_legacy_v1.yaml
@@ -33,7 +33,7 @@ description: >-
   on-policy distillation, on the chained calculator split with Qwen3-0.6B
   distilled from Qwen3-1.7B on one 16 GB consumer GPU.
 
-base: ../../recipes/qwen_consumer_gpu_calc.yaml
+base: ../../recipes/qwen_consumer_gpu_calc_raw_teacher.yaml
 cold_start_cycles: 12
 eval_split: test
 seeds: [1234]

--- a/benchmarks/configs/gpu_calc_hard_local_adapter.yaml
+++ b/benchmarks/configs/gpu_calc_hard_local_adapter.yaml
@@ -28,7 +28,7 @@ description: >-
   fine-tuning and on-policy distillation from raw, privileged-answer and
   protocol-SFT Qwen3-1.7B teachers on the chained calculator split.
 
-base: ../../recipes/qwen_consumer_gpu_calc.yaml
+base: ../../recipes/qwen_consumer_gpu_calc_raw_teacher.yaml
 common_overrides:
   environment: {difficulty: hard, test_tasks: 24}
   train:

--- a/docs/banner.svg
+++ b/docs/banner.svg
@@ -62,9 +62,7 @@
           stroke="#94a3b8" stroke-opacity=".22"/>
     <circle cx="61" cy="223.5" r="3" fill="#67e8f9"/>
     <text x="72" y="228" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
-          font-size="11.5" fill="#dbeafe">pip install "miniverl[train]"</text>
-
-    <line x1="405" y1="28" x2="405" y2="222" stroke="#ffffff" stroke-opacity=".12"/>
+          font-size="11.5" fill="#dbeafe">pip install miniverl</text>
 
     <g>
       <rect x="437" y="28" width="397" height="56" rx="12" fill="url(#card)"

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -314,7 +314,8 @@ miniverl benchmark benchmarks/configs/gpu_calc_hard.yaml \
 ```
 
 `benchmarks/configs/gpu_calc_hard.yaml` is the GPU counterpart: it uses
-`recipes/qwen_consumer_gpu_calc.yaml` as its base, 12 cold-start cycles, the
+`recipes/qwen_consumer_gpu_calc_raw_teacher.yaml` as its historical-control
+base, 12 cold-start cycles, the
 `test` split, `difficulty: hard`, two prespecified seeds, and five arms:
 `cold-start-only`, `sft-continued`, `opd-raw-teacher`,
 `opd-privileged-context` and `opd-protocol-sft-teacher`. The final arm is gated
@@ -560,7 +561,8 @@ them in prose.
 ### Attributing a cold start's gains to the method
 
 This one is not hypothetical. On the one measured 16 GB run of
-`recipes/qwen_consumer_gpu_calc.yaml` (run id `rtx4080-calc-opd`), held-out
+`recipes/qwen_consumer_gpu_calc_raw_teacher.yaml` (run id
+`rtx4080-calc-opd`), held-out
 greedy evaluation on 12 calculator tasks went from 0.0 percent to 100.0 percent
 across 16 optimizer steps in 481.1 s. The 8-cycle SFT cold start did most of
 that work: the first OPD rollout batch already scored 83.3 percent. That run

--- a/docs/design.md
+++ b/docs/design.md
@@ -454,7 +454,8 @@ KD/OPD loop. It is cheap (no generation) and it is what gets the policy emitting
 syntactically valid tool calls at all. It is also the reason a single end-to-end
 number is not evidence that OPD helped.
 
-On the one full 16 GB run of `recipes/qwen_consumer_gpu_calc.yaml` (run id
+On the one full 16 GB run of
+`recipes/qwen_consumer_gpu_calc_raw_teacher.yaml` (run id
 `rtx4080-calc-opd`), 16 optimizer steps took 481.1 s and held-out greedy
 evaluation on 12 calculator tasks went from 0.0 percent to 100.0 percent.
 Attributing that to on-policy distillation would be wrong: the 8-cycle SFT cold

--- a/docs/gpu-calc-hard-equal-update-v2.svg
+++ b/docs/gpu-calc-hard-equal-update-v2.svg
@@ -1,26 +1,26 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="581" viewBox="0 0 1120 581" role="img" aria-labelledby="benchmark-title benchmark-desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="603" viewBox="0 0 1120 603" role="img" aria-labelledby="benchmark-title benchmark-desc">
 <title id="benchmark-title">miniVERL protocol-teacher benchmark</title>
-<desc id="benchmark-desc">Strict held-out success and training time for equal-optimizer-update arms over 2 prespecified seeds. 2 zero-success arms are labeled collapsed. The cold-start baseline is labeled no training.</desc>
-<style>text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,Segoe UI,sans-serif;fill:#172033}.title{font-size:25px;font-weight:750;letter-spacing:-.3px}.sub{font-size:13px;fill:#64748b}.head{font-size:14px;font-weight:700}.label{font-size:14px;font-weight:560}.value{font-size:13px;font-weight:700}.axis{font-size:11.5px;fill:#718096}.note{font-size:11.5px;fill:#64748b}.panel{fill:#f8fafc;stroke:#e2e8f0}.track{fill:#e9eef5}.grid{stroke:#cbd5e1;stroke-width:1}.separator{stroke:#e8edf3;stroke-width:1}.dot{fill:#fff;stroke-width:2}.pill{fill:#fff;stroke-width:1.4}</style>
+<desc id="benchmark-desc">Strict held-out success and training time for equal-optimizer-update arms over 2 prespecified seeds. 2 protocol-incompatible negative controls are shown separately from the supported comparison. The cold-start baseline is labeled no training.</desc>
+<style>text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,Segoe UI,sans-serif;fill:#172033}.title{font-size:25px;font-weight:750;letter-spacing:-.3px}.sub{font-size:13px;fill:#64748b}.head{font-size:14px;font-weight:700}.label{font-size:14px;font-weight:560}.value{font-size:13px;font-weight:700}.axis{font-size:11.5px;fill:#718096}.note{font-size:11.5px;fill:#64748b}.section{font-size:10.5px;font-weight:750;letter-spacing:1.2px;fill:#94a3b8}.panel{fill:#f8fafc;stroke:#e2e8f0}.track{fill:#e9eef5}.grid{stroke:#cbd5e1;stroke-width:1}.separator{stroke:#e8edf3;stroke-width:1}.dot{fill:#fff;stroke-width:2}.pill{fill:#fff;stroke-width:1.4}</style>
 <rect width="100%" height="100%" rx="16" fill="#ffffff"/>
-<rect x=".75" y=".75" width="1118.5" height="579.5" rx="15.25" fill="none" stroke="#e2e8f0" stroke-width="1.5"/>
-<text class="title" x="36" y="42">Protocol alignment prevents collapse</text>
+<rect x=".75" y=".75" width="1118.5" height="601.5" rx="15.25" fill="none" stroke="#e2e8f0" stroke-width="1.5"/>
+<text class="title" x="36" y="42">Protocol-aligned OPD matches continued SFT</text>
 <text class="sub" x="36" y="68">schema v2  ·  2 prespecified seeds  ·  budget axis: optimizer_steps</text>
-<rect class="panel" x="282" y="91" width="380" height="433" rx="12"/>
-<rect class="panel" x="702" y="91" width="380" height="433" rx="12"/>
+<rect class="panel" x="282" y="91" width="380" height="455" rx="12"/>
+<rect class="panel" x="702" y="91" width="380" height="455" rx="12"/>
 <text class="head" x="315" y="119">Strict held-out success</text>
 <text class="head" x="735" y="119">Training time</text>
-<line class="grid" x1="315.0" y1="139" x2="315.0" y2="519"/>
+<line class="grid" x1="315.0" y1="139" x2="315.0" y2="541"/>
 <text class="axis" x="315.0" y="153" text-anchor="middle">0%</text>
-<line class="grid" x1="457.5" y1="139" x2="457.5" y2="519"/>
+<line class="grid" x1="457.5" y1="139" x2="457.5" y2="541"/>
 <text class="axis" x="457.5" y="153" text-anchor="middle">50%</text>
-<line class="grid" x1="600.0" y1="139" x2="600.0" y2="519"/>
+<line class="grid" x1="600.0" y1="139" x2="600.0" y2="541"/>
 <text class="axis" x="600.0" y="153" text-anchor="middle">100%</text>
-<line class="grid" x1="735.0" y1="139" x2="735.0" y2="519"/>
+<line class="grid" x1="735.0" y1="139" x2="735.0" y2="541"/>
 <text class="axis" x="735.0" y="153" text-anchor="middle">0s</text>
-<line class="grid" x1="870.0" y1="139" x2="870.0" y2="519"/>
+<line class="grid" x1="870.0" y1="139" x2="870.0" y2="541"/>
 <text class="axis" x="870.0" y="153" text-anchor="middle">300s</text>
-<line class="grid" x1="1005.0" y1="139" x2="1005.0" y2="519"/>
+<line class="grid" x1="1005.0" y1="139" x2="1005.0" y2="541"/>
 <text class="axis" x="1005.0" y="153" text-anchor="middle">600s</text>
 <g data-arm="cold-start-only" data-success-mean="0.750000" data-train-seconds-mean="0.061326">
 <text class="label" x="36" y="195">Cold start</text>
@@ -47,41 +47,42 @@
 <text class="value" x="1017" y="270">86s</text>
 </g>
 <line class="separator" x1="36" y1="302" x2="1082" y2="302"/>
-<g data-arm="opd-raw-teacher" data-success-mean="0.000000" data-train-seconds-mean="443.953792">
-<text class="label" x="36" y="345">OPD · raw teacher</text>
-<rect class="pill" x="327" y="327" width="92" height="26" rx="13" stroke="#ef4444"/>
-<text class="value" x="373" y="344" text-anchor="middle" fill="#ef4444">COLLAPSED</text>
-<rect class="track" x="735" y="330" width="270" height="20" rx="5"/>
-<rect x="735" y="330" width="199.8" height="20" rx="5" fill="#ef4444" opacity=".84"/>
-<circle class="dot" cx="945.9" cy="335" r="3.5" stroke="#ef4444"/>
-<circle class="dot" cx="923.7" cy="345" r="3.5" stroke="#ef4444"/>
-<text class="value" x="1017" y="345">444s</text>
-</g>
-<line class="separator" x1="36" y1="377" x2="1082" y2="377"/>
-<g data-arm="opd-privileged-context" data-success-mean="0.000000" data-train-seconds-mean="531.523058">
-<text class="label" x="36" y="420">OPD · privileged context</text>
-<rect class="pill" x="327" y="402" width="92" height="26" rx="13" stroke="#f59e0b"/>
-<text class="value" x="373" y="419" text-anchor="middle" fill="#f59e0b">COLLAPSED</text>
-<rect class="track" x="735" y="405" width="270" height="20" rx="5"/>
-<rect x="735" y="405" width="239.2" height="20" rx="5" fill="#f59e0b" opacity=".84"/>
-<circle class="dot" cx="988.5" cy="410" r="3.5" stroke="#f59e0b"/>
-<circle class="dot" cx="959.9" cy="420" r="3.5" stroke="#f59e0b"/>
-<text class="value" x="1017" y="420">532s</text>
-</g>
-<line class="separator" x1="36" y1="452" x2="1082" y2="452"/>
 <g data-arm="opd-protocol-sft-teacher" data-success-mean="1.000000" data-train-seconds-mean="523.820241">
-<text class="label" x="36" y="495">OPD · protocol-aligned teacher</text>
-<rect class="track" x="315" y="480" width="285" height="20" rx="5"/>
-<rect x="315" y="480" width="285.0" height="20" rx="5" fill="#10b981" opacity=".84"/>
-<circle class="dot" cx="600.0" cy="485" r="3.5" stroke="#10b981"/>
-<circle class="dot" cx="600.0" cy="495" r="3.5" stroke="#10b981"/>
-<text class="value" x="612" y="495">100%</text>
-<rect class="track" x="735" y="480" width="270" height="20" rx="5"/>
-<rect x="735" y="480" width="235.7" height="20" rx="5" fill="#10b981" opacity=".84"/>
-<circle class="dot" cx="970.7" cy="485" r="3.5" stroke="#10b981"/>
-<circle class="dot" cx="970.8" cy="495" r="3.5" stroke="#10b981"/>
-<text class="value" x="1017" y="495">524s</text>
+<text class="label" x="36" y="345">OPD · protocol-aligned teacher</text>
+<rect class="track" x="315" y="330" width="285" height="20" rx="5"/>
+<rect x="315" y="330" width="285.0" height="20" rx="5" fill="#10b981" opacity=".84"/>
+<circle class="dot" cx="600.0" cy="335" r="3.5" stroke="#10b981"/>
+<circle class="dot" cx="600.0" cy="345" r="3.5" stroke="#10b981"/>
+<text class="value" x="612" y="345">100%</text>
+<rect class="track" x="735" y="330" width="270" height="20" rx="5"/>
+<rect x="735" y="330" width="235.7" height="20" rx="5" fill="#10b981" opacity=".84"/>
+<circle class="dot" cx="970.7" cy="335" r="3.5" stroke="#10b981"/>
+<circle class="dot" cx="970.8" cy="345" r="3.5" stroke="#10b981"/>
+<text class="value" x="1017" y="345">524s</text>
 </g>
-<text class="note" x="36" y="546">Collapsed = 0% strict success in every recorded seed; cold start records setup only (0.06s), not a training phase.</text>
-<text class="note" x="36" y="564">Bars are seed means; hollow dots are individual seeds [1234, 20260727]. Source JSON SHA-256 53fc1d4d5b7adee0</text>
+<line class="separator" x1="36" y1="385" x2="1082" y2="385"/>
+<text class="section" x="36" y="403">DIAGNOSTIC CONTROLS · INTENTIONALLY PROTOCOL-INCOMPATIBLE TEACHERS</text>
+<g data-arm="opd-raw-teacher" data-success-mean="0.000000" data-train-seconds-mean="443.953792">
+<text class="label" x="36" y="442">Raw teacher (control)</text>
+<rect class="pill" x="327" y="424" width="154" height="26" rx="13" stroke="#ef4444"/>
+<text class="value" x="404.0" y="441" text-anchor="middle" fill="#ef4444">PROTOCOL MISMATCH</text>
+<rect class="track" x="735" y="427" width="270" height="20" rx="5"/>
+<rect x="735" y="427" width="199.8" height="20" rx="5" fill="#ef4444" opacity=".84"/>
+<circle class="dot" cx="945.9" cy="432" r="3.5" stroke="#ef4444"/>
+<circle class="dot" cx="923.7" cy="442" r="3.5" stroke="#ef4444"/>
+<text class="value" x="1017" y="442">444s</text>
+</g>
+<line class="separator" x1="36" y1="474" x2="1082" y2="474"/>
+<g data-arm="opd-privileged-context" data-success-mean="0.000000" data-train-seconds-mean="531.523058">
+<text class="label" x="36" y="517">Privileged context (control)</text>
+<rect class="pill" x="327" y="499" width="154" height="26" rx="13" stroke="#f59e0b"/>
+<text class="value" x="404.0" y="516" text-anchor="middle" fill="#f59e0b">PROTOCOL MISMATCH</text>
+<rect class="track" x="735" y="502" width="270" height="20" rx="5"/>
+<rect x="735" y="502" width="239.2" height="20" rx="5" fill="#f59e0b" opacity=".84"/>
+<circle class="dot" cx="988.5" cy="507" r="3.5" stroke="#f59e0b"/>
+<circle class="dot" cx="959.9" cy="517" r="3.5" stroke="#f59e0b"/>
+<text class="value" x="1017" y="517">532s</text>
+</g>
+<text class="note" x="36" y="568">Diagnostic controls intentionally use protocol-incompatible teachers; strict success was 0% in every seed; cold start records setup only (0.06s), not a training phase.</text>
+<text class="note" x="36" y="586">Bars are seed means; hollow dots are individual seeds [1234, 20260727]. Source JSON SHA-256 53fc1d4d5b7adee0</text>
 </svg>

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -210,7 +210,8 @@ results.
 
 ### The 16 GB run demonstrates the pipeline, not an OPD-over-SFT win
 
-`recipes/qwen_consumer_gpu_calc.yaml` (run id `rtx4080-calc-opd`) completed 16
+`recipes/qwen_consumer_gpu_calc_raw_teacher.yaml` (run id
+`rtx4080-calc-opd`) completed 16
 optimizer steps in 481.1 s, and held-out greedy evaluation on 12 calculator
 tasks went from 0.0% to 100.0%.
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -361,11 +361,13 @@ instead.
 
 ## Measured: one OPD cycle on an RTX 4080
 
-Produced by `scripts/gpu_smoke.py` with its default arguments against
-`recipes/qwen_consumer_gpu_calc.yaml`.
+Produced by `scripts/gpu_smoke.py` with the historical raw-teacher recipe
+`recipes/qwen_consumer_gpu_calc_raw_teacher.yaml`.
 
 ```bash
-python scripts/gpu_smoke.py --output runs/gpu-smoke
+python scripts/gpu_smoke.py \
+  --recipe recipes/qwen_consumer_gpu_calc_raw_teacher.yaml \
+  --output runs/gpu-smoke
 ```
 
 The script overrides the recipe budgets before running: `cycles=1`,

--- a/docs/rtx4080-baselines.md
+++ b/docs/rtx4080-baselines.md
@@ -48,7 +48,9 @@ Measured by `torch.cuda.max_memory_allocated` and `max_memory_reserved`, with
 the counters reset immediately before the phase.
 
 ```bash
-python scripts/gpu_smoke.py --output runs/gpu-smoke
+python scripts/gpu_smoke.py \
+  --recipe recipes/qwen_consumer_gpu_calc_raw_teacher.yaml \
+  --output runs/gpu-smoke
 ```
 
 | quantity | value |
@@ -60,7 +62,8 @@ python scripts/gpu_smoke.py --output runs/gpu-smoke
 | projection chunk size | 256 (unchanged) |
 | OOM retries used | **0** |
 
-Configuration that produced it: `recipes/qwen_consumer_gpu_calc.yaml` with
+Configuration that produced it:
+`recipes/qwen_consumer_gpu_calc_raw_teacher.yaml` with
 `train.cycles: 1`, `rollouts_per_cycle: 2`, `sft_warmup_cycles: 1`,
 `max_new_tokens_per_turn: 48`, `environment.train_tasks: 16`, `eval.tasks: 2`.
 
@@ -115,7 +118,7 @@ every wall-clock number on this page:
 ## The published recipe, end to end
 
 ```bash
-miniverl train recipes/qwen_consumer_gpu_calc.yaml --run-id rtx4080-calc-opd
+miniverl train recipes/qwen_consumer_gpu_calc_raw_teacher.yaml --run-id rtx4080-calc-opd
 ```
 
 | quantity | value |

--- a/recipes/qwen_consumer_gpu_calc.yaml
+++ b/recipes/qwen_consumer_gpu_calc.yaml
@@ -1,5 +1,5 @@
-# miniVERL 16 GB recipe: on-policy distillation of Qwen3-0.6B from Qwen3-1.7B
-# on the calculator environment, on a single consumer GPU.
+# miniVERL supported 16 GB recipe: on-policy distillation of Qwen3-0.6B from a
+# protocol-aligned Qwen3-1.7B teacher on one consumer GPU.
 #
 # Verified facts about this model pair (checked against the Hugging Face API on
 # 2026-07-27, and re-checkable with the commands in docs/reproducibility.md):
@@ -9,27 +9,28 @@
 #   * vocab_size 151936, tokenizer_class Qwen2Tokenizer, tie_word_embeddings true;
 #   * Qwen3 needs transformers >= 4.51.
 #
-# The revisions below are pinned. miniVERL records them in manifest.json, and
-# `miniverl train` will fail loudly rather than silently resolve to a moved main.
+# The model and adapter revisions below are pinned. The teacher adapter passed
+# an independent 100% strict tool-policy evaluation before the downstream OPD
+# result was inspected. miniVERL checks that competence record before loading.
 #
 #   miniverl doctor
 #   miniverl validate recipes/qwen_consumer_gpu_calc.yaml
 #   miniverl train    recipes/qwen_consumer_gpu_calc.yaml --dry-run
 #   miniverl train    recipes/qwen_consumer_gpu_calc.yaml
 #
-# Measured peak VRAM on an RTX 4080 (16 GB) is recorded in
-# docs/rtx4080-baselines.md. Do not trust any number in this comment block that
-# is not also in that file.
+# Measured base-pair memory and the two-seed protocol-teacher comparison are in
+# docs/rtx4080-baselines.md. The historical protocol-naive recipe is preserved
+# separately as qwen_consumer_gpu_calc_raw_teacher.yaml.
 
 schema_version: 1
 
 run:
-  name: qwen3-calc-opd-4080
+  name: qwen3-calc-opd-protocol-4080
   mode: opd
   seed: 1234
   output_dir: runs
   deterministic: true
-  tags: [consumer-gpu, rtx4080, qwen3, calculator]
+  tags: [consumer-gpu, rtx4080, qwen3, calculator, protocol-teacher]
 
 models:
   backend: hf
@@ -61,6 +62,12 @@ models:
     quantization: none
     attn_implementation: sdpa
     mode: standard
+    adapter:
+      source: hub
+      path: DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher
+      revision: 23323751318135484c06c043b1f9b9e7016dd89f
+      require_policy_evaluation: true
+      minimum_strict_success_rate: 0.5
 
 environment:
   name: calculator

--- a/recipes/qwen_consumer_gpu_calc_raw_teacher.yaml
+++ b/recipes/qwen_consumer_gpu_calc_raw_teacher.yaml
@@ -1,0 +1,135 @@
+# Historical negative-control recipe: Qwen3-0.6B distilled from the raw
+# Qwen3-1.7B instruct checkpoint on the calculator environment.
+#
+# The raw teacher has never learned miniVERL's tool-call protocol. It is
+# preserved to reproduce the original RTX 4080 measurements and the diagnosed
+# protocol-mismatch failure; it is NOT the recommended quickstart. Use
+# recipes/qwen_consumer_gpu_calc.yaml for the supported protocol-aligned path.
+#
+# Verified facts about this model pair (checked against the Hugging Face API on
+# 2026-07-27, and re-checkable with the commands in docs/reproducibility.md):
+#   * both repositories are Apache-2.0;
+#   * tokenizer.json is BYTE-IDENTICAL across the pair
+#     (sha256 aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4);
+#   * vocab_size 151936, tokenizer_class Qwen2Tokenizer, tie_word_embeddings true;
+#   * Qwen3 needs transformers >= 4.51.
+#
+#   miniverl validate recipes/qwen_consumer_gpu_calc_raw_teacher.yaml
+#   miniverl train recipes/qwen_consumer_gpu_calc_raw_teacher.yaml --dry-run
+#
+# The measured outcomes and transcript-level diagnosis are recorded in
+# docs/rtx4080-baselines.md.
+
+schema_version: 1
+
+run:
+  name: qwen3-calc-opd-4080
+  mode: opd
+  seed: 1234
+  output_dir: runs
+  deterministic: true
+  tags: [consumer-gpu, rtx4080, qwen3, calculator]
+
+models:
+  backend: hf
+  device: auto
+  student:
+    model_id: Qwen/Qwen3-0.6B
+    revision: c1899de289a04d12100db370d81485cdf75e47ca
+    tokenizer_revision: c1899de289a04d12100db370d81485cdf75e47ca
+    dtype: bfloat16
+    quantization: nf4
+    attn_implementation: sdpa
+    gradient_checkpointing: true
+    lora:
+      enabled: true
+      r: 16
+      alpha: 32
+      dropout: 0.0
+      target_modules: [q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj]
+  teacher:
+    model_id: Qwen/Qwen3-1.7B
+    revision: 70d244cc86ccca08cf5af4e1e306ecf908b1ad5e
+    tokenizer_revision: 70d244cc86ccca08cf5af4e1e306ecf908b1ad5e
+    dtype: bfloat16
+    quantization: none
+    attn_implementation: sdpa
+    mode: standard
+
+environment:
+  name: calculator
+  difficulty: medium
+  params:
+    prompt_style: full
+  train_tasks: 256
+  eval_tasks: 48
+  test_tasks: 48
+  split_seed: 7
+
+rollout:
+  max_turns: 3
+  max_new_tokens_per_turn: 48
+  max_total_tokens: 704
+  temperature: 1.0
+  top_p: 0.95
+  max_parse_errors: 2
+  max_repeated_calls: 2
+
+selection:
+  selector: hybrid
+  ratio: 0.6
+  critical_weight: 1.0
+  other_weight: 1.0
+
+loss:
+  mode: bucketed_topk_tail
+  divergence: reverse_kl
+  temperature: 1.0
+  scale_by_temperature_squared: true
+  top_k: 64
+  tail_epsilon: 1.0e-9
+  chunk_size: 256
+  sampled_token_nll_weight: 0.0
+
+train:
+  cycles: 8
+  rollouts_per_cycle: 6
+  gradient_accumulation_steps: 6
+  opd_freshness: strict
+  learning_rate: 1.0e-4
+  weight_decay: 0.0
+  max_grad_norm: 1.0
+  warmup_steps: 2
+  lr_schedule: cosine
+  optimizer: adamw8bit
+  sft_warmup_cycles: 8
+  save_every_cycles: 4
+  eval_every_cycles: 4
+
+memory:
+  strategy: auto
+  oom_retries: 3
+  min_chunk_size: 16
+  empty_cache_between_phases: true
+  reset_peak_stats_each_cycle: true
+  auto_swap_vram_headroom_gb: 2.0
+
+cache:
+  entries_per_shard: 8
+  strict_policy_version: true
+  reuse_across_policy_versions: false
+  dtype: float16
+  keep_cycles: 2
+  verify_checksums_on_load: true
+
+eval:
+  enabled: true
+  split: eval
+  tasks: 12
+  temperature: 0.0
+  seed: 0
+
+report:
+  enabled: true
+  max_trajectories: 4
+  max_tokens_per_trajectory: 320

--- a/scripts/publish_benchmark_artifacts.py
+++ b/scripts/publish_benchmark_artifacts.py
@@ -93,14 +93,28 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
                 "seconds_mean": sum(seconds) / len(seconds),
             }
         )
-    collapsed_count = sum(row["success_mean"] == 0.0 for row in rows)
+    display_order = {
+        "cold-start-only": 0,
+        "sft-continued": 1,
+        "opd-protocol-sft-teacher": 2,
+        "opd-raw-teacher": 3,
+        "opd-privileged-context": 4,
+    }
+    rows.sort(key=lambda row: display_order.get(row["name"], len(display_order)))
+    diagnostic_names = {"opd-raw-teacher", "opd-privileged-context"}
+    diagnostic_count = sum(row["name"] in diagnostic_names for row in rows)
+    diagnostic_start = next(
+        (index for index, row in enumerate(rows) if row["name"] in diagnostic_names),
+        None,
+    )
     cold_start_seconds = next(
         (row["seconds_mean"] for row in rows if row["name"] == "cold-start-only"),
         None,
     )
 
     width = 1120
-    height = 206 + len(rows) * 75
+    diagnostic_gap = 22 if diagnostic_start is not None else 0
+    height = 206 + len(rows) * 75 + diagnostic_gap
     label_x = 36
     success_x = 315
     success_w = 285
@@ -118,8 +132,8 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
     labels = {
         "cold-start-only": "Cold start",
         "sft-continued": "Continued SFT",
-        "opd-raw-teacher": "OPD · raw teacher",
-        "opd-privileged-context": "OPD · privileged context",
+        "opd-raw-teacher": "Raw teacher (control)",
+        "opd-privileged-context": "Privileged context (control)",
         "opd-protocol-sft-teacher": "OPD · protocol-aligned teacher",
     }
 
@@ -136,8 +150,11 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
         "Strict held-out success and training time for equal-optimizer-update arms "
         f"over {len(result.seeds)} prespecified seeds."
     )
-    if collapsed_count:
-        desc += f" {collapsed_count} zero-success arms are labeled collapsed."
+    if diagnostic_count:
+        desc += (
+            f" {diagnostic_count} protocol-incompatible negative controls are "
+            "shown separately from the supported comparison."
+        )
     if cold_start_seconds is not None:
         desc += " The cold-start baseline is labeled no training."
     svg += line(f'<desc id="benchmark-desc">{desc}</desc>')
@@ -148,6 +165,7 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
         ".sub{font-size:13px;fill:#64748b}.head{font-size:14px;font-weight:700}"
         ".label{font-size:14px;font-weight:560}.value{font-size:13px;font-weight:700}"
         ".axis{font-size:11.5px;fill:#718096}.note{font-size:11.5px;fill:#64748b}"
+        ".section{font-size:10.5px;font-weight:750;letter-spacing:1.2px;fill:#94a3b8}"
         ".panel{fill:#f8fafc;stroke:#e2e8f0}.track{fill:#e9eef5}"
         ".grid{stroke:#cbd5e1;stroke-width:1}.separator{stroke:#e8edf3;stroke-width:1}"
         ".dot{fill:#fff;stroke-width:2}.pill{fill:#fff;stroke-width:1.4}"
@@ -158,7 +176,9 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
         f'<rect x=".75" y=".75" width="{width - 1.5}" height="{height - 1.5}" rx="15.25" '
         'fill="none" stroke="#e2e8f0" stroke-width="1.5"/>'
     )
-    svg += line('<text class="title" x="36" y="42">Protocol alignment prevents collapse</text>')
+    svg += line(
+        '<text class="title" x="36" y="42">Protocol-aligned OPD matches continued SFT</text>'
+    )
     svg += line(
         f'<text class="sub" x="36" y="68">schema v{result.schema_version}  ·  '
         f"{len(result.seeds)} prespecified seeds  ·  budget axis: "
@@ -190,11 +210,18 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
         )
 
     for index, row in enumerate(rows):
-        y = 190 + index * 75
+        is_diagnostic = row["name"] in diagnostic_names
+        y = 190 + index * 75 + (diagnostic_gap if is_diagnostic else 0)
         color = colors.get(row["name"], "#4b5563")
         escaped_name = html.escape(row["name"])
         display_name = html.escape(labels.get(row["name"], row["name"]))
-        if index:
+        if diagnostic_start is not None and index == diagnostic_start:
+            svg += line(f'<line class="separator" x1="36" y1="{y - 52}" x2="1082" y2="{y - 52}"/>')
+            svg += line(
+                f'<text class="section" x="36" y="{y - 34}">DIAGNOSTIC CONTROLS · '
+                "INTENTIONALLY PROTOCOL-INCOMPATIBLE TEACHERS</text>"
+            )
+        elif index:
             svg += line(f'<line class="separator" x1="36" y1="{y - 38}" x2="1082" y2="{y - 38}"/>')
         svg += line(
             f'<g data-arm="{escaped_name}" '
@@ -204,13 +231,15 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
         svg += line(f'<text class="label" x="{label_x}" y="{y + 5}">{display_name}</text>')
 
         if row["success_mean"] == 0.0:
+            status = "PROTOCOL MISMATCH" if is_diagnostic else "NO SOLVES"
+            pill_width = 154 if is_diagnostic else 92
             svg += line(
-                f'<rect class="pill" x="{success_x + 12}" y="{y - 13}" width="92" '
+                f'<rect class="pill" x="{success_x + 12}" y="{y - 13}" width="{pill_width}" '
                 f'height="26" rx="13" stroke="{color}"/>'
             )
             svg += line(
-                f'<text class="value" x="{success_x + 58}" y="{y + 4}" '
-                f'text-anchor="middle" fill="{color}">COLLAPSED</text>'
+                f'<text class="value" x="{success_x + 12 + pill_width / 2:.1f}" y="{y + 4}" '
+                f'text-anchor="middle" fill="{color}">{status}</text>'
             )
         else:
             success_end = success_x + success_w * row["success_mean"]
@@ -265,8 +294,11 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
         svg += line("</g>")
 
     notes = []
-    if collapsed_count:
-        notes.append("Collapsed = 0% strict success in every recorded seed")
+    if diagnostic_count:
+        notes.append(
+            "Diagnostic controls intentionally use protocol-incompatible teachers; "
+            "strict success was 0% in every seed"
+        )
     if cold_start_seconds is not None:
         notes.append(
             f"cold start records setup only ({cold_start_seconds:.2f}s), not a training phase"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -31,6 +31,7 @@ from pydantic import ValidationError
 
 from miniverl.config.models import (
     CONFIG_SCHEMA_VERSION,
+    AdapterSource,
     Divergence,
     LossMode,
     LRSchedule,
@@ -134,6 +135,23 @@ def test_every_run_recipe_validates(path: Path) -> None:
 def test_run_recipe_fields_match_the_yaml_leaf_for_leaf(path: Path) -> None:
     config = RunConfig.from_yaml(path)
     _assert_same_leaves(_read_raw(path), config.model_dump(mode="json"))
+
+
+def test_consumer_gpu_quickstart_uses_competence_gated_protocol_teacher() -> None:
+    supported = RunConfig.from_yaml(RECIPES_DIR / "qwen_consumer_gpu_calc.yaml")
+    raw_control = RunConfig.from_yaml(RECIPES_DIR / "qwen_consumer_gpu_calc_raw_teacher.yaml")
+
+    adapter = supported.models.teacher.adapter
+    assert adapter is not None
+    assert adapter.source is AdapterSource.HUB
+    assert adapter.path == "DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher"
+    assert adapter.revision == "23323751318135484c06c043b1f9b9e7016dd89f"
+    assert adapter.require_policy_evaluation is True
+    assert adapter.minimum_strict_success_rate == pytest.approx(0.5)
+
+    assert supported.models.student.model_id == raw_control.models.student.model_id
+    assert supported.models.teacher.model_id == raw_control.models.teacher.model_id
+    assert raw_control.models.teacher.adapter is None
 
 
 def test_toy_cpu_recipe_is_parsed_into_the_expected_typed_values() -> None:

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -269,14 +269,20 @@ def test_published_gpu_visualization_matches_its_source_result():
     text_nodes = [text.strip() for text in root.itertext() if text.strip()]
     visible_text = " ".join(text_nodes)
     assert f"Source JSON SHA-256 {digest[:16]}" in visible_text
-    assert "Collapsed = 0% strict success in every recorded seed" in visible_text
+    assert "Protocol-aligned OPD matches continued SFT" in visible_text
+    assert "DIAGNOSTIC CONTROLS" in visible_text
+    assert "Diagnostic controls intentionally use protocol-incompatible teachers" in visible_text
     cold_text = [text.strip() for text in groups["cold-start-only"].itertext() if text.strip()]
     assert "NO TRAINING" in cold_text
     assert "0s" not in cold_text
     for name in ("opd-raw-teacher", "opd-privileged-context"):
         arm_text = [text.strip() for text in groups[name].itertext() if text.strip()]
-        assert "COLLAPSED" in arm_text
+        assert "PROTOCOL MISMATCH" in arm_text
         assert "0%" not in arm_text
+    assert "COLLAPSED" not in visible_text
+    assert text_nodes.index("OPD · protocol-aligned teacher") < text_nodes.index(
+        "DIAGNOSTIC CONTROLS · INTENTIONALLY PROTOCOL-INCOMPATIBLE TEACHERS"
+    )
     assert "\ufffd" not in visible_text
 
     from miniverl.evaluation.schema import BenchmarkResult


### PR DESCRIPTION
## What changed

- remove the banner divider that crossed the word “agents” and present the lightweight `pip install miniverl` entry point
- explain the torch-free base install versus the `train` extra in both READMEs
- make the pinned, competence-gated protocol-teacher adapter the default consumer-GPU recipe
- preserve the previous raw-teacher recipe as an explicitly labeled diagnostic control with the same parsed payload
- reorganize the benchmark SVG so the supported OPD/SFT comparison leads and the two protocol-incompatible controls are separated and labeled `PROTOCOL MISMATCH`
- update historical recipe references, the SVG generator, and regression tests

## Why

The repeated 0% rows came from protocol-naive teachers whose losses decreased normally but whose tool policies were incompatible with the student environment. They are useful negative controls, not trainer crashes. The repository was inconsistent because its default GPU quickstart still selected the raw teacher even though the verified protocol-aligned adapter had already reached 100% in both prespecified seeds.

## Validation

- `ruff check .`
- `ruff format --check .`
- `mypy src/miniverl`
- `pytest -q -m "not gpu and not network" -ra --cov=miniverl --cov-report=term-missing --cov-fail-under=80` — 1008 passed, 6 deselected, 87.61% coverage
- targeted config/packaging/schema-v2 tests — 199 passed
- both consumer recipes validate and dry-run
- clean wheel base install on Python 3.10 imports without torch; `doctor` reports core commands available
- wheel/sdist build and `twine check` pass
- published benchmark JSON remains byte-identical at SHA-256 `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`
- regenerated banner and benchmark SVGs parse as XML and were visually inspected
