### PR TITLE
Harden v0.2.1 correctness and lifecycle

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - cuda

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,77 @@ jobs:
           print("no unfinished implementation markers")
           PY
 
+  training-boundaries:
+    name: training ${{ matrix.name }} py${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: minimum
+            python-version: "3.10"
+            torch: "2.3.*"
+            transformers: "4.51.*"
+            peft: "0.12.*"
+            accelerate: "0.33.*"
+            numpy: "1.24.*"
+            bitsandbytes: "0.43.*"
+          - name: latest
+            python-version: "3.13"
+            torch: ""
+            transformers: ""
+            peft: ""
+            accelerate: ""
+            numpy: ""
+            bitsandbytes: ""
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install declared training boundary
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          if [[ "${{ matrix.name }}" == "minimum" ]]; then
+            pip install "torch==${{ matrix.torch }}" --index-url https://download.pytorch.org/whl/cpu
+            pip install \
+              "transformers==${{ matrix.transformers }}" \
+              "peft==${{ matrix.peft }}" \
+              "accelerate==${{ matrix.accelerate }}" \
+              "numpy==${{ matrix.numpy }}" \
+              "bitsandbytes==${{ matrix.bitsandbytes }}"
+            pip install -e ".[dev]"
+          else
+            pip install torch --index-url https://download.pytorch.org/whl/cpu
+            pip install -e ".[dev,train,cuda]"
+          fi
+
+      - name: Report resolved boundary
+        run: |
+          python - <<'PY'
+          import importlib.metadata as md
+          for name in ("torch", "transformers", "peft", "accelerate", "numpy", "bitsandbytes"):
+              print(name, md.version(name))
+          from transformers import Qwen3Config
+          from bitsandbytes.nn import Linear4bit
+          assert Qwen3Config(vocab_size=128).vocab_size == 128
+          assert Linear4bit is not None
+          PY
+
+      - name: No-network toy training smoke
+        env:
+          HF_HUB_OFFLINE: "1"
+          TRANSFORMERS_OFFLINE: "1"
+          MINIVERL_LOG_LEVEL: WARNING
+        run: |
+          pytest -q \
+            tests/integration/test_toy_pipeline.py::test_sft_completes_without_loading_a_teacher \
+            tests/integration/test_manifest_lifecycle.py::test_successful_training_finalizes_manifest_without_changing_startup
+
   transformers-compat:
     name: transformers ${{ matrix.transformers-version }}
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ All notable changes to miniVERL are recorded here. The format follows
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-07-29
+
+Correctness, lifecycle safety and reproducibility release.
+
+### Added
+
+- Exclusive new-run creation, collision-resistant generated IDs, mutually
+  exclusive `--resume`/`--resume-from`/`--overwrite` behavior, and atomic
+  whole-run replacement with rollback.
+- Atomic sibling-directory checkpoints with a manifest written last, SHA-256
+  and size validation, a content digest, model/config/tokenizer identity, and
+  state-based latest-checkpoint selection. Legacy v0.2 checkpoints remain
+  readable and are explicitly labeled `legacy_unchecksummed`.
+- A persisted, checksummed offline-KD dataset containing the exact trajectories,
+  task order, token spans and provenance required for exact resume.
+- Immutable startup manifests and atomic terminal manifests for completed,
+  failed and interrupted runs, including actual optimizer, parameter, rollout,
+  chunk-size, OOM, artifact and checkpoint state.
+- Precise agent-event counters separating emitted and parsed calls, successful
+  executions, execution errors, unknown tools, parse errors, repeated
+  termination and final-answer format/verification outcomes.
+- Versioned structural tokenizer identity, revision-aware tokenizer comparison,
+  LM-head vocabulary compatibility checks and fail-before-mutation trainable
+  weight validation.
+- Explicit `parameter_version`, `rollout_policy_version`,
+  `rollout_iteration` and `global_optimizer_step` records while retaining
+  `policy_version` as a compatibility alias.
+- Benchmark resume support and regression coverage for run collisions,
+  checkpoint corruption, standalone evaluation, exact offline resume, manifest
+  terminal states, OOM transaction boundaries, event metrics, tokenizer
+  identity and model-state loading.
+
 ### Changed
 
 - The default consumer-GPU recipe now uses the pinned, competence-gated
@@ -16,6 +48,40 @@ All notable changes to miniVERL are recorded here. The format follows
   0% strict success as a generic collapse.
 - Installation examples distinguish the torch-free `miniverl` core from the
   `miniverl[train]` extra required for local optimization.
+- OOM recovery now retries only the gradient-computation phase, restoring RNG
+  and clearing partial gradients. The optimizer commit is non-retryable, so a
+  single update cannot execute twice.
+- Historical tool prompt/protocol v1 is frozen byte-for-byte for the published
+  adapter and benchmark; corrected v2 examples are parser-valid and adapter
+  competence gates are protocol-version aware.
+- Per-token loss output now reports the optimized objective, divergence and
+  sampled-token cross-entropy separately; SFT span metrics report CE instead
+  of a meaningless zero divergence.
+- Cache schema v2 preserves exact zero tails and ordered span types, honors
+  checksum configuration, records complete teacher-adapter provenance and
+  rejects lossy dtypes in exact full-vocabulary mode while retaining v1 reads.
+- `ToolEnvironment.reset()` is now the authoritative initial observation and
+  is called once per trajectory. Public trainer examples consistently use
+  context managers.
+- The benchmark figure labels non-training and protocol-mismatch controls
+  directly instead of rendering misleading zero-length training bars.
+
+### Fixed
+
+- New, demo and benchmark runs can no longer append into or silently mix with a
+  non-empty output directory.
+- Standalone evaluation validates a checkpoint before loading and restores only
+  model weights, never optimizer, RNG or teacher state.
+- Missing or shape-incompatible trainable weights fail before any backend
+  parameter is mutated.
+- No-op and failed updates no longer advance the parameter version; replay can
+  perform multiple successful commits while preserving one rollout version.
+- Tool calls are no longer double counted, malformed final markers are not
+  format-valid, verifier failures are not successes, and
+  `max_parse_errors: 0` terminates at the first parse error.
+- Hugging Face offline model loading now resolves a concrete cached snapshot
+  before entering Transformers, preventing version-dependent adapter probes
+  from issuing a network request.
 
 ## [0.2.0] - 2026-07-28
 
@@ -197,5 +263,7 @@ Same-tokenizer only; one trajectory per forward pass; `swap` unavailable for
 quantized models; only Qwen3 and Qwen2 architectures tested; single-seed GPU
 results. The full list is in `docs/limitations.md`.
 
+[Unreleased]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 title: "miniVERL: On-policy distillation for tool-using agents on one GPU"
 message: "If you use miniVERL in your work, please cite it as below."
 type: software
-version: 0.2.0
-date-released: 2026-07-28
+version: 0.2.1
+date-released: 2026-07-29
 license: Apache-2.0
 repository-code: "https://github.com/DaoyuanLi2816/mini-verl"
 url: "https://github.com/DaoyuanLi2816/mini-verl"
@@ -96,4 +96,4 @@ references:
     url: "https://arxiv.org/abs/2603.07079"
     notes: >-
       Motivates recording per-token teacher entropy. Entropy-aware divergence
-      mixing is a roadmap item and is not implemented in miniVERL v0.2.0.
+      mixing is a roadmap item and is not implemented in miniVERL v0.2.1.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -11,14 +11,14 @@ Last updated: 2026-07-29.
 | item | current state |
 | --- | --- |
 | audited starting commit | public and local `main` both resolved to `5b1c043b188b30b1261e118293f6fe124e2b7acb` after `git fetch --all --prune` on 2026-07-29 |
-| working branch | `v0.2.1-correctness`, created without rewriting `main` or the immutable `v0.2.0` tag |
+| integration source | branch `v0.2.1-correctness` and correctness PR [#11](https://github.com/DaoyuanLi2816/mini-verl/pull/11), created without rewriting `main` or the immutable `v0.2.0` tag; the PR remains the authoritative integration record after its source branch is deleted |
 | version transition | post-v0.2.0 work started at honest `0.2.1.dev0`; the fully gated release candidate is now `0.2.1` in source, changelog and citation metadata |
-| release state | correctness PR [#11](https://github.com/DaoyuanLi2816/mini-verl/pull/11) carries the complete candidate from branch `v0.2.1-correctness`; CI/merge is the remaining pre-publication integration step; no tag, PyPI upload or GitHub Release for `v0.2.1` exists |
+| release state | correctness PR [#11](https://github.com/DaoyuanLi2816/mini-verl/pull/11) carries the complete candidate and records its required checks and merge state; no tag, PyPI upload or GitHub Release for `v0.2.1` exists |
 | publication authorization | absent; the release may be prepared and merged, but must not be tagged or published without explicit authorization |
 | frozen scientific artifact | `benchmarks/results/gpu-calc-hard-equal-update-v2.json` remains required at SHA-256 `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc` |
 | immutable protocol adapter | `DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher@23323751318135484c06c043b1f9b9e7016dd89f`; its original v1 competence record is accepted for v1 without fabricating v0.2.1 metrics, and it was neither overwritten nor retrained |
 | local wheel | `miniverl-0.2.1-py3-none-any.whl`, SHA-256 `78bdeaefc7592caaf1004eb01a2ec2ec3060fc96d5ba7853d9d499de254c080d` |
-| local sdist | `miniverl-0.2.1.tar.gz`, SHA-256 `d6f41cf5c861decdd7e3bdd6bf5fafa9299edb1ef635cfa94bebadb8bcd52acf` |
+| local sdist | `miniverl-0.2.1.tar.gz`, SHA-256 `80f890c1ab8be0ccdf6c5ce293a5c4d7bb6a6f7ab7a57db34090384fcaa7e16c` |
 | exact blocker | publication authorization is absent; after a green merge, stop before creating `v0.2.1` or triggering Trusted Publishing |
 
 ### Correctness changes and evidence
@@ -72,8 +72,9 @@ Last updated: 2026-07-29.
 
 Currently failing commands: **none**.
 
-Next action: wait for every required check on PR #11, merge it, verify `main`,
-and stop before the tag because publication is not authorized.
+Integration record: PR #11 and its required checks are authoritative. Once
+GitHub records a green merge, no further release action is authorized: stop
+before creating `v0.2.1` or triggering Trusted Publishing.
 
 ## v0.2 release-hardening status
 

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -4,7 +4,77 @@ Living build log for **miniVERL** (`mini-verl` / `miniverl` / CLI `miniverl`).
 A checkbox is not evidence: every completed item names the command that was run
 and what it printed.
 
-Last updated: 2026-07-28.
+Last updated: 2026-07-29.
+
+## v0.2.1 correctness release status
+
+| item | current state |
+| --- | --- |
+| audited starting commit | public and local `main` both resolved to `5b1c043b188b30b1261e118293f6fe124e2b7acb` after `git fetch --all --prune` on 2026-07-29 |
+| working branch | `v0.2.1-correctness`, created without rewriting `main` or the immutable `v0.2.0` tag |
+| version transition | post-v0.2.0 work started at honest `0.2.1.dev0`; the fully gated release candidate is now `0.2.1` in source, changelog and citation metadata |
+| release state | local release candidate complete; correctness PR/CI/merge is the remaining pre-publication integration step; no tag, PyPI upload or GitHub Release for `v0.2.1` exists |
+| publication authorization | absent; the release may be prepared and merged, but must not be tagged or published without explicit authorization |
+| frozen scientific artifact | `benchmarks/results/gpu-calc-hard-equal-update-v2.json` remains required at SHA-256 `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc` |
+| immutable protocol adapter | `DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher@23323751318135484c06c043b1f9b9e7016dd89f`; its original v1 competence record is accepted for v1 without fabricating v0.2.1 metrics, and it was neither overwritten nor retrained |
+| local wheel | `miniverl-0.2.1-py3-none-any.whl`, SHA-256 `78bdeaefc7592caaf1004eb01a2ec2ec3060fc96d5ba7853d9d499de254c080d` |
+| local sdist | `miniverl-0.2.1.tar.gz`, SHA-256 `d6f41cf5c861decdd7e3bdd6bf5fafa9299edb1ef635cfa94bebadb8bcd52acf` |
+| exact blocker | publication authorization is absent; after a green merge, stop before creating `v0.2.1` or triggering Trusted Publishing |
+
+### Correctness changes and evidence
+
+| area | defect and implemented invariant | regression evidence |
+| --- | --- | --- |
+| run lifecycle | a new run could silently attach to a non-empty directory; creation is now exclusive, generated IDs include microseconds plus randomness, resume/overwrite are explicit and mutually exclusive, and overwrite uses rollback-safe whole-directory replacement | run creation, collision, concurrency, stale append, demo and benchmark resume tests; final-wheel collision exited 1 with every file hash unchanged, then `--overwrite` produced `status=completed`, eight fresh metric records and no stale standalone-eval file |
+| checkpoints/eval | checkpoint names could be selected lexicographically, writes were not atomic/checksummed, and eval could load fresh or partial weights; complete sibling-temp checkpoints now have a manifest, SHA-256/size/content digest and identity, and selection uses validated `state.global_step` | corruption, missing weights, duplicate-step ambiguity, temp-ignore, stale-final, legacy-v0.2 and fail-before-mutation tests; clean-wheel standalone eval loaded only weights and reported checkpoint/global step 4, parameter version 4 and `checksummed_v1` |
+| offline KD | resume could regenerate the nominally fixed dataset; trajectories, task order, exact spans/tails and provenance are now a first-class checksummed artifact | uninterrupted/resumed parameter, optimizer, task order, cache and dataset digest equality tests |
+| manifests | startup and terminal state could be conflated; immutable `manifest.start.json` and atomic completed/failed/interrupted `manifest.json` records preserve original failures and actual counters/digests | lifecycle, exception-preservation and fault-injection tests |
+| OOM transaction | retry boundaries could repeat stochastic work or an optimizer commit; only gradient computation is retryable with RNG restoration and gradient clearing, while optimizer commit is single-shot | RNG/dropout equivalence, one-commit, optimizer-OOM and non-OOM tests |
+| protocol/adapter | the historical v1 prompt has an ambiguous example, but changing it would invalidate the published adapter; v1 is frozen, v2 examples parse, and competence is protocol-version aware | v1 byte fixture, v2 parse/round-trip and v1/v2 adapter-gate tests; the immutable Hub revision passed the live network test |
+| losses/metrics | SFT span metrics could report zero divergence instead of CE, and tool events were double counted; objective/divergence/CE are distinct and emitted/parsed/executed/error/final events have precise denominators | per-token aggregate equivalence and adversarial agent-event tests |
+| cache/identity | empty tails, ordered span types, checksum flags, adapter identity and tokenizer/model revisions could be ambiguous or lossy; schema v2 fixes each while retaining v1 reads | exact-zero, ordering, checksum, adapter, exact-full-vocab, structural tokenizer, revision and LM-head tests |
+| parameter versions | cycle count was used as a proxy for parameter changes; `parameter_version` advances only after a successful commit and rollout/optimizer counters are separate | no-op, failed update, replay and exact-resume tests |
+| reset/lifecycle API | the runner could ignore `reset()`'s observation and examples could leak trainer resources; reset is authoritative and public examples use context managers | dynamic reset/state-ID/exactly-once and destructive close/context tests |
+
+### Final local gates
+
+- `git diff --check`, `ruff check .`, `ruff format --check .`,
+  `mypy src/miniverl` and actionlint 1.7.12 all pass.
+- `pytest -q -m "not gpu and not network" --cov=miniverl
+  --cov-report=term-missing --cov-fail-under=80`:
+  **1066 passed, 6 deselected, 87.11% branch coverage**.
+- `pytest -q -m gpu` on Torch 2.13.0+cu130 and an NVIDIA GeForce RTX 4080:
+  **5 passed, 1067 deselected**.
+- `pytest -q -m network`: **3 passed, 1069 deselected**, including the pinned
+  public protocol-teacher revision.
+- Minimum boundary, Python 3.10.11 / Torch 2.3.1+cpu / Transformers 4.51.3 /
+  PEFT 0.12.0 / Accelerate 0.33.0 / NumPy 1.24.4 / bitsandbytes 0.43.3:
+  **132 passed** under the offline guard.
+- Current boundary, Python 3.13.13 / Torch 2.13.0+cpu / Transformers 5.14.1 /
+  PEFT 0.20.0 / Accelerate 1.14.0 / NumPy 2.5.1 / bitsandbytes 0.50.0:
+  **132 passed** under the offline guard.
+- Clean build produced exactly one wheel and one sdist; both passed
+  `twine check`. Wheel/sdist content assertions passed.
+- A clean core-wheel environment ran help/version/doctor without installing or
+  importing torch, Transformers, PEFT or bitsandbytes. A separate clean
+  `[train]` environment ran demo, inspect, report, collision, overwrite and
+  weights-only standalone evaluation.
+- Every run recipe validated, every benchmark config resolved, the generated
+  JSON Schema byte-matched the committed file, every benchmark result
+  validated, all tracked JSON/JSONL parsed, 26 Markdown files passed link
+  checking, and no model weights/caches/databases are tracked.
+- The banner and benchmark SVG were rendered at native size and inspected.
+  `docs/gpu-calc-hard-equal-update-v2.svg` remains generated from the frozen
+  JSON and labels the cold start `NO TRAINING` and the diagnostic controls
+  `PROTOCOL MISMATCH` instead of presenting inapplicable zero bars as outcomes.
+- GitHub environment `pypi` exists with a branch policy; `release.yml` still
+  uses OIDC `id-token: write`; public PyPI remains `miniverl 0.2.0`.
+
+Currently failing commands: **none**.
+
+Next action: commit the complete candidate, open the correctness PR, wait for
+every required GitHub check, merge it, verify `main`, and stop before the tag
+because publication is not authorized.
 
 ## v0.2 release-hardening status
 

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -13,7 +13,7 @@ Last updated: 2026-07-29.
 | audited starting commit | public and local `main` both resolved to `5b1c043b188b30b1261e118293f6fe124e2b7acb` after `git fetch --all --prune` on 2026-07-29 |
 | working branch | `v0.2.1-correctness`, created without rewriting `main` or the immutable `v0.2.0` tag |
 | version transition | post-v0.2.0 work started at honest `0.2.1.dev0`; the fully gated release candidate is now `0.2.1` in source, changelog and citation metadata |
-| release state | local release candidate complete; correctness PR/CI/merge is the remaining pre-publication integration step; no tag, PyPI upload or GitHub Release for `v0.2.1` exists |
+| release state | correctness PR [#11](https://github.com/DaoyuanLi2816/mini-verl/pull/11) carries the complete candidate from branch `v0.2.1-correctness`; CI/merge is the remaining pre-publication integration step; no tag, PyPI upload or GitHub Release for `v0.2.1` exists |
 | publication authorization | absent; the release may be prepared and merged, but must not be tagged or published without explicit authorization |
 | frozen scientific artifact | `benchmarks/results/gpu-calc-hard-equal-update-v2.json` remains required at SHA-256 `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc` |
 | immutable protocol adapter | `DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher@23323751318135484c06c043b1f9b9e7016dd89f`; its original v1 competence record is accepted for v1 without fabricating v0.2.1 metrics, and it was neither overwritten nor retrained |
@@ -72,9 +72,8 @@ Last updated: 2026-07-29.
 
 Currently failing commands: **none**.
 
-Next action: commit the complete candidate, open the correctness PR, wait for
-every required GitHub check, merge it, verify `main`, and stop before the tag
-because publication is not authorized.
+Next action: wait for every required check on PR #11, merge it, verify `main`,
+and stop before the tag because publication is not authorized.
 
 ## v0.2 release-hardening status
 

--- a/README.md
+++ b/README.md
@@ -23,17 +23,21 @@ where they belong — without Ray, a GPU cluster, or a 40 GB accelerator.
 python -m pip install miniverl            # lightweight core
 miniverl doctor
 python -m pip install "miniverl[train]"   # add the local training stack
-miniverl demo --output runs/demo        # no network, no GPU, ~50 s on a laptop CPU
+miniverl demo --output runs/demo          # no network, no GPU, ~50 s on a laptop CPU
 ```
 
 The base install is the torch-free core (`doctor`, `validate`, `inspect`,
 `report`, schemas and the Python API). The `train` extra adds torch,
 Transformers and PEFT because `demo` performs real optimization.
+This split is intentional: `pip install miniverl` is enough to inspect and
+validate artifacts without downloading a multi-gigabyte ML stack; use
+`pip install "miniverl[train]"` whenever the goal is training or evaluation.
 
 **What it makes inspectable**
 
-- **Policy truth:** every OPD batch is sampled from the policy version it
-  updates; stale teacher targets are rejected.
+- **Policy truth:** strict OPD takes one update from each freshly sampled
+  parameter version; explicit replay keeps the rollout version visible, and
+  stale teacher targets are rejected.
 - **Token truth:** tool output stays context, while only typed assistant spans
   can enter the loss.
 - **Budget truth:** exact full-vocabulary objectives and compressed
@@ -107,6 +111,12 @@ two controls intentionally remove that guarantee: their loss decreased
 normally, but they taught the student an incompatible tool policy. This is a
 measured teacher-competence failure, not a trainer crash.
 
+The historical teacher-selection gate and the downstream benchmark both used
+the same 24-task v0.2 `test` set. Candidate A was prespecified and passed on the
+first attempt, so no fallback tuning occurred, but the final set was not a
+completely untouched test set. Future teacher selection uses `eval`; downstream
+reporting uses `test`. See [limitations](docs/limitations.md).
+
 OPD still only ties SFT and takes about 6x as much training time here
 (523.8 s versus 86.4 s on average). The task saturates; two seeds do not support
 a significance claim, and no general OPD advantage is claimed. See the
@@ -145,7 +155,8 @@ artifact landed and what to run next:
 demo complete  runs/demo
  mode              opd (genuine on-policy distillation)
  optimizer steps   132
- policy versions   13
+ parameter version 132
+ rollout iterations 13
  wall clock        52.9 s
  token provenance  45597 of 226383 tokens trainable (20%); 180786 are context
                    and can never be a target
@@ -324,6 +335,11 @@ result file. Nothing is estimated or extrapolated.
 | 4-bit | `python -m pip install ".[cuda]"` | bitsandbytes, for NF4 QLoRA and the 8-bit optimizer. |
 | Development | `python -m pip install ".[dev]"` | pytest, hypothesis, ruff, mypy, build, twine. |
 
+The published-package equivalents are `miniverl`, `miniverl[train]`,
+`miniverl[cuda]` and `miniverl[dev]`. Core Python 3.10–3.13 is tested without
+torch. The full CPU ML suite and Transformers 4.51.x/5.x compatibility rows run
+on Python 3.12; GPU paths are opt-in and were measured locally on Python 3.12.
+
 Install the CUDA build of torch that matches your driver separately; the PyPI
 wheel is CPU-only on some platforms:
 
@@ -367,8 +383,8 @@ from miniverl.config import RunConfig
 from miniverl.trainer import OPDTrainer
 
 config = RunConfig.from_yaml("recipes/toy_cpu.yaml")
-trainer = OPDTrainer.from_config(config)
-result = trainer.train()
+with OPDTrainer.from_config(config) as trainer:
+    result = trainer.train()
 
 print(result.run_dir, result.global_step, result.eval["success_rate"])
 ```
@@ -377,6 +393,9 @@ print(result.run_dir, result.global_step, result.eval["success_rate"])
 
 Subclass `ToolEnvironment`, register it, and every recipe key works unchanged.
 `examples/custom_environment/` is a complete, runnable example.
+`reset(task)` is authoritative: it is called exactly once per episode, and its
+`Observation.text` plus `state_id` enter the trajectory. `user_prompt(task)` is
+only a compatibility helper; the runner does not call it a second time.
 
 ```python
 from miniverl.environments import ToolEnvironment, ToolSpec

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,12 +24,15 @@ miniVERL 是一个紧凑、可审计的训练实验室，让小型语言模型�
 python -m pip install miniverl            # 轻量核心层
 miniverl doctor
 python -m pip install "miniverl[train]"   # 添加本地训练依赖
-miniverl demo --output runs/demo        # 无需联网、无需 GPU，笔记本 CPU 上约 50 秒
+miniverl demo --output runs/demo          # 无需联网、无需 GPU，笔记本 CPU 上约 50 秒
 ```
 
 基础安装是不含 torch 的核心层（`doctor`、`validate`、`inspect`、`report`、
 schema 与 Python API）。`train` extra 会添加 torch、Transformers 与 PEFT，
 因为 `demo` 会执行真实优化。
+这种拆分是有意的：`pip install miniverl` 可以在不下载数 GB 机器学习依赖的
+情况下检查和验证产物；要进行训练或评估，请安装
+`pip install "miniverl[train]"`。
 
 **它让三件事可以被检查**
 
@@ -126,7 +129,8 @@ miniverl demo --output runs/demo
 demo complete  runs/demo
  mode              opd (genuine on-policy distillation)
  optimizer steps   132
- policy versions   13
+ parameter version 132
+ rollout iterations 13
  wall clock        52.9 s
  token provenance  45597 of 226383 tokens trainable (20%); 180786 are context
                    and can never be a target
@@ -257,8 +261,8 @@ from miniverl.config import RunConfig
 from miniverl.trainer import OPDTrainer
 
 config = RunConfig.from_yaml("recipes/toy_cpu.yaml")
-trainer = OPDTrainer.from_config(config)
-result = trainer.train()
+with OPDTrainer.from_config(config) as trainer:
+    result = trainer.train()
 
 print(result.run_dir, result.global_step, result.eval["success_rate"])
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -1,61 +1,30 @@
 # TODO
 
-Everything the v0.1.0 scope required is done; see `PROJECT_STATE.md` for the
-evidence table. This file is what is left, split into what is blocked on someone
-with credentials and what is genuinely future work.
+This is the post-v0.2.1 research and engineering backlog. Completed release,
+publication, protocol-teacher and two-seed benchmark work lives in
+`PROJECT_STATE.md` and `CHANGELOG.md`, not in this active list.
 
-## Blocked on credentials or infrastructure
+## Scientific follow-up
 
-These cannot be completed from a commit. Each one names the exact command or
-step, so nothing has to be rediscovered.
+- [ ] Select future protocol-teacher candidates on the `eval` split and reserve
+      `test` for downstream reporting.
+- [ ] Evaluate on a less saturated task family with at least three prespecified
+      seeds; retain SFT, raw-teacher and protocol-aligned controls.
+- [ ] Run JSON-navigation and SQLite real-model comparisons with the same
+      matched-budget and immutable-artifact discipline.
+- [ ] Repeat the measured GPU recipes on Linux; do not treat the expected
+      throughput improvement as measured until those artifacts exist.
 
-- [ ] **Publish to PyPI.** Register a trusted publisher on the PyPI project
-      (`DaoyuanLi2816` / `mini-verl` / `release.yml` / environment `pypi`), then
-      add the `publish` job described in `docs/release-checklist.md`. Re-check
-      that the name `miniverl` is still free first; it was on 2026-07-27
-      (`https://pypi.org/pypi/miniverl/json` returned 404). If taken, publish as
-      `mini-verl-opd` and change only `[project] name`.
-- [ ] **Push the repository and create the `v0.1.0` release.** The tag must be
-      `v0.1.0`; the release workflow will refuse it otherwise.
-- [ ] **Repository settings.** Description:
-      `On-policy distillation for tool-using LLM agents on one consumer GPU.`
-      Topics: `llm`, `on-policy-distillation`, `knowledge-distillation`,
-      `agentic-rl`, `tool-use`, `qlora`, `consumer-gpu`, `post-training`,
-      `qwen`, `llm-agents`, `verl`. Social preview: `docs/banner.svg` rendered
-      to PNG.
-- [ ] **A GPU CI runner.** `.github/workflows/gpu.yml` targets a self-hosted
-      runner labelled `cuda`. Until one is registered the workflow stays queued,
-      which is expected. The same tests were run locally; results are in
-      `docs/rtx4080-baselines.md`.
+## Runtime scope
 
-## Measurement gaps worth closing
+- [ ] Cross-tokenizer distillation with an explicit alignment contract.
+- [ ] Padded multi-trajectory batching; today gradient accumulation supplies
+      the effective batch size.
+- [ ] Additional tested model families beyond Qwen2/Qwen3.
+- [ ] Entropy-aware divergence mixing after a prespecified experiment; current
+      code records teacher entropy but does not implement the method.
+- [ ] A maintained GPU CI runner. GPU tests remain opt-in until real CUDA
+      infrastructure is configured.
 
-Not required for the release, but each would make a claim stronger.
-
-- [ ] **More seeds on GPU.** Every GPU number is single-seed. Three seeds on
-      `benchmarks/configs/gpu_calc_hard.yaml` would turn "measured" into
-      "measured with a variance estimate".
-- [ ] **A Linux measurement.** Decoding on the measured Windows machine is
-      kernel-launch bound (a 14-token prefill costs about the same as a cached
-      one-token step). The same recipe on Linux would very likely be faster, but
-      that is a prediction and is **not measured**; the docs say so.
-- [ ] **A teacher that knows the protocol.** The GPU benchmark shows that
-      distilling toward a raw instruct teacher can reduce task success. An arm
-      that SFTs the teacher first would separate "OPD does not help here" from
-      "this teacher does not help here".
-- [ ] **The JSON-navigation and SQLite recipes on GPU.** Only the calculator
-      environment has been run end to end on real models.
-
-## Roadmap (deliberately not implemented in v0.1.0)
-
-Listed in `docs/limitations.md` too. Nothing below exists in the code.
-
-- [ ] Cross-tokenizer distillation. Currently rejected with an explicit error.
-- [ ] Padded multi-sequence batching. Today one trajectory per forward pass, so
-      `gradient_accumulation_steps` is the batch size.
-- [ ] Entropy-aware divergence mixing (arXiv:2603.07079). miniVERL already
-      records per-token teacher entropy, which is the input such a method needs.
-- [ ] More model families. Only Qwen3 and Qwen2 are tested.
-- [ ] More environments. The registry and the example make this the cheapest
-      contribution to accept.
-- [ ] Multi-GPU. Out of scope on purpose; use verl.
+Multi-GPU training, Ray, FSDP, DeepSpeed, vLLM and PPO/GRPO remain intentionally
+out of scope; use verl or another distributed training system for those needs.

--- a/benchmarks/configs/cpu_toy_calc.yaml
+++ b/benchmarks/configs/cpu_toy_calc.yaml
@@ -20,6 +20,7 @@ description: >-
 
 base: ../../recipes/toy_cpu.yaml
 common_overrides:
+  environment: {params: {protocol_version: v1}}
   train: {sft_warmup_cycles: 0, opd_freshness: strict}
 cold_start_overrides:
   environment: {difficulty: easy}

--- a/benchmarks/configs/gpu_calc_hard.yaml
+++ b/benchmarks/configs/gpu_calc_hard.yaml
@@ -29,7 +29,7 @@ description: >-
 
 base: ../../recipes/qwen_consumer_gpu_calc_raw_teacher.yaml
 common_overrides:
-  environment: {difficulty: hard, test_tasks: 24}
+  environment: {difficulty: hard, test_tasks: 24, params: {protocol_version: v1}}
   train:
     sft_warmup_cycles: 0
     learning_rate: 5.0e-5

--- a/benchmarks/configs/gpu_calc_hard_local_adapter.yaml
+++ b/benchmarks/configs/gpu_calc_hard_local_adapter.yaml
@@ -30,7 +30,7 @@ description: >-
 
 base: ../../recipes/qwen_consumer_gpu_calc_raw_teacher.yaml
 common_overrides:
-  environment: {difficulty: hard, test_tasks: 24}
+  environment: {difficulty: hard, test_tasks: 24, params: {protocol_version: v1}}
   train:
     sft_warmup_cycles: 0
     learning_rate: 5.0e-5

--- a/benchmarks/schema/benchmark-result.schema.json
+++ b/benchmarks/schema/benchmark-result.schema.json
@@ -4,6 +4,18 @@
       "additionalProperties": false,
       "description": "Measured outcome for one arm at one seed.\n\nThe compatibility normalizer maps the two renamed v1 fields into their v2\ncumulative names. Properties retain the old Python accessor names without\nserializing duplicate fields into new artifacts.",
       "properties": {
+        "assistant_turns": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assistant Turns"
+        },
         "avg_tool_calls": {
           "title": "Avg Tool Calls",
           "type": "number"
@@ -102,6 +114,18 @@
           "default": null,
           "title": "Divergence"
         },
+        "emitted_tool_calls": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Emitted Tool Calls"
+        },
         "evaluation_seconds": {
           "anyOf": [
             {
@@ -125,6 +149,42 @@
           ],
           "default": null,
           "title": "Final Answer Format Validity Rate"
+        },
+        "final_answers_emitted": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Final Answers Emitted"
+        },
+        "final_answers_format_valid": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Final Answers Format Valid"
+        },
+        "final_answers_verified": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Final Answers Verified"
         },
         "generated_tokens_per_task": {
           "title": "Generated Tokens Per Task",
@@ -219,6 +279,42 @@
           "title": "Optimizer Steps",
           "type": "integer"
         },
+        "parse_errors": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Parse Errors"
+        },
+        "parse_valid_tool_call_rate": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Parse Valid Tool Call Rate"
+        },
+        "parsed_tool_calls": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Parsed Tool Calls"
+        },
         "peak_allocated_bytes": {
           "anyOf": [
             {
@@ -258,6 +354,18 @@
           ],
           "default": null,
           "title": "Protocol Token Accuracy"
+        },
+        "repeated_call_terminations": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Repeated Call Terminations"
         },
         "resolved_config_digest": {
           "anyOf": [
@@ -511,6 +619,54 @@
           "default": null,
           "title": "Tool Call Count"
         },
+        "tool_execution_error_rate": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Execution Error Rate"
+        },
+        "tool_execution_errors": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Execution Errors"
+        },
+        "tool_execution_success_rate": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Execution Success Rate"
+        },
+        "tool_execution_successes": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Execution Successes"
+        },
         "top_k": {
           "anyOf": [
             {
@@ -539,6 +695,18 @@
           ],
           "default": null,
           "title": "Train Seconds"
+        },
+        "unknown_tool_calls": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Unknown Tool Calls"
         },
         "valid_tool_call_rate": {
           "anyOf": [

--- a/docs/adr/0008-no-pickle-anywhere.md
+++ b/docs/adr/0008-no-pickle-anywhere.md
@@ -28,11 +28,13 @@ fingerprint, vocabulary size, `top_k`, temperature, loss mode, dtype) and one
 `"{trajectory_id}|{field}"`. Every entry also carries its own sha256 over the
 six tensor fields, recomputed and compared on read.
 
-**Checkpoints** (`src/miniverl/training/checkpoint.py`): three files per
-directory -- `adapter.safetensors` (trainable weights only),
-`optimizer.safetensors` (optimizer moment tensors) and `state.json`. The
-optimizer state dict is split by `_split_optimizer_state` into tensors, param
-groups and scalars precisely so that no opaque blob has to be pickled.
+**Checkpoints** (`src/miniverl/training/checkpoint.py`):
+`adapter.safetensors` (trainable weights only), optional
+`optimizer.safetensors` (optimizer moment tensors), `state.json`, and a
+`checkpoint.json` completion/integrity manifest written last. The optimizer
+state dict is split by `_split_optimizer_state` into tensors, param groups and
+scalars precisely so that no opaque blob has to be pickled. New checkpoints
+record byte sizes and SHA-256 checksums for every payload file.
 
 **Trajectories** (`src/miniverl/trajectory/io.py`): one JSON object per line,
 schema-version-checked and pydantic-validated on both write and read.
@@ -47,11 +49,11 @@ safetensors header is an 8-byte little-endian length followed by that many
 bytes of UTF-8 JSON, so `read_safetensors_header` parses it with the standard
 library alone -- no torch, no numpy, no safetensors package. That is what lets
 `miniverl cache stats` and `miniverl cache validate` inspect and checksum a
-cache from a bare `pip install miniverl`. And because `-inf` in a float16 shard
-is awkward for downstream consumers, `_finite_tail` stores an exactly-empty
-tail as `-1.0e4`; the loss floors the tail anyway, so the substitution is
-invisible, and `tests/unit/test_cache.py::test_exact_zero_tail_survives_storage`
-pins it.
+cache from a bare `pip install miniverl`. Exactly empty probability tails are
+stored as `-inf` and round-trip as exact zeros; exact full-vocabulary mode
+rejects float16 cache storage so no lossy representation can be called exact.
+`tests/unit/test_cache.py::test_exact_zero_tail_survives_storage` pins the
+empty-tail behavior.
 
 ## Consequences
 

--- a/docs/banner.svg
+++ b/docs/banner.svg
@@ -62,7 +62,7 @@
           stroke="#94a3b8" stroke-opacity=".22"/>
     <circle cx="61" cy="223.5" r="3" fill="#67e8f9"/>
     <text x="72" y="228" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
-          font-size="11.5" fill="#dbeafe">pip install miniverl</text>
+          font-size="11.5" fill="#dbeafe">pip install "miniverl[train]"</text>
 
     <g>
       <rect x="437" y="28" width="397" height="56" rx="12" fill="url(#card)"

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -28,19 +28,39 @@ These come from `RolloutStats` in `src/miniverl/agent/loop.py`. One
 | `rollouts` | number of trajectories folded in |
 | `solved` | trajectories whose `verification.solved` is true |
 | `success_rate` | `solved / n` |
-| `avg_turns` | `sum(len(trajectory.turns)) / n` |
-| `avg_tool_calls` | turns whose recorded tool call is marked valid, divided by `n` |
-| `invalid_tool_call_rate` | `invalid_tool_calls / max(tool_calls + invalid_tool_calls, 1)` |
+| `assistant_turns` | assistant generations that emitted at least one token |
+| `emitted_tool_calls` | generations containing a `<tool_call>` opening marker |
+| `parsed_tool_calls` | emitted tool-call blocks accepted by the protocol parser |
+| `tool_execution_successes` | parsed calls whose environment step returned `ok=true` |
+| `tool_execution_errors` | parsed calls whose environment step failed or raised |
+| `unknown_tool_calls` | execution errors classified specifically as `unknown_tool` |
+| `parse_errors` | assistant generations that parsed as neither a tool call nor a final answer |
+| `repeated_call_terminations` | episodes stopped by the repeated-identical-call limit |
+| `final_answers_emitted` | generations containing a `<final>` opening marker |
+| `final_answers_format_valid` | final blocks accepted by the parser and not classified malformed by the verifier |
+| `final_answers_verified` | parsed final blocks for which the verifier returned a record |
+| `parse_valid_tool_call_rate` | `parsed_tool_calls / emitted_tool_calls`, or `null` when no tool block was emitted |
+| `tool_execution_success_rate` | successes divided by `successes + errors`, or `null` when no call was executed |
+| `tool_execution_error_rate` | errors divided by `successes + errors`, or `null` when no call was executed |
+| `final_answer_format_validity_rate` | `final_answers_format_valid / final_answers_emitted`, or `null` when no final block was emitted |
+| `avg_turns` | `assistant_turns / n` |
+| `avg_tool_calls` | `parsed_tool_calls / n` |
 | `generated_tokens` | sum of `trajectory.generated_token_count` |
 | `generated_tokens_per_task` | `generated_tokens / n` |
-| `tokens_per_solved_task` | `generated_tokens / solved`, or NaN when `solved == 0` |
+| `tokens_per_solved_task` | `generated_tokens / solved`, or `null` when `solved == 0` |
 | `termination_reasons` | counter over `TerminationReason` |
 | `failure_categories` | counter over `FailureCategory`, plus `no_final_answer` for trajectories with no verification record |
 
-`invalid_tool_calls` counts two things, both incremented in
-`RolloutRunner.rollout`: a turn whose assistant text failed to parse as either
-a tool call or a final answer, and a parsed tool call that the environment
-rejected (`step.ok` false).
+The old `tool_call_count`, `valid_tool_call_rate` and
+`invalid_tool_call_rate` fields remain derived compatibility aliases for
+schema-v1/v2 readers. New artifacts and reports use the precise fields above:
+a parsed call with invalid arguments is one emitted call, one parsed call and
+one execution error; it is never counted twice. A parse error is not an
+execution error.
+
+`rollout.max_parse_errors` is the maximum tolerated count. The episode stops
+as soon as the count reaches that value: `0` stops on the first parse error and
+`2` stops on the second. Tool execution errors do not advance this counter.
 
 `TerminationReason` is one of `final_answer`, `max_turns`, `max_tokens`,
 `parse_error_limit`, `repeated_call_limit`, `environment_error`,
@@ -58,8 +78,10 @@ rejected (`step.ok` false).
 | `tag` | label for this evaluation pass (`baseline`, `final`, `cycleN`, `benchmark-<arm>`, `standalone`) |
 | `split` | `train`, `eval` or `test` |
 | `tasks` | number of tasks evaluated, capped by `eval.tasks` (falling back to `environment.eval_tasks`) |
-| `policy_version` | policy version at evaluation time |
-| `global_step` | optimizer steps completed at evaluation time |
+| `parameter_version` | successful student parameter updates completed at evaluation time |
+| `policy_version` | deprecated alias of `parameter_version` |
+| `global_optimizer_step` / `global_step` | optimizer steps completed at evaluation time |
+| `rollout_policy_version` | parameter version that generated the most recently consumed rollout batch |
 | `temperature` | `eval.temperature`; the shipped recipes use `0.0`, which is exact argmax decoding |
 | `seconds` | wall clock of the evaluation pass |
 | `rollout_tokens_per_second` | `generated_tokens / seconds` |
@@ -142,7 +164,7 @@ comparisons.
 | `teacher_adapter` | validated adapter identity, hashes and policy evaluation, or null |
 | `top_k` | `manifest["objective"]["top_k"]`: the student vocabulary size in `exact_full_vocab` mode, otherwise `min(loss.top_k, vocab_size)` |
 | `optimizer_steps` | `TrainResult.global_step` |
-| `policy_version` | policy version reached |
+| `policy_version` | backward-compatible alias of the final parameter version |
 | `tasks` ... `tokens_per_solved_task` | the held-out evaluation payload above; `tokens_per_solved_task` is stored as `null` when it was NaN |
 | `selected_training_tokens_total`, `model_generated_training_tokens_total`, `teacher_queried_positions_total` | numerators summed over every cycle; SFT teacher-query fields are null |
 | `selected_position_ratio`, `teacher_queried_position_ratio` | ratios of summed numerators and denominators, never an average of cycle ratios |
@@ -311,6 +333,10 @@ miniverl benchmark benchmarks/configs/gpu_calc_hard.yaml --output runs/benchmark
 # Strictly offline after preloading every pinned model, tokenizer and adapter
 miniverl benchmark benchmarks/configs/gpu_calc_hard.yaml \
   --output runs/benchmarks --offline
+
+# Continue a validated partial benchmark; existing arm directories otherwise fail
+miniverl benchmark benchmarks/configs/gpu_calc_hard.yaml \
+  --output runs/benchmarks --resume
 ```
 
 `benchmarks/configs/gpu_calc_hard.yaml` is the GPU counterpart: it uses
@@ -351,6 +377,8 @@ Options, all from `src/miniverl/cli.py`:
   Markdown
 - `--offline` - prohibit all network access and require every model, tokenizer
   and pinned adapter file to exist locally or in the Hugging Face cache
+- `--resume` - intentionally resume validated cold-start/arm checkpoints after
+  a partial run; without it, any arm-directory collision is a hard error
 - `--json` - print the whole result as JSON instead of a table
 
 `miniverl benchmark` requires the training extra

--- a/docs/design.md
+++ b/docs/design.md
@@ -211,15 +211,15 @@ flowchart TD
 
     H5 --> I["_optimize(samples, phase='opd')"]
     I --> I1["run_with_oom_retry(...)"]
-    I1 --> I2["_run_group(group, chunk_size)"]
+    I1 --> I2["_compute_group_gradients(group, chunk_size)"]
     I2 --> I3["student.hidden_states_at(with_grad=True)"]
     I3 --> I4["chunked_selected_position_loss()<br/>provider.divergence per chunk, backward=True"]
-    I4 --> I5["clip_grad_norm_ + schedule.lr_at + optimizer.step()"]
+    I4 --> I5["_commit_update()<br/>clip_grad_norm_ + schedule.lr_at + optimizer.step()"]
     I5 --> I6["metrics_log.write(record)"]
 
     I6 --> J["_write_token_analysis(samples)<br/>last cycle only"]
     J --> K["aggregate_selection_stats + cycle record"]
-    K --> L["policy_version += 1<br/>cache.prune_before()"]
+    K --> L["successful update only<br/>parameter_version += 1"]
     L --> E
 
     E --> M["evaluate(tag='final')<br/>temperature 0.0, held-out split"]
@@ -369,7 +369,9 @@ then `clip_grad_norm_`, `schedule.lr_at(global_step)` written into every
 `param_group["lr"]`, and `optimizer.step()`.
 
 Per-step records go to `metrics.jsonl` with `phase`, `cycle`, `step`,
-`policy_version`, `loss`, `grad_norm`, `lr`, `selected_positions`,
+`global_optimizer_step`, `parameter_version`, the deprecated
+`policy_version` alias, `rollout_policy_version`, `loss`, `divergence_loss`,
+`sampled_token_nll`, `grad_norm`, `lr`, `selected_positions`,
 `trajectories_in_step`, `teacher_entropy_mean`, `loss_by_span_type`, `seconds`,
 `train_selected_tokens_per_second`, `projection_chunk_size` and a
 `gpu.snapshot()` memory block.
@@ -383,11 +385,14 @@ mixing (see [Roadmap](#8-roadmap-not-implemented)).
 
 ### 3.8 Policy version bookkeeping
 
-At the end of an OPD cycle `policy_version += 1`, and
-`cache.prune_before(policy_version - cache.keep_cycles)` deletes entries (and
-whole shards, once empty) from older versions. Because `run.mode: opd` forces
-`cache.strict_policy_version: true`, any attempt to read a target at the wrong
-version raises `StaleCacheError`.
+After each successful optimizer commit, `parameter_version += 1`;
+`policy_version` is its deprecated compatibility alias. A cycle with no selected
+positions and a failed optimizer commit both leave it unchanged. Each trajectory
+and teacher target retain the `rollout_policy_version` that generated them, so
+explicit replay can consume one rollout version in multiple updates without
+relabelling the data. Because `run.mode: opd` forces
+`cache.strict_policy_version: true`, any attempt to read a target under a
+different rollout version raises `StaleCacheError`.
 
 ### 3.9 Memory strategies
 
@@ -427,11 +432,11 @@ knobs to turn.
 
 One class runs all three because they differ only along two axes.
 
-| `run.mode` | trajectories | targets | `policy_version` |
+| `run.mode` | trajectories | targets | parameter-version behavior |
 | --- | --- | --- | --- |
-| `sft` | `oracle_rollout` reference traces | the tokens themselves (cross-entropy) | increments per cycle |
-| `offline_kd` | one fixed trajectory set, reused | one frozen teacher cache | never increments |
-| `opd` | sampled from the *current* student every cycle | teacher scoring those exact states, every cycle | increments per cycle |
+| `sft` | `oracle_rollout` reference traces | the tokens themselves (cross-entropy) | increments after each successful optimizer commit |
+| `offline_kd` | one persisted fixed trajectory set, reused | one frozen teacher cache | increments after each successful optimizer commit; the rollout version stays fixed |
+| `opd` | sampled from the *current* student every rollout iteration | teacher scoring those exact states, every iteration | increments after each successful optimizer commit; strict mode takes one update per rollout version |
 
 The distinction is enforced by config validation, not documentation:
 `offline_kd` is the only mode allowed to set
@@ -505,7 +510,8 @@ the same as a real run's):
   checkpoints/final/
     adapter.safetensors                    trainable weights only
     optimizer.safetensors                  optimizer moment tensors
-    state.json                             step, policy version, scheduler, RNG
+    state.json                             step, parameter/rollout versions, scheduler, RNG
+    checkpoint.json                        completion marker, identity and file checksums
   eval.json                                final summary written by train()
   report.html                              self-contained offline report
   summary.md                               Markdown version of the same data
@@ -533,7 +539,8 @@ re-resolve an `auto` decision differently from the run being evaluated.
 mode, seed, determinism flag, environment description and split sizes, both
 model records (id, revision, quantization, precision, resolved
 `BackendCapabilities`), the tokenizer fingerprint and vocabulary size, the full
-objective block, the memory plan, the policy version, and a
+objective block, the memory plan, global optimizer step, parameter and rollout
+versions, and a
 `measurement_status` block that says `not_run_no_cuda` rather than reporting a
 zero when there is no GPU.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -225,6 +225,16 @@ designed to test that.
 
 ### Protocol alignment prevents collapse but does not beat SFT
 
+The v0.2 tool prompt is now named protocol `v1` and remains byte-stable for
+historical artifacts. Its full and compact prompt examples were ambiguous:
+the final-answer placeholder looked like a literal wrapper even though the
+calculator verifier expects the numeric payload inside `<final>`. Protocol
+`v2` corrects the examples and round-trips them through the parser. Existing
+adapters and recipes stay on explicit `v1`; miniVERL refuses to use a
+competence-gated adapter under a different requested protocol. This versioning
+fix prevents silent reinterpretation, but it does not rewrite the frozen v0.2
+benchmark or adapter.
+
 The primary schema-v2 comparison uses an explicit equal-optimizer-update axis,
 two prespecified seeds and the `hard` split:
 
@@ -242,6 +252,43 @@ seen with both protocol-naive teachers, supporting the legacy transcript
 diagnosis. It still only ties SFT. This repository therefore has evidence that
 teacher protocol competence matters for this setup, but no evidence that OPD
 outperforms verified supervised continuation.
+
+There is an additional selection caveat. Candidate A was prespecified, passed
+the 50% gate on its first run, and therefore triggered no fallback tuning.
+However, the teacher gate used the same 24-task v0.2 `test` set that was later
+used for downstream OPD reporting. The downstream OPD outcome was not consulted
+when selecting the teacher, but the final task set was not completely untouched.
+The historical recipe and grid retain that fact. Future protocol-teacher
+selection must evaluate on `eval`; downstream comparisons must report `test`.
+
+### Teacher preparation is part of the cost
+
+The measured continuation-only protocol-OPD cost is **523.8 s** per student run
+on the RTX 4080 (mean over the two v0.2 seeds). Preparing Candidate A took
+**554.9 s** once. On the same measured wall-time basis:
+
+| accounting view | seconds per student run |
+| --- | ---: |
+| continuation only, reusing the published teacher | 523.8 |
+| teacher preparation + one continuation | 1,078.7 |
+| teacher reused across 5 student runs | 634.8 amortized |
+| teacher reused across 10 student runs | 579.3 amortized |
+
+These figures add measured training times; they exclude download, export and
+human selection time. Teacher preparation is reusable, not free.
+
+### Support claims follow the test matrix
+
+| surface | evidence |
+| --- | --- |
+| torch-free core | Python 3.10, 3.11, 3.12 and 3.13 in CI |
+| full CPU ML suite | Python 3.12 in CI |
+| no-network toy training | oldest/newest training-stack Python rows in CI |
+| Transformers | 4.51.x and supported 5.x rows on Python 3.12 |
+| GPU paths | opt-in workflow plus local RTX 4080 evidence on Python 3.12 |
+
+The core Python matrix is not a claim that every torch/PEFT/bitsandbytes build
+supports every one of those interpreters.
 
 The [schema-v2 result](../benchmarks/results/gpu-calc-hard-equal-update-v2.json)
 contains both seeds and every arm's complete resolved-config diff. The preserved

--- a/docs/protocol-teacher-grid.md
+++ b/docs/protocol-teacher-grid.md
@@ -9,6 +9,12 @@ the deterministic `hard` calculator oracle traces, eight traces per optimizer
 update, greedy evaluation on the same 24 held-out test tasks, and otherwise the
 complete config in `recipes/qwen3_1.7b_protocol_teacher_sft.yaml`.
 
+That `test` choice is retained as historical provenance, not recommended
+methodology. The same 24 tasks were later used in the downstream v0.2
+benchmark, so they were not a completely untouched final test set. Candidate A
+passed on the first prespecified attempt and no fallback tuning occurred.
+Future grids select on `eval` and reserve `test` for downstream reporting.
+
 | candidate | optimizer updates | learning rate | changed from A |
 | --- | ---: | ---: | --- |
 | A (primary) | 24 | `1e-4` | none |
@@ -34,8 +40,9 @@ diff is independently checkable.
 ## Execution record
 
 Candidate A was run once on 2026-07-27 and reached **100.0% strict held-out
-success (24/24)**, 100.0% valid tool-call rate and 100.0% final-answer format
-validity. It therefore passed the 50% gate. Per the rule above, A was exported
+success (24/24)**, 100.0% parse-valid tool-call rate, 100.0% execution success
+and 100.0% final-answer format validity. It therefore passed the 50% gate. Per
+the rule above, A was exported
 and candidates B and C were not run. The downstream OPD result was not consulted
 when making that decision; hashes and the full competence record are in
 [`teacher-adapters.md`](teacher-adapters.md).

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,117 +1,138 @@
 # Release checklist
 
-This is the release gate and publication record for `v0.2.0`. A checked box
-means the command was executed on the v0.2 source or the named invariant was
-inspected. The `release` workflow re-runs the mechanical gates and fails a tag
-if any item before *After the tag* is left unchecked.
+This is the release gate for `v0.2.1`. A checked item names an invariant that
+was exercised on the release-candidate source. The tag workflow repeats the
+mechanical gates and refuses inconsistent metadata or an unchecked pre-tag
+item.
+
+Publication is intentionally separate: `v0.2.1` must not be tagged or uploaded
+until the maintainer explicitly authorizes it.
 
 ## Version consistency
 
-- [x] `src/miniverl/__init__.py` `__version__` is the release version.
-- [x] `CHANGELOG.md` has a `## [<version>]` section with a date.
-- [x] `CITATION.cff` `version:` matches.
-- [x] The git tag will be `v<version>`.
+- [x] `src/miniverl/__init__.py` is `0.2.1`.
+- [x] `CHANGELOG.md` has a dated `## [0.2.1]` section.
+- [x] `CITATION.cff` version and release date match.
+- [x] The future annotated tag is exactly `v0.2.1`.
+- [x] The package/project name remains `miniverl`.
 
-Checked by: `.github/workflows/release.yml`, job `validate-and-test`.
+## Correctness and lifecycle
 
-## Code quality
+- [x] New-run, collision, concurrent creation, overwrite, resume and stale
+      JSONL-append regressions pass.
+- [x] Atomic checkpoint save, state-based selection, checksum corruption,
+      missing weights, identity mismatch, legacy v0.2 reads and weights-only
+      standalone evaluation regressions pass.
+- [x] Exact uninterrupted/resumed OPD and offline-KD tests pass; offline resume
+      reuses the persisted dataset, order and teacher cache.
+- [x] Completed, failed and interrupted manifest tests pass with actual progress
+      and OOM state.
+- [x] RNG-restored gradient OOM retry, dropout equivalence, single optimizer
+      commit, optimizer-OOM and non-OOM propagation tests pass.
+- [x] Protocol v1 byte stability, parser-valid v2 examples, render/parse
+      round-trips and protocol-aware adapter competence gates pass.
+- [x] Per-token objective/CE/divergence accounting and precise emitted,
+      parsed, executed, error and final-answer metric tests pass.
+- [x] Exact-zero tails, ordered span types, checksum policy, adapter identity,
+      full-vocabulary exactness and lossy-dtype rejection tests pass.
+- [x] Structural/revision tokenizer identity, output-vocabulary compatibility,
+      padded vocabulary and fail-before-mutation model-state tests pass.
+- [x] No-op, success, failure, replay and resume parameter-version tests pass.
+- [x] Dynamic reset observation/state provenance and exactly-once reset tests
+      pass.
 
-- [x] `ruff check .`
-- [x] `ruff format --check .`
-- [x] `mypy src/miniverl`
-- [x] `pytest -q -m "not gpu and not network"` with the coverage gate
-      (the exact v0.2 count and coverage are recorded in `PROJECT_STATE.md`)
-- [x] `pytest -q -m gpu` on a machine with CUDA
-- [x] `rg -n "TODO|FIXME|XXX|HACK|NotImplementedError" src tests examples scripts`
-      has no unfinished implementation markers; its sole match is the
-      intentional compatibility catch for older model APIs in
-      `models/adapters.py`.
+## Quality gates
 
-## Packaging
+- [x] `git diff --check`.
+- [x] `ruff check .`.
+- [x] `ruff format --check .`.
+- [x] `mypy src/miniverl`.
+- [x] Full non-GPU/non-network pytest suite passes with branch coverage above
+      the required 80%.
+- [x] All GPU tests pass on an NVIDIA GeForce RTX 4080.
+- [x] All opt-in network tests pass.
+- [x] Transformers 4.51.x and 5.x compatibility tests pass.
+- [x] The declared minimum Python 3.10 training dependency bundle passes the
+      no-network toy/HF contract.
+- [x] The current Python 3.13 training dependency bundle passes the same
+      contract.
+- [x] `actionlint` passes with the repository's `cuda` self-hosted label
+      declared in `.github/actionlint.yaml`.
+- [x] No unfinished implementation markers remain under `src`, `tests`,
+      `examples` or `scripts`.
 
-- [x] `python -m build` produces both an sdist and a wheel.
+## Packaging and clean installs
+
+- [x] A clean `python -m build` produces one `0.2.1` wheel and one sdist.
 - [x] `python -m twine check dist/*` passes.
-- [x] The wheel contains `miniverl/reporting/templates/report.html.j2` and does
-      **not** contain `tests/`.
-- [x] The sdist contains `recipes/`, `tests/`, `LICENSE` and `README.md`.
-- [x] A fresh virtual environment installing only the wheel can run
-      `miniverl --help`, `miniverl --version` and `miniverl doctor --json`, with
-      torch absent.
-- [x] A second fresh environment with `[train]` can run `miniverl demo --fast`
-      end to end.
+- [x] The wheel contains the report template and no tests.
+- [x] The sdist contains recipes, tests, docs, license and both READMEs.
+- [x] A clean core-only wheel install runs `--help`, `--version` and
+      `doctor --json` with torch, Transformers, PEFT and bitsandbytes absent
+      and unimported.
+- [x] A clean install of the same wheel with `[train]` runs demo, inspect,
+      report and weights-only standalone eval.
+- [x] Reusing the demo output without `--overwrite` fails without changing a
+      file; explicit overwrite produces a fresh completed run.
 
-## Documentation
+## Artifacts, documentation and hygiene
 
-- [x] Every command in `README.md` has been executed; placeholder forms were
-      instantiated with the concrete toy/Qwen run, benchmark and adapter paths
-      recorded in `PROJECT_STATE.md`.
-- [x] `README.zh-CN.md` describes the same behaviour as `README.md`.
-- [x] Every number in the README and in `docs/` is measured, or marked
-      "not measured" / "not run".
-- [x] The verl disclaimer is present and accurate.
-- [x] Badges point at workflows that exist. The PyPI badge was added only after
-      the public `0.2.0` publication was independently verified.
-- [x] `docs/limitations.md` is current and does not undersell anything.
+- [x] Every shipped run recipe validates; every benchmark config resolves.
+- [x] The committed benchmark JSON Schema is byte-identical to generated
+      output and all published results validate.
+- [x] The frozen
+      `benchmarks/results/gpu-calc-hard-equal-update-v2.json` SHA-256 remains
+      `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`.
+- [x] The benchmark SVG remains generated from and bound to that exact JSON.
+- [x] All tracked JSON/JSONL parses strictly.
+- [x] README and documentation Markdown links pass link checking.
+- [x] Public artifacts contain no real absolute user path, username, hostname
+      or secret.
+- [x] No model weights, checkpoints, caches or databases are tracked.
+- [x] The banner and benchmark SVG were rendered and visually inspected.
+- [x] The base-vs-`[train]` installation split and v1 scientific confound are
+      stated explicitly.
+- [x] `TODO.md`, `PROJECT_STATE.md`, support claims and dependency boundaries
+      describe the release-candidate implementation.
+- [x] No RecoveryBench or unrelated feature expansion was added.
 
-## Artifacts and hygiene
+## Trusted publishing readiness
 
-- [x] `git status --porcelain` is empty at the release-candidate commit.
-- [x] No model weights, checkpoints, Hugging Face caches, databases, secrets or
-      absolute user paths are committed
-      (`git ls-files | rg "\.(safetensors|bin|pt|ckpt|sqlite|db)$"` is empty).
-- [x] `benchmarks/schema/benchmark-result.schema.json` matches
-      `miniverl schema`.
-- [x] Every file in `benchmarks/results/` validates against that schema.
-
-## Publishing (completed)
-
-The workflow stores no secret or long-lived PyPI token. Its publish, public
-verification and GitHub Release jobs each independently require a `push` event
-whose ref starts with `refs/tags/v`; `workflow_dispatch` validates, tests,
-builds and uploads a workflow artifact but can never publish.
-
-The exact pending publisher was registered with project `miniverl`, owner
-`DaoyuanLi2816`, repository `mini-verl`, workflow `release.yml` and environment
-`pypi`. The tag was pushed only after that account-side registration was
-confirmed.
-
-Tag run
-[`30421231859`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30421231859)
-completed successfully on 2026-07-28 (2026-07-29 UTC):
-
-1. `v0.2.0` resolved to release commit
-   `6092706b4a4e750c4571d7d6a7decbc26af851b2`.
-2. The full quality gate passed and the wheel and sdist were built exactly once.
-3. OIDC Trusted Publishing created
-   [`miniverl 0.2.0`](https://pypi.org/project/miniverl/0.2.0/) without a token.
-4. Public PyPI metadata, file hashes and repository-identity attestations passed,
-   followed by a clean public install and CLI exercise.
-5. Only then did the workflow create
-   [`miniVERL v0.2.0`](https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.2.0)
-   with the verified wheel, sdist and `SHA256SUMS`.
-
-### Published artifact identity
-
-- `miniverl-0.2.0-py3-none-any.whl`:
-  SHA-256 `cf850a6333483a3ee22c0c0e98df1e1b2e6faa184480573e0666658b53a29262`
-- `miniverl-0.2.0.tar.gz`:
-  SHA-256 `3d5107b4f6351204335f800ce924208843f08f54441378bd9f25c3c6fa17456b`
-
-Independent downloads from both PyPI and the GitHub Release reproduced those
-digests. PyPI reports Trusted Publishing and an attestation publisher of
-`release.yml` on `DaoyuanLi2816/mini-verl`.
+- [x] PyPI reports project `miniverl` and current public version `0.2.0`.
+- [x] GitHub environment `pypi` exists and has a deployment branch policy.
+- [x] `release.yml` requests `id-token: write`, uses the `pypi` environment and
+      publishes only on a tag push.
+- [x] The maintainer registered the pending publisher for
+      `DaoyuanLi2816/mini-verl`, workflow `release.yml`, environment `pypi`.
+- [x] The immutable `v0.2.0` tag and public artifacts are unchanged.
 
 ## After the tag
 
-- [x] Set the GitHub repository description to
-      `On-policy distillation for tool-using LLM agents on one consumer GPU.`
-- [x] Set the topics: `llm`, `on-policy-distillation`, `knowledge-distillation`,
-      `agentic-rl`, `tool-use`, `qlora`, `consumer-gpu`, `post-training`, `qwen`,
-      `llm-agents`, `verl`.
-- [ ] Upload `docs/banner.svg` (rendered to PNG) as the social preview image.
-- [x] Create the GitHub release from the verified release distributions and
-      generated notes.
+These actions remain deliberately unchecked until publication is explicitly
+authorized:
 
-The remaining social-preview upload is a repository-settings action. A
-1280×640 PNG was rendered and inspected; the `release` workflow only inspects
-the sections above.
+- [ ] Create annotated tag `v0.2.1` on the exact validated main commit.
+- [ ] Verify the tag workflow tests and builds the distributions once.
+- [ ] Verify OIDC publication, public PyPI hashes and attestations.
+- [ ] Verify the GitHub Release contains the same wheel, sdist and
+      `SHA256SUMS`.
+- [ ] Install public `miniverl==0.2.1` in a clean environment and run
+      `miniverl --version` plus `miniverl doctor --json`.
+- [ ] Open the post-release state-sync PR and bump main to `0.2.2.dev0`.
+
+## Historical v0.2.0 record
+
+Tag workflow
+[`30421231859`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30421231859)
+published `v0.2.0` from commit
+`6092706b4a4e750c4571d7d6a7decbc26af851b2` on 2026-07-28
+(2026-07-29 UTC).
+
+- Wheel SHA-256:
+  `cf850a6333483a3ee22c0c0e98df1e1b2e6faa184480573e0666658b53a29262`
+- Sdist SHA-256:
+  `3d5107b4f6351204335f800ce924208843f08f54441378bd9f25c3c6fa17456b`
+- PyPI:
+  [`miniverl 0.2.0`](https://pypi.org/project/miniverl/0.2.0/)
+- GitHub:
+  [`miniVERL v0.2.0`](https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.2.0)

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -307,27 +307,33 @@ library versions.
 
 ## Exact-resume guarantees
 
-A checkpoint directory holds exactly three files, and
+A new checkpoint directory holds three required files plus an optional
+optimizer tensor file, and
 `tests/integration/test_resume_and_swap.py::test_checkpoint_files_are_pickle_free`
-asserts that list is exact:
+asserts that the tensor/state payloads are pickle-free:
 
 ```
 checkpoints/step-000012/
   adapter.safetensors      # trainable weights only
-  optimizer.safetensors    # optimizer moment tensors
+  optimizer.safetensors    # optimizer moment tensors; absent before any moments exist
   state.json               # everything that is not a tensor
+  checkpoint.json          # written last: identity, sizes, SHA-256 and content digest
 ```
 
 Tensors go through safetensors and structure goes through JSON. `torch.save`
 is never used, so loading a checkpoint cannot execute code. The same test
-asserts neither safetensors file begins with a pickle protocol opcode.
+asserts no safetensors file begins with a pickle protocol opcode. Checkpoints
+are assembled in a sibling temporary directory, fully validated, then swapped
+into place. Readers ignore incomplete temporary directories.
 
 `state.json` carries, measured from a real run:
 
 ```
 config_digest, cycle, global_step, metrics, miniverl_version,
+offline_dataset_digest, parameter_version, resolved_config_digest,
 optimizer_param_groups, optimizer_scalars, optimizer_state_keys,
-policy_version, rng, scaler, scheduler, schema_version, task_cursor
+policy_version, rng, rollout_iteration, rollout_policy_version, scaler,
+scheduler, schema_version, task_cursor
 ```
 
 `rng` contains `python_state`, `torch_state`, `cuda_states` and `numpy_state`.
@@ -342,9 +348,9 @@ CUDA states only when the device count matches.
 `tests/integration/test_resume_and_swap.py::test_uninterrupted_and_resumed_training_agree_exactly`
 runs four cycles in one process, then runs the same schedule with an
 interruption after two cycles, a checkpoint, and a fresh trainer that resumes.
-It asserts the final `global_step`, `policy_version` and `task_cursor` match
-exactly, and that the largest absolute difference over all trainable
-parameters is at most `1e-6`.
+It asserts the final `global_step`, `parameter_version`, `policy_version` alias
+and `task_cursor` match exactly, and that the largest absolute difference over
+all trainable parameters is at most `1e-6`.
 
 That is a numerical tolerance, not bitwise equality. The module docstring of
 `src/miniverl/training/checkpoint.py` says "match bit-for-bit" and names

--- a/docs/teacher-adapters.md
+++ b/docs/teacher-adapters.md
@@ -19,8 +19,9 @@ miniverl train recipes/qwen3_1.7b_protocol_teacher_sft.yaml \
 
 The final held-out evaluation, not SFT loss, is the competence record. It writes
 strict task success as the primary metric and also records diagnostic lenient
-success, valid tool-call rate/count, final-answer format validity and average
-turns. Protocol-token accuracy is `null` for free-running trajectories because
+success, parse-valid tool-call rate, execution success/error rates,
+final-answer format validity and average turns. Protocol-token accuracy is
+`null` for free-running trajectories because
 there is no aligned token target; the measurement status states that explicitly.
 The primary candidate and conditional one-variable fallbacks were fixed before
 training in [`protocol-teacher-grid.md`](protocol-teacher-grid.md).
@@ -29,9 +30,15 @@ training in [`protocol-teacher-grid.md`](protocol-teacher-grid.md).
 
 Candidate A completed 24 optimizer updates on the RTX 4080 and scored **100.0%**
 strict success on all 24 held-out tasks, with 100.0% lenient diagnostic success,
-100.0% valid tool-call rate, 100.0% final-answer format validity, 33 tool calls
-and 2.375 average turns. It passed the prespecified 50% gate, so candidates B
-and C were not run.
+100.0% parse-valid tool-call rate, 100.0% tool-execution success, 100.0%
+final-answer format validity, 33 parsed tool calls and 2.375 average turns. It
+passed the prespecified 50% gate, so candidates B and C were not run.
+
+Historical limitation: this v0.2 gate used the same 24 `test` tasks later used
+for the downstream benchmark. Candidate A passed first and no fallback tuning
+occurred, but the final task set was not completely untouched. Future teacher
+selection uses `eval`, while downstream reporting uses `test`; the historical
+recipe is not rewritten as though that had already happened.
 
 The exported artifact is intentionally not committed to Git. Its public Hub
 copy and reviewable identity are:
@@ -118,3 +125,9 @@ gate against supervising with a clearly broken protocol policy. Passing it does
 not make the teacher “stronger” by definition; the exact teacher metrics are
 carried into run and benchmark provenance and must be compared with the student
 under the same environment.
+
+The immutable v0.2 adapter is a protocol-v1 artifact. Its competence record
+predates the v0.2.1 split between emitted, parsed and executed tool events, so
+those new fields are absent and are not synthesized. That original record is
+accepted only for v1. A v2 competence-gated adapter must include the precise
+event counters and rates as well as an explicit v2 protocol identity.

--- a/docs/trajectory-schema.md
+++ b/docs/trajectory-schema.md
@@ -74,7 +74,7 @@ hard error rather than a silently ignored field.
 | `critical_mask` | `list[bool]` | `True` where the span type is in `CRITICAL_SPAN_TYPES`. Also re-derived and checked. |
 | `spans` | `list[Span]` | The partition. Must be in ascending `start` order and must tile `[0, len(token_ids))` with no gap and no overlap. |
 | `turns` | `list[Turn]` | One entry per assistant action. Defaults to empty. |
-| `policy_version` | `int >= 0` | Which policy produced the rollout. Incremented once per OPD cycle, so it is what makes a stale teacher-cache entry detectable. Default `0`. |
+| `policy_version` | `int >= 0` | Backward-compatible name for the exact `parameter_version` that generated the rollout. It increments only after a successful optimizer step; a no-op or failed update does not advance it. Default `0`. |
 | `tokenizer_fingerprint` | `str` | Behavioural tokenizer hash. Two tokenizers with the same fingerprint tokenize identically. Alignment refuses to proceed when the student and teacher fingerprints differ. |
 | `model_id` | `str` | The model that generated the rollout. |
 | `model_revision` | `str \| None` | Pinned revision, when one was configured. |
@@ -179,7 +179,7 @@ own reason so the failure taxonomy in reports is exact.
 | `final_answer` | The policy emitted a parseable `<final>` block. The only reason that carries a `verification` record. |
 | `max_turns` | The turn budget ran out. This is also the initial value of the loop variable, so it is what a rollout that ends without hitting any other condition reports. |
 | `max_tokens` | `rollout.max_total_tokens` was reached before the next turn could start. |
-| `parse_error_limit` | Parse errors exceeded `rollout.max_parse_errors`. |
+| `parse_error_limit` | Parse-error count reached `rollout.max_parse_errors` (`0` means stop on the first error; `2` means stop on the second). |
 | `repeated_call_limit` | An identical call signature repeated more than `rollout.max_repeated_calls` times. |
 | `environment_error` | Defined in the enum. Not emitted by `RolloutRunner`. |
 | `eos_without_final` | The backend emitted EOS, or produced zero tokens, without a final answer. |

--- a/examples/custom_environment/reverse_environment.py
+++ b/examples/custom_environment/reverse_environment.py
@@ -278,11 +278,8 @@ def main() -> int:
     assert solved == len(splits["train"])
 
     output = Path(sys.argv[1] if len(sys.argv) > 1 else "runs/examples")
-    trainer = OPDTrainer.from_config(build_config(str(output)), run_id="reverse-opd")
-    try:
+    with OPDTrainer.from_config(build_config(str(output)), run_id="reverse-opd") as trainer:
         result = trainer.train()
-    finally:
-        trainer.close()
 
     baseline = (result.baseline_eval or {}).get("success_rate")
     final = (result.eval or {}).get("success_rate")

--- a/examples/custom_teacher/sharpened_teacher.py
+++ b/examples/custom_teacher/sharpened_teacher.py
@@ -209,8 +209,7 @@ def main() -> int:
     from miniverl.trainer import OPDTrainer
 
     output = Path(sys.argv[1] if len(sys.argv) > 1 else "runs/examples")
-    trainer = OPDTrainer.from_config(build_config(str(output)), run_id="sharpened-teacher")
-    try:
+    with OPDTrainer.from_config(build_config(str(output)), run_id="sharpened-teacher") as trainer:
         assert isinstance(trainer.scorer, LocalTeacherScorer)
         baseline_scorer = trainer.scorer
         trainer.scorer = SharpenedTeacherScorer(baseline_scorer, sharpness=2.0)
@@ -222,8 +221,6 @@ def main() -> int:
         )
 
         result = trainer.train()
-    finally:
-        trainer.close()
 
     # The targets really were modified: re-score one stored trajectory both ways
     # and confirm the sharpened distribution is more concentrated.

--- a/recipes/benchmark_calc.yaml
+++ b/recipes/benchmark_calc.yaml
@@ -25,6 +25,7 @@ description: >-
 
 base: toy_cpu.yaml
 common_overrides:
+  environment: {params: {protocol_version: v1}}
   train:
     learning_rate: 5.0e-4
     lr_schedule: constant

--- a/recipes/qwen3_1.7b_protocol_teacher_sft.yaml
+++ b/recipes/qwen3_1.7b_protocol_teacher_sft.yaml
@@ -57,6 +57,7 @@ environment:
   difficulty: hard
   params:
     prompt_style: full
+    protocol_version: v1
   train_tasks: 256
   eval_tasks: 24
   test_tasks: 24

--- a/recipes/qwen_consumer_gpu_calc.yaml
+++ b/recipes/qwen_consumer_gpu_calc.yaml
@@ -74,6 +74,7 @@ environment:
   difficulty: medium
   params:
     prompt_style: full
+    protocol_version: v1
   train_tasks: 256
   eval_tasks: 48
   test_tasks: 48

--- a/recipes/qwen_consumer_gpu_calc_raw_teacher.yaml
+++ b/recipes/qwen_consumer_gpu_calc_raw_teacher.yaml
@@ -61,6 +61,7 @@ environment:
   difficulty: medium
   params:
     prompt_style: full
+    protocol_version: v1
   train_tasks: 256
   eval_tasks: 48
   test_tasks: 48

--- a/recipes/qwen_consumer_gpu_jsonnav.yaml
+++ b/recipes/qwen_consumer_gpu_jsonnav.yaml
@@ -57,6 +57,7 @@ environment:
   difficulty: medium           # requires find -> get, two dependent calls
   params:
     prompt_style: full
+    protocol_version: v1
   train_tasks: 192
   eval_tasks: 32
   test_tasks: 32

--- a/recipes/toy_cpu.yaml
+++ b/recipes/toy_cpu.yaml
@@ -66,6 +66,7 @@ environment:
   difficulty: easy
   params:
     prompt_style: compact   # the toy tokenizer is near-character-level
+    protocol_version: v1    # frozen historical v0.2 prompt
   train_tasks: 256
   eval_tasks: 24
   test_tasks: 24

--- a/recipes/toy_exact_full_vocab.yaml
+++ b/recipes/toy_exact_full_vocab.yaml
@@ -59,6 +59,7 @@ environment:
   difficulty: easy
   params:
     prompt_style: compact
+    protocol_version: v1
   train_tasks: 192
   eval_tasks: 16
   test_tasks: 16

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = ["__version__"]

--- a/src/miniverl/agent/loop.py
+++ b/src/miniverl/agent/loop.py
@@ -29,6 +29,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from miniverl.agent.protocol import (
+    FINAL_OPEN,
+    TOOL_CALL_OPEN,
     ActionKind,
     parse_assistant_text,
     render_final,
@@ -45,6 +47,8 @@ from miniverl.agent.transcript import (
 )
 from miniverl.config.models import RolloutConfig
 from miniverl.environments.base import (
+    FailureCategory,
+    Observation,
     OracleActionKind,
     Task,
     ToolCall,
@@ -72,6 +76,19 @@ class RolloutStats:
     rollouts: int = 0
     solved: int = 0
     turns: int = 0
+    assistant_turns: int = 0
+    emitted_tool_calls: int = 0
+    parsed_tool_calls: int = 0
+    tool_execution_successes: int = 0
+    tool_execution_errors: int = 0
+    unknown_tool_calls: int = 0
+    parse_errors: int = 0
+    repeated_call_terminations: int = 0
+    final_answers_emitted: int = 0
+    final_answers_format_valid: int = 0
+    final_answers_verified: int = 0
+    # Deprecated compatibility aliases. New code and artifacts should use the
+    # event-specific counters above.
     tool_calls: int = 0
     invalid_tool_calls: int = 0
     valid_final_answers: int = 0
@@ -91,15 +108,77 @@ class RolloutStats:
         assert self.failure_categories is not None
         self.rollouts += 1
         self.turns += len(trajectory.turns)
-        self.tool_calls += sum(
-            1 for t in trajectory.turns if t.tool_call is not None and t.tool_call.valid
-        )
+        has_precise_counters = getattr(trajectory, "assistant_turns", None) is not None
+        if has_precise_counters:
+            assistant_turns = int(trajectory.assistant_turns or 0)
+            emitted_tool_calls = int(trajectory.emitted_tool_calls or 0)
+            parsed_tool_calls = int(trajectory.parsed_tool_calls or 0)
+            execution_successes = int(trajectory.tool_execution_successes or 0)
+            execution_errors = int(trajectory.tool_execution_errors or 0)
+            unknown_tool_calls = int(trajectory.unknown_tool_calls or 0)
+            parse_errors = int(trajectory.parse_errors or 0)
+            repeated_terminations = int(trajectory.repeated_call_terminations or 0)
+            final_answers_emitted = int(trajectory.final_answers_emitted or 0)
+            final_answers_format_valid = int(trajectory.final_answers_format_valid or 0)
+            final_answers_verified = int(trajectory.final_answers_verified or 0)
+        else:
+            # Legacy trajectories predate the event counters. Derive the
+            # narrowest backward-compatible interpretation available from their
+            # turn records without claiming unavailable distinctions.
+            assistant_turns = len(trajectory.turns)
+            parsed_turns = [
+                turn
+                for turn in trajectory.turns
+                if turn.tool_call is not None and turn.tool_call.valid
+            ]
+            parse_error_turns = [
+                turn
+                for turn in trajectory.turns
+                if turn.tool_call is not None and not turn.tool_call.valid
+            ]
+            emitted_tool_calls = len(parsed_turns) + len(parse_error_turns)
+            parsed_tool_calls = len(parsed_turns)
+            execution_successes = 0
+            execution_errors = 0
+            for turn in parsed_turns:
+                tool_result = getattr(turn, "tool_result", None)
+                if tool_result is None or tool_result.ok:
+                    execution_successes += 1
+                else:
+                    execution_errors += 1
+            unknown_tool_calls = 0
+            parse_errors = len(parse_error_turns)
+            repeated_terminations = int(
+                trajectory.termination_reason is TerminationReason.REPEATED_CALL_LIMIT
+            )
+            final_answers_emitted = int(
+                trajectory.termination_reason is TerminationReason.FINAL_ANSWER
+            )
+            final_answers_verified = int(trajectory.verification is not None)
+            final_answers_format_valid = int(
+                trajectory.verification is not None
+                and trajectory.verification.failure_category
+                != FailureCategory.MALFORMED_ANSWER.value
+            )
+
+        self.assistant_turns += assistant_turns
+        self.emitted_tool_calls += emitted_tool_calls
+        self.parsed_tool_calls += parsed_tool_calls
+        self.tool_execution_successes += execution_successes
+        self.tool_execution_errors += execution_errors
+        self.unknown_tool_calls += unknown_tool_calls
+        self.parse_errors += parse_errors
+        self.repeated_call_terminations += repeated_terminations
+        self.final_answers_emitted += final_answers_emitted
+        self.final_answers_format_valid += final_answers_format_valid
+        self.final_answers_verified += final_answers_verified
+        self.tool_calls += parsed_tool_calls
         self.invalid_tool_calls += trajectory.invalid_tool_calls
         self.generated_tokens += trajectory.generated_token_count
         reason = trajectory.termination_reason.value
         self.termination_reasons[reason] = self.termination_reasons.get(reason, 0) + 1
         if trajectory.verification is not None:
-            self.valid_final_answers += 1
+            self.valid_final_answers += final_answers_format_valid
             if trajectory.verification.solved:
                 self.solved += 1
             category = trajectory.verification.failure_category or "solved"
@@ -114,20 +193,53 @@ class RolloutStats:
         assert self.termination_reasons is not None
         assert self.failure_categories is not None
         n = max(self.rollouts, 1)
-        tool_call_count = self.tool_calls + self.invalid_tool_calls
+        tool_execution_attempts = self.tool_execution_successes + self.tool_execution_errors
+        parse_valid_tool_call_rate = (
+            self.parsed_tool_calls / self.emitted_tool_calls if self.emitted_tool_calls else None
+        )
+        tool_execution_success_rate = (
+            self.tool_execution_successes / tool_execution_attempts
+            if tool_execution_attempts
+            else None
+        )
+        tool_execution_error_rate = (
+            self.tool_execution_errors / tool_execution_attempts
+            if tool_execution_attempts
+            else None
+        )
         return {
             "rollouts": self.rollouts,
             "solved": self.solved,
             "success_rate": self.solved / n,
             "strict_task_success_rate": self.solved / n,
-            "avg_turns": self.turns / n,
-            "avg_tool_calls": self.tool_calls / n,
-            "tool_call_count": tool_call_count,
-            "valid_tool_call_rate": (
-                self.tool_calls / tool_call_count if tool_call_count else None
+            "assistant_turns": self.assistant_turns,
+            "emitted_tool_calls": self.emitted_tool_calls,
+            "parsed_tool_calls": self.parsed_tool_calls,
+            "tool_execution_successes": self.tool_execution_successes,
+            "tool_execution_errors": self.tool_execution_errors,
+            "unknown_tool_calls": self.unknown_tool_calls,
+            "parse_errors": self.parse_errors,
+            "repeated_call_terminations": self.repeated_call_terminations,
+            "final_answers_emitted": self.final_answers_emitted,
+            "final_answers_format_valid": self.final_answers_format_valid,
+            "final_answers_verified": self.final_answers_verified,
+            "parse_valid_tool_call_rate": parse_valid_tool_call_rate,
+            "tool_execution_success_rate": tool_execution_success_rate,
+            "tool_execution_error_rate": tool_execution_error_rate,
+            "final_answer_format_validity_rate": (
+                self.final_answers_format_valid / self.final_answers_emitted
+                if self.final_answers_emitted
+                else None
             ),
-            "invalid_tool_call_rate": self.invalid_tool_calls / max(tool_call_count, 1),
-            "final_answer_format_validity_rate": self.valid_final_answers / n,
+            "avg_turns": self.assistant_turns / n,
+            "avg_tool_calls": self.parsed_tool_calls / n,
+            # Deprecated aliases retained for backward readers. A "valid" tool
+            # call means parse-valid here; execution success is reported above.
+            "tool_call_count": self.emitted_tool_calls,
+            "valid_tool_call_rate": parse_valid_tool_call_rate,
+            "invalid_tool_call_rate": (
+                self.parse_errors / self.emitted_tool_calls if self.emitted_tool_calls else 0.0
+            ),
             "generated_tokens": self.generated_tokens,
             "generated_tokens_per_task": self.generated_tokens / n,
             # None, not NaN: JSON has no NaN literal, so writing one produces a
@@ -169,7 +281,7 @@ class RolloutRunner:
         """The backend's tokenizer."""
         return self.backend.tokenizer
 
-    def _new_builder(self, task: Task) -> TranscriptBuilder:
+    def _new_builder(self, initial_observation: Observation) -> TranscriptBuilder:
         builder = TranscriptBuilder(self.tokenizer, self.chat_format)
         builder.add_context(
             key="sys",
@@ -184,8 +296,9 @@ class RolloutRunner:
             span_type=SpanType.USER,
             turn_id=0,
             role="user",
-            body=self.environment.user_prompt(task),
+            body=initial_observation.text,
             open_next_assistant=True,
+            env_state_id=initial_observation.state_id,
         )
         return builder
 
@@ -279,11 +392,22 @@ class RolloutRunner:
         turn_budget = max_turns if max_turns is not None else cfg.max_turns
         sample_temperature = cfg.temperature if temperature is None else temperature
 
-        self.environment.reset(task)
-        builder = self._new_builder(task)
+        initial_observation = self.environment.reset(task)
+        builder = self._new_builder(initial_observation)
         turns: list[Turn] = []
         call_counts: Counter[str] = Counter()
         invalid_calls = 0
+        assistant_turns = 0
+        emitted_tool_calls = 0
+        parsed_tool_calls = 0
+        tool_execution_successes = 0
+        tool_execution_errors = 0
+        unknown_tool_calls = 0
+        parse_errors = 0
+        repeated_call_terminations = 0
+        final_answers_emitted = 0
+        final_answers_format_valid = 0
+        final_answers_verified = 0
         generated_tokens = 0
         verification: VerificationRecord | None = None
         metadata_error: str | None = None
@@ -306,8 +430,13 @@ class RolloutRunner:
             if not generation.token_ids:
                 termination = TerminationReason.EOS_WITHOUT_FINAL
                 break
+            assistant_turns += 1
             generated_tokens += len(generation.token_ids)
             parsed = parse_assistant_text(generation.text)
+            if TOOL_CALL_OPEN in generation.text:
+                emitted_tool_calls += 1
+            if FINAL_OPEN in generation.text:
+                final_answers_emitted += 1
 
             if parsed.kind is ActionKind.FINAL:
                 self._add_model_spans(
@@ -335,11 +464,15 @@ class RolloutRunner:
                     failure_category=result.failure_category.value,
                     detail=result.detail,
                 )
+                final_answers_verified += 1
+                if result.failure_category is not FailureCategory.MALFORMED_ANSWER:
+                    final_answers_format_valid += 1
                 turns.append(Turn(turn_id=turn_id, is_final=True))
                 termination = TerminationReason.FINAL_ANSWER
                 break
 
             if parsed.kind is ActionKind.TOOL_CALL:
+                parsed_tool_calls += 1
                 call_id = f"c{turn_id}"
                 name = parsed.tool_name or ""
                 arguments = parsed.arguments or {}
@@ -383,6 +516,7 @@ class RolloutRunner:
                             ),
                         )
                     )
+                    repeated_call_terminations += 1
                     termination = TerminationReason.REPEATED_CALL_LIMIT
                     break
 
@@ -414,11 +548,17 @@ class RolloutRunner:
                             ),
                         )
                     )
+                    tool_execution_errors += 1
                     termination = TerminationReason.ENVIRONMENT_ERROR
                     metadata_error = exc.message
                     break
                 if not step.ok:
                     invalid_calls += 1
+                    tool_execution_errors += 1
+                    if step.failure_category is FailureCategory.UNKNOWN_TOOL:
+                        unknown_tool_calls += 1
+                else:
+                    tool_execution_successes += 1
                 self._add_observation(
                     builder,
                     turn_id=turn_id,
@@ -449,6 +589,7 @@ class RolloutRunner:
 
             # Parse error.
             invalid_calls += 1
+            parse_errors += 1
             self._add_model_spans(
                 builder,
                 turn_id=turn_id,
@@ -474,7 +615,7 @@ class RolloutRunner:
             if generation.stop_reason == "eos":
                 termination = TerminationReason.EOS_WITHOUT_FINAL
                 break
-            if invalid_calls > cfg.max_parse_errors:
+            if parse_errors >= max(cfg.max_parse_errors, 1):
                 termination = TerminationReason.PARSE_ERROR_LIMIT
                 break
             self._add_observation(
@@ -502,12 +643,26 @@ class RolloutRunner:
             verification=verification,
             generated_token_count=generated_tokens,
             invalid_tool_calls=invalid_calls,
+            event_counters={
+                "assistant_turns": assistant_turns,
+                "emitted_tool_calls": emitted_tool_calls,
+                "parsed_tool_calls": parsed_tool_calls,
+                "tool_execution_successes": tool_execution_successes,
+                "tool_execution_errors": tool_execution_errors,
+                "unknown_tool_calls": unknown_tool_calls,
+                "parse_errors": parse_errors,
+                "repeated_call_terminations": repeated_call_terminations,
+                "final_answers_emitted": final_answers_emitted,
+                "final_answers_format_valid": final_answers_format_valid,
+                "final_answers_verified": final_answers_verified,
+            },
             metadata={
                 "source": "policy",
                 "seed": seed,
                 "temperature": sample_temperature,
                 "difficulty": task.difficulty,
                 "split": task.split,
+                "initial_observation_state_id": initial_observation.state_id,
                 **({"environment_error": metadata_error} if metadata_error else {}),
             },
         )
@@ -529,8 +684,8 @@ class RolloutRunner:
         truncated oracle trace would silently degrade every SFT target built
         from it, so the failure is allowed to propagate.
         """
-        self.environment.reset(task)
-        builder = self._new_builder(task)
+        initial_observation = self.environment.reset(task)
+        builder = self._new_builder(initial_observation)
         turns: list[Turn] = []
         generated_tokens = 0
         verification: VerificationRecord | None = None
@@ -612,10 +767,31 @@ class RolloutRunner:
             verification=verification,
             generated_token_count=generated_tokens,
             invalid_tool_calls=0,
+            event_counters={
+                "assistant_turns": len(turns),
+                "emitted_tool_calls": sum(turn.tool_call is not None for turn in turns),
+                "parsed_tool_calls": sum(turn.tool_call is not None for turn in turns),
+                "tool_execution_successes": sum(
+                    turn.tool_result is not None and turn.tool_result.ok for turn in turns
+                ),
+                "tool_execution_errors": sum(
+                    turn.tool_result is not None and not turn.tool_result.ok for turn in turns
+                ),
+                "unknown_tool_calls": 0,
+                "parse_errors": 0,
+                "repeated_call_terminations": 0,
+                "final_answers_emitted": int(verification is not None),
+                "final_answers_format_valid": int(
+                    verification is not None
+                    and verification.failure_category != FailureCategory.MALFORMED_ANSWER.value
+                ),
+                "final_answers_verified": int(verification is not None),
+            },
             metadata={
                 "source": "oracle",
                 "difficulty": task.difficulty,
                 "split": task.split,
+                "initial_observation_state_id": initial_observation.state_id,
             },
         )
 
@@ -668,5 +844,22 @@ class RolloutRunner:
             verification=student.verification,
             generated_token_count=student.generated_token_count,
             invalid_tool_calls=student.invalid_tool_calls,
+            event_counters={
+                field: int(getattr(student, field))
+                for field in (
+                    "assistant_turns",
+                    "emitted_tool_calls",
+                    "parsed_tool_calls",
+                    "tool_execution_successes",
+                    "tool_execution_errors",
+                    "unknown_tool_calls",
+                    "parse_errors",
+                    "repeated_call_terminations",
+                    "final_answers_emitted",
+                    "final_answers_format_valid",
+                    "final_answers_verified",
+                )
+                if getattr(student, field) is not None
+            },
             metadata={"source": "privileged_teacher_render", "of": student.trajectory_id},
         )

--- a/src/miniverl/agent/transcript.py
+++ b/src/miniverl/agent/transcript.py
@@ -259,6 +259,7 @@ class TranscriptBuilder:
         verification: VerificationRecord | None = None,
         generated_token_count: int = 0,
         invalid_tool_calls: int = 0,
+        event_counters: dict[str, int] | None = None,
         metadata: dict[str, object] | None = None,
     ) -> Trajectory:
         """Freeze the accumulated segments into a validated trajectory."""
@@ -285,5 +286,6 @@ class TranscriptBuilder:
             termination_reason=termination_reason,
             generated_token_count=generated_token_count,
             invalid_tool_calls=invalid_tool_calls,
+            **dict(event_counters or {}),
             metadata=dict(metadata or {}),
         )

--- a/src/miniverl/cache/store.py
+++ b/src/miniverl/cache/store.py
@@ -36,6 +36,7 @@ from typing import Any
 from miniverl.errors import CacheCorruptionError, CacheError, StaleCacheError
 from miniverl.schemas.cache import (
     CACHE_SCHEMA_VERSION,
+    READABLE_CACHE_SCHEMA_VERSIONS,
     CacheCompressionStats,
     CacheEntryMeta,
     CacheIndex,
@@ -130,20 +131,36 @@ class TeacherCache:
         teacher_model_id: str,
         teacher_model_revision: str | None,
         tokenizer_fingerprint: str,
+        tokenizer_identity: dict[str, Any] | None = None,
+        teacher_adapter_provenance: dict[str, Any] | None = None,
         vocab_size: int,
         top_k: int,
         temperature: float,
         loss_mode: str,
         dtype: str = "float32",
         entries_per_shard: int = 32,
-        overwrite: bool = True,
+        overwrite: bool = False,
     ) -> TeacherCache:
         """Create (or reset) a cache directory."""
         target = Path(path)
+        if loss_mode == "exact_full_vocab" and dtype != "float32":
+            raise CacheError(
+                "exact_full_vocab requires a float32 teacher cache so its objective "
+                "is not silently quantized"
+            )
         if target.exists() and overwrite:
-            for child in sorted(target.glob("*")):
-                if child.is_file():
+            for child in sorted(target.iterdir()):
+                if child.is_dir():
+                    import shutil
+
+                    shutil.rmtree(child)
+                else:
                     child.unlink()
+        elif target.exists() and any(target.iterdir()):
+            raise CacheError(
+                f"teacher cache already exists at {target}",
+                hint="open and validate it when resuming, or choose a new cache directory",
+            )
         target.mkdir(parents=True, exist_ok=True)
         index = CacheIndex(
             schema_version=CACHE_SCHEMA_VERSION,
@@ -151,6 +168,10 @@ class TeacherCache:
             teacher_model_id=teacher_model_id,
             teacher_model_revision=teacher_model_revision,
             tokenizer_fingerprint=tokenizer_fingerprint,
+            tokenizer_identity=dict(tokenizer_identity or {}),
+            teacher_adapter_provenance=(
+                dict(teacher_adapter_provenance) if teacher_adapter_provenance is not None else None
+            ),
             vocab_size=vocab_size,
             top_k=top_k,
             temperature=temperature,
@@ -177,10 +198,10 @@ class TeacherCache:
         except json.JSONDecodeError as exc:
             raise CacheCorruptionError(f"{index_path} is not valid JSON: {exc}") from exc
         version = payload.get("schema_version")
-        if version != CACHE_SCHEMA_VERSION:
+        if version not in READABLE_CACHE_SCHEMA_VERSIONS:
             raise StaleCacheError(
                 f"cache schema_version {version!r} is not readable by this miniVERL build "
-                f"(expected {CACHE_SCHEMA_VERSION})",
+                f"(readable versions: {sorted(READABLE_CACHE_SCHEMA_VERSIONS)})",
                 hint="delete the cache directory and re-score; teacher targets are "
                 "cheap to regenerate and must never be silently reinterpreted",
             )
@@ -192,6 +213,48 @@ class TeacherCache:
                 "teacher cache failed validation:\n  - " + "\n  - ".join(problems)
             )
         return cache
+
+    def assert_compatible(
+        self,
+        *,
+        teacher_model_id: str,
+        teacher_model_revision: str | None,
+        tokenizer_fingerprint: str,
+        tokenizer_identity: dict[str, Any] | None,
+        teacher_adapter_provenance: dict[str, Any] | None,
+        vocab_size: int,
+        top_k: int,
+        temperature: float,
+        loss_mode: str,
+        dtype: str,
+    ) -> None:
+        """Reject reuse when any objective or teacher identity component changed."""
+        expected: dict[str, Any] = {
+            "teacher_model_id": teacher_model_id,
+            "teacher_model_revision": teacher_model_revision,
+            "tokenizer_fingerprint": tokenizer_fingerprint,
+            "vocab_size": vocab_size,
+            "top_k": top_k,
+            "temperature": temperature,
+            "loss_mode": loss_mode,
+            "dtype": dtype,
+        }
+        if self.index.schema_version >= 2:
+            expected["tokenizer_identity"] = dict(tokenizer_identity or {})
+            expected["teacher_adapter_provenance"] = (
+                dict(teacher_adapter_provenance) if teacher_adapter_provenance is not None else None
+            )
+        mismatches = {
+            key: (getattr(self.index, key), value)
+            for key, value in expected.items()
+            if getattr(self.index, key) != value
+        }
+        if mismatches:
+            details = ", ".join(
+                f"{key}: cache={actual!r}, current={current!r}"
+                for key, (actual, current) in sorted(mismatches.items())
+            )
+            raise StaleCacheError(f"teacher cache identity mismatch ({details})")
 
     # -- writing -----------------------------------------------------------
 
@@ -254,6 +317,7 @@ class TeacherCache:
                 "checksum": digest.hexdigest(),
                 "tail_is_exact_zero": tail_is_exact_zero,
                 "selected_span_types": span_counts,
+                "ordered_span_types": list(batch.span_types),
             },
         }
         self._pending_order.append(batch.trajectory_id)
@@ -273,6 +337,7 @@ class TeacherCache:
             tensor_keys=list(_TENSOR_FIELDS),
             checksum=digest.hexdigest(),
             selected_span_types=span_counts,
+            ordered_span_types=list(batch.span_types),
         )
 
     def _next_shard_name(self) -> str:
@@ -316,6 +381,7 @@ class TeacherCache:
                 tensor_keys=list(_TENSOR_FIELDS),
                 checksum=meta["checksum"],
                 selected_span_types=meta["selected_span_types"],
+                ordered_span_types=meta["ordered_span_types"],
             )
         self._pending.clear()
         self._pending_order.clear()
@@ -375,16 +441,27 @@ class TeacherCache:
                 f"checksum mismatch for {trajectory_id!r} in shard {entry.shard}: "
                 f"expected {entry.checksum[:16]}..., got {digest.hexdigest()[:16]}..."
             )
-        span_types: list[str] = []
-        for name, count in sorted(entry.selected_span_types.items()):
-            span_types.extend([name] * count)
+        if entry.ordered_span_types is not None:
+            span_types = list(entry.ordered_span_types)
+        elif len(entry.selected_span_types) <= 1:
+            span_types = [
+                name for name, count in entry.selected_span_types.items() for _ in range(count)
+            ]
+        else:
+            raise StaleCacheError(
+                f"v1 cache entry {trajectory_id!r} does not preserve ordered span types",
+                hint="re-score this legacy cache before using per-span metrics",
+            )
+        tail_log_prob = loaded["tail_log_prob"].to(device=device, dtype=torch.float32)
+        if entry.tail_is_exact_zero:
+            tail_log_prob = torch.full_like(tail_log_prob, float("-inf"))
         return TeacherTargetBatch(
             trajectory_id=trajectory_id,
             policy_version=entry.policy_version,
             positions=loaded["positions"].to(device),
             topk_indices=loaded["topk_indices"].to(device=device, dtype=torch.long),
             topk_log_probs=loaded["topk_log_probs"].to(device=device, dtype=torch.float32),
-            tail_log_prob=loaded["tail_log_prob"].to(device=device, dtype=torch.float32),
+            tail_log_prob=tail_log_prob,
             target_token_ids=loaded["target_token_ids"].to(device),
             weights=loaded["weights"].to(device),
             temperature=entry.temperature,

--- a/src/miniverl/cli.py
+++ b/src/miniverl/cli.py
@@ -22,7 +22,8 @@ from rich.markup import escape
 from rich.table import Table
 
 from miniverl import __version__
-from miniverl.errors import MiniVerlError
+from miniverl.errors import ConfigError, MiniVerlError
+from miniverl.utils.runs import make_run_id
 
 app = typer.Typer(
     name="miniverl",
@@ -298,6 +299,11 @@ def validate(
 def demo(
     output: Path = typer.Option(Path("runs/demo"), "--output", help="Run directory to create."),
     fast: bool = typer.Option(False, "--fast", help="Shrink every budget (CI smoke test)."),
+    overwrite: bool = typer.Option(
+        False,
+        "--overwrite",
+        help="Explicitly replace the whole existing demo run directory.",
+    ),
     as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
     report_html: bool = typer.Option(True, "--report/--no-report", help="Also render report.html."),
 ) -> None:
@@ -313,18 +319,25 @@ def demo(
     target = Path(output)
     try:
         config = demo_config(fast=fast, output_dir=target.parent)
-        trainer = OPDTrainer.from_config(config, output_dir=target.parent, run_id=target.name)
-        try:
+        if overwrite and target.exists() and not as_json:
+            console.print(
+                f"[yellow]overwrite[/yellow] replacing whole run directory {_esc(target)}"
+            )
+        with OPDTrainer.from_config(
+            config,
+            output_dir=target.parent,
+            run_id=target.name,
+            overwrite=overwrite,
+        ) as trainer:
             result = trainer.train()
-        finally:
-            trainer.close()
+            paths = trainer.paths
         report_path: Path | None = None
         if report_html:
             from miniverl.reporting import ReportData, write_markdown, write_report
 
-            report_path = write_report(trainer.paths.root, trainer.paths.report_html)
-            write_markdown(ReportData.from_run(trainer.paths.root), trainer.paths.summary_md)
-        artifacts = _artifact_listing(trainer.paths.root)
+            report_path = write_report(paths.root, paths.report_html)
+            write_markdown(ReportData.from_run(paths.root), paths.summary_md)
+        artifacts = _artifact_listing(paths.root)
     except MiniVerlError as exc:
         _fail(exc)
         return
@@ -338,18 +351,19 @@ def demo(
         _emit_json(payload)
         return
     console.print()
-    console.print(f"[bold green]demo complete[/bold green]  {_esc(trainer.paths.root)}")
+    console.print(f"[bold green]demo complete[/bold green]  {_esc(paths.root)}")
     table = Table(show_header=False, box=None)
     baseline = (result.baseline_eval or {}).get("success_rate")
     final = (result.eval or {}).get("success_rate")
     table.add_row("mode", f"{result.mode} (genuine on-policy distillation)")
     table.add_row("optimizer steps", str(result.global_step))
-    table.add_row("policy versions", str(result.policy_version))
+    table.add_row("parameter version", str(result.parameter_version))
+    table.add_row("rollout iterations", str(result.cycles_completed))
     table.add_row("wall clock", f"{result.duration_seconds:.1f} s")
-    provenance = _provenance_summary(trainer.paths.trajectories)
+    provenance = _provenance_summary(paths.trajectories)
     if provenance:
         table.add_row("token provenance", provenance)
-    compression = _cache_summary(trainer.paths.teacher_cache)
+    compression = _cache_summary(paths.teacher_cache)
     if compression:
         table.add_row("teacher cache", compression)
     table.add_row(
@@ -372,11 +386,9 @@ def demo(
         console.print(f"  {_esc(name)}  [dim]{_esc(size)}[/dim]")
     console.print()
     console.print("[bold]next[/bold]")
-    console.print(f"  miniverl inspect {_esc(trainer.paths.trajectories)}")
-    console.print(f"  miniverl cache stats {_esc(trainer.paths.teacher_cache)}")
-    console.print(
-        f"  miniverl report {_esc(trainer.paths.root)} --out {_esc(trainer.paths.report_html)}"
-    )
+    console.print(f"  miniverl inspect {_esc(paths.trajectories)}")
+    console.print(f"  miniverl cache stats {_esc(paths.teacher_cache)}")
+    console.print(f"  miniverl report {_esc(paths.root)} --out {_esc(paths.report_html)}")
 
 
 def _provenance_summary(path: Path) -> str:
@@ -440,6 +452,21 @@ def train(
         None, "--output", help="Parent directory for the run (default: run.output_dir)."
     ),
     run_id: Optional[str] = typer.Option(None, "--run-id", help="Explicit run id."),
+    resume: Optional[Path] = typer.Option(
+        None,
+        "--resume",
+        help="Continue an existing run from its highest valid checkpoint.",
+    ),
+    resume_from: Optional[Path] = typer.Option(
+        None,
+        "--resume-from",
+        help="Continue an existing run from this exact checkpoint directory.",
+    ),
+    overwrite: bool = typer.Option(
+        False,
+        "--overwrite",
+        help="Explicitly replace the whole target run directory.",
+    ),
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
@@ -464,6 +491,23 @@ def train(
         err_console.print(f"[red]invalid recipe[/red] {_esc(recipe)}\n{_esc(exc)}")
         raise typer.Exit(1) from None
 
+    if resume is not None and resume_from is not None:
+        _fail(ConfigError("--resume and --resume-from are mutually exclusive"))
+        return
+    if overwrite and (resume is not None or resume_from is not None):
+        _fail(ConfigError("--overwrite cannot be combined with --resume or --resume-from"))
+        return
+    if (resume is not None or resume_from is not None) and (
+        run_id is not None or output is not None
+    ):
+        _fail(
+            ConfigError(
+                "--resume/--resume-from cannot be combined with --run-id or --output",
+                hint="the existing run directory already determines its id and output root",
+            )
+        )
+        return
+
     if dry_run:
         steps_per_cycle = max(
             1,
@@ -485,6 +529,9 @@ def train(
             * (config.train.cycles + config.train.sft_warmup_cycles),
             "planned_rollouts": config.train.rollouts_per_cycle * config.train.cycles,
             "output_dir": str(output or config.run.output_dir),
+            "resume": str(resume) if resume is not None else None,
+            "resume_from": str(resume_from) if resume_from is not None else None,
+            "overwrite": overwrite,
             "resolved_config": json.loads(json.dumps(config.model_dump(mode="json"), default=str)),
         }
         if as_json:
@@ -509,24 +556,38 @@ def train(
         _require_training_stack("miniverl train")
         from miniverl.trainer import OPDTrainer
 
-        trainer = OPDTrainer.from_config(
-            config, output_dir=output, run_id=run_id, local_files_only=offline
-        )
-        try:
+        explicit_id = run_id or config.run.run_id
+        if overwrite and explicit_id and not as_json:
+            target = Path(output or config.run.output_dir) / make_run_id(
+                config.run.name,
+                explicit=explicit_id,
+            )
+            if target.exists():
+                console.print(
+                    f"[yellow]overwrite[/yellow] replacing whole run directory {_esc(target)}"
+                )
+        with OPDTrainer.from_config(
+            config,
+            output_dir=output,
+            run_id=run_id,
+            local_files_only=offline,
+            overwrite=overwrite,
+            resume=resume,
+            resume_from=resume_from,
+        ) as trainer:
             result = trainer.train()
-        finally:
-            trainer.close()
+            paths = trainer.paths
         report_path: Path | None = None
         if make_report and config.report.enabled:
             from miniverl.reporting import ReportData, write_markdown, write_report
 
             report_path = write_report(
-                trainer.paths.root,
-                trainer.paths.report_html,
+                paths.root,
+                paths.report_html,
                 max_trajectories=config.report.max_trajectories,
                 max_tokens=config.report.max_tokens_per_trajectory,
             )
-            write_markdown(ReportData.from_run(trainer.paths.root), trainer.paths.summary_md)
+            write_markdown(ReportData.from_run(paths.root), paths.summary_md)
     except (MiniVerlError, ModuleNotFoundError) as exc:
         _fail(exc)
         return
@@ -536,15 +597,15 @@ def train(
         _emit_json(payload)
         return
     console.print()
-    console.print(f"[bold green]run complete[/bold green] {_esc(trainer.paths.root)}")
+    console.print(f"[bold green]run complete[/bold green] {_esc(paths.root)}")
     baseline = (result.baseline_eval or {}).get("success_rate")
     final = (result.eval or {}).get("success_rate")
     console.print(
         f"  task success {_fmt_pct(baseline)} -> {_fmt_pct(final)} "
         f"in {result.global_step} optimizer steps ({result.duration_seconds:.1f} s)"
     )
-    console.print(f"  eval  miniverl eval --run {_esc(trainer.paths.root)}")
-    console.print(f"  report {_esc(report_path or trainer.paths.report_html)}")
+    console.print(f"  eval  miniverl eval --run {_esc(paths.root)}")
+    console.print(f"  report {_esc(report_path or paths.report_html)}")
 
 
 # ------------------------------------------------------------------- eval
@@ -598,9 +659,11 @@ def eval_command(
         "lenient_diagnostic_success_rate",
         "avg_turns",
         "avg_tool_calls",
-        "tool_call_count",
-        "valid_tool_call_rate",
-        "invalid_tool_call_rate",
+        "emitted_tool_calls",
+        "parsed_tool_calls",
+        "parse_valid_tool_call_rate",
+        "tool_execution_success_rate",
+        "tool_execution_error_rate",
         "final_answer_format_validity_rate",
         "protocol_token_accuracy",
         "generated_tokens_per_task",
@@ -626,6 +689,11 @@ def benchmark(
         "--offline",
         help="Refuse network access; use only local or already-cached model and adapter files.",
     ),
+    resume: bool = typer.Option(
+        False,
+        "--resume",
+        help="Resume validated per-seed/per-arm run directories after a partial benchmark.",
+    ),
     as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
 ) -> None:
     """Run a matched-budget comparison across training modes."""
@@ -640,6 +708,7 @@ def benchmark(
             output_dir=output,
             notes=notes,
             local_files_only=offline,
+            resume=resume,
         )
     except (ValidationError, MiniVerlError) as exc:
         if isinstance(exc, MiniVerlError):

--- a/src/miniverl/config/models.py
+++ b/src/miniverl/config/models.py
@@ -350,6 +350,9 @@ class RolloutConfig(_Base):
     temperature: float = Field(default=1.0, ge=0.0, le=5.0)
     top_p: float = Field(default=1.0, gt=0.0, le=1.0)
     top_k: int = Field(default=0, ge=0)
+    # Maximum parse errors tolerated in an episode. The rollout terminates as
+    # soon as the count reaches this limit; zero therefore terminates on the
+    # first parse error.
     max_parse_errors: int = Field(default=2, ge=0, le=32)
     max_repeated_calls: int = Field(default=2, ge=1, le=32)
 
@@ -555,6 +558,11 @@ class RunConfig(_Base):
             )
 
         if self.loss.mode is LossMode.EXACT_FULL_VOCAB:
+            if self.cache.dtype != "float32":
+                raise ValueError(
+                    "loss.mode=exact_full_vocab requires cache.dtype=float32; a float16 "
+                    "teacher-probability cache would make the advertised exact objective lossy"
+                )
             # top_k is meaningless in exact mode. Reject it only when the recipe
             # *explicitly* set it to something other than 1, so that omitting the
             # key entirely -- the remedy the message suggests -- actually works.

--- a/src/miniverl/environments/base.py
+++ b/src/miniverl/environments/base.py
@@ -166,7 +166,12 @@ class ToolEnvironment(ABC):
 
     @abstractmethod
     def reset(self, task: Task) -> Observation:
-        """Start an episode for ``task`` and return the initial observation."""
+        """Start an episode and return its authoritative initial text and state.
+
+        The runner calls this exactly once and writes ``Observation.text`` and
+        ``state_id`` into trajectory provenance. Dynamic environments should
+        compute their initial view here.
+        """
         ...
 
     @abstractmethod
@@ -208,12 +213,28 @@ class ToolEnvironment(ABC):
             raise ValueError(f"prompt_style must be 'full' or 'compact', got {style!r}")
         return style
 
+    @property
+    def protocol_version(self) -> str:
+        """Prompt/protocol contract; v1 is the frozen historical v0.2 prompt."""
+        version = str(self.params.get("protocol_version", "v1"))
+        if version not in ("v1", "v2"):
+            raise ValueError(f"protocol_version must be 'v1' or 'v2', got {version!r}")
+        return version
+
     def system_prompt(self) -> str:
         """System message describing the protocol and the available tools."""
         if self.prompt_style == "compact":
             tools = "\n".join(
                 f"- {spec.name}({', '.join(spec.parameters)})" for spec in self.tool_specs()
             )
+            if self.protocol_version == "v2":
+                return (
+                    "Use tools to solve the task.\n"
+                    f"{tools}\n"
+                    "Reply with one block:\n<tool_call>\n"
+                    '{"name":"calculator","arguments":{"expression":"2+2"}}\n'
+                    "</tool_call>\nor\n<final>\n4\n</final>"
+                )
             return (
                 "Use tools to solve the task.\n"
                 f"{tools}\n"
@@ -221,6 +242,20 @@ class ToolEnvironment(ABC):
                 "</tool_call>\nor\n<final>\nanswer\n</final>"
             )
         tools = "\n".join(spec.render() for spec in self.tool_specs())
+        if self.protocol_version == "v2":
+            return (
+                "You are a tool-using assistant. Solve the task with the tools below.\n"
+                "\n"
+                "Tools:\n"
+                f"{tools}\n"
+                "\n"
+                "Reply with exactly one block per turn.\n"
+                "To call a tool:\n"
+                '<tool_call>\n{"name":"calculator","arguments":{"expression":"2+2"}}\n'
+                "</tool_call>\n"
+                "To answer:\n"
+                "<final>\n4\n</final>"
+            )
         return (
             "You are a tool-using assistant. Solve the task with the tools below.\n"
             "\n"
@@ -235,14 +270,24 @@ class ToolEnvironment(ABC):
         )
 
     def user_prompt(self, task: Task) -> str:
-        """User message for ``task``."""
+        """Compatibility helper for built-ins constructing ``reset()`` output.
+
+        The rollout runner never calls this separately: ``reset()`` is the one
+        authoritative initial-observation contract.
+        """
         return task.prompt
 
     # -- diagnostics -----------------------------------------------------
 
     def describe(self) -> dict[str, Any]:
         """Environment identity for the run manifest."""
-        return {"name": self.name, "params": dict(self.params)}
+        return {
+            "name": self.name,
+            "params": {
+                **dict(self.params),
+                "protocol_version": self.protocol_version,
+            },
+        }
 
 
 #: Index offsets keeping the three splits disjoint by construction.

--- a/src/miniverl/errors.py
+++ b/src/miniverl/errors.py
@@ -27,6 +27,7 @@ __all__ = [
     "CheckpointError",
     "ReportError",
     "RunNotFoundError",
+    "RunDirectoryError",
 ]
 
 
@@ -121,3 +122,7 @@ class ReportError(MiniVerlError):
 
 class RunNotFoundError(MiniVerlError):
     """A run directory does not exist or is missing required artifacts."""
+
+
+class RunDirectoryError(MiniVerlError):
+    """A run directory could not be created, resumed or safely replaced."""

--- a/src/miniverl/evaluation/benchmark.py
+++ b/src/miniverl/evaluation/benchmark.py
@@ -215,16 +215,20 @@ def _cold_start(
     output_dir: Path,
     *,
     local_files_only: bool = False,
+    resume_existing: bool = False,
 ) -> tuple[Path | None, float]:
     if run_config.train.cycles <= 0:
         return None, 0.0
     from miniverl.trainer import OPDTrainer
 
     started = time.perf_counter()
+    run_id = f"{run_config.run.name}-s{run_config.run.seed}"
+    existing = output_dir / run_id
     with OPDTrainer.from_config(
         run_config,
-        output_dir=output_dir,
-        run_id=f"{run_config.run.name}-s{run_config.run.seed}",
+        output_dir=None if resume_existing and existing.is_dir() else output_dir,
+        run_id=None if resume_existing and existing.is_dir() else run_id,
+        resume=existing if resume_existing and existing.is_dir() else None,
         local_files_only=local_files_only,
     ) as trainer:
         result = trainer.train()
@@ -345,6 +349,7 @@ def _run_one_arm(
     common_dump: dict[str, Any],
     checkpoint: Path | None,
     local_files_only: bool = False,
+    resume_existing: bool = False,
 ) -> ArmResult:
     """Run one arm inside a model-owning lifetime boundary."""
     from miniverl.trainer import OPDTrainer
@@ -352,10 +357,12 @@ def _run_one_arm(
 
     declared_config = portable_payload(run_config.model_dump(mode="json"))
     arm_started = time.perf_counter()
+    existing = target / run_config.run.name
     with OPDTrainer.from_config(
         run_config,
-        output_dir=target,
-        run_id=run_config.run.name,
+        output_dir=None if resume_existing and existing.is_dir() else target,
+        run_id=None if resume_existing and existing.is_dir() else run_config.run.name,
+        resume=existing if resume_existing and existing.is_dir() else None,
         local_files_only=local_files_only,
     ) as trainer:
         runtime_config = portable_payload(
@@ -451,6 +458,27 @@ def _run_one_arm(
             ),
             avg_turns=float(evaluation["avg_turns"]),
             avg_tool_calls=float(evaluation["avg_tool_calls"]),
+            **{
+                key: int(evaluation[key]) if evaluation.get(key) is not None else None
+                for key in (
+                    "assistant_turns",
+                    "emitted_tool_calls",
+                    "parsed_tool_calls",
+                    "tool_execution_successes",
+                    "tool_execution_errors",
+                    "unknown_tool_calls",
+                    "parse_errors",
+                    "repeated_call_terminations",
+                    "final_answers_emitted",
+                    "final_answers_format_valid",
+                    "final_answers_verified",
+                )
+            },
+            parse_valid_tool_call_rate=finite_or_none(evaluation.get("parse_valid_tool_call_rate")),
+            tool_execution_success_rate=finite_or_none(
+                evaluation.get("tool_execution_success_rate")
+            ),
+            tool_execution_error_rate=finite_or_none(evaluation.get("tool_execution_error_rate")),
             tool_call_count=int(evaluation["tool_call_count"]),
             valid_tool_call_rate=finite_or_none(evaluation.get("valid_tool_call_rate")),
             invalid_tool_call_rate=float(evaluation["invalid_tool_call_rate"]),
@@ -495,8 +523,14 @@ def run_benchmark(
     notes: str = "",
     invocation: list[str] | None = None,
     local_files_only: bool = False,
+    resume: bool = False,
 ) -> BenchmarkResult:
-    """Execute every preflight-validated arm and write a schema-v2 result."""
+    """Execute every preflight-validated arm and write a schema-v2 result.
+
+    Existing arm directories are always collisions unless ``resume=True``.
+    Resume attaches to their validated checkpoints and intentionally extends
+    the same logs; it never treats stale files as a new benchmark run.
+    """
     # Preflight every seed before creating a run directory or allocating a model.
     preflight = {seed: resolve_benchmark_configs(config, seed=seed) for seed in config.seeds}
     common_config = preflight[config.seeds[0]][0]
@@ -516,6 +550,7 @@ def run_benchmark(
                 cold_config,
                 target,
                 local_files_only=local_files_only,
+                resume_existing=resume,
             )
         finally:
             _isolate_next_trainer(f"cold start seed {seed}")
@@ -547,6 +582,7 @@ def run_benchmark(
                         common_dump=common_dump,
                         checkpoint=checkpoint,
                         local_files_only=local_files_only,
+                        resume_existing=resume,
                     )
                 )
             finally:

--- a/src/miniverl/evaluation/evaluator.py
+++ b/src/miniverl/evaluation/evaluator.py
@@ -9,11 +9,12 @@ recipe -- is what makes the evaluation reproduce the run it is evaluating: any
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 from typing import Any
 
 from miniverl.config.models import RunConfig
-from miniverl.errors import RunNotFoundError
+from miniverl.errors import CheckpointError, RunNotFoundError
 from miniverl.utils.logging import get_logger
 from miniverl.utils.runs import RunPaths, write_json
 
@@ -34,7 +35,11 @@ def evaluate_run(
 ) -> dict[str, Any]:
     """Re-evaluate a finished run and write the result next to it."""
     from miniverl.trainer import OPDTrainer
-    from miniverl.training.checkpoint import latest_checkpoint, load_checkpoint
+    from miniverl.training.checkpoint import (
+        latest_checkpoint,
+        load_checkpoint,
+        validate_checkpoint,
+    )
 
     paths = RunPaths.open(run_dir)
     if not paths.config_resolved.is_file():
@@ -47,30 +52,46 @@ def evaluate_run(
         config = config.model_copy(update={"eval": config.eval.model_copy(update={"tasks": tasks})})
 
     target_checkpoint = Path(checkpoint) if checkpoint else latest_checkpoint(paths.checkpoints)
+    if target_checkpoint is None:
+        raise CheckpointError(
+            f"no checkpoint found under {paths.checkpoints}",
+            hint="finish training or pass --checkpoint with a complete checkpoint directory",
+        )
+    validated = validate_checkpoint(target_checkpoint)
+    resolved_digest = hashlib.sha256(paths.config_resolved.read_bytes()).hexdigest()
+    if (
+        validated.state.resolved_config_digest
+        and validated.state.resolved_config_digest != resolved_digest
+    ):
+        raise CheckpointError(
+            "the checkpoint does not belong to this resolved run configuration",
+            hint="evaluate the run directory that originally produced this checkpoint",
+        )
     trainer = OPDTrainer.from_config(
         config,
         output_dir=paths.root.parent,
         run_id=paths.root.name,
         local_files_only=local_files_only,
         write_artifacts=False,
+        for_evaluation=True,
     )
     try:
-        if target_checkpoint is not None and Path(target_checkpoint).is_dir():
-            load_checkpoint(
-                target_checkpoint,
-                backend=trainer.student,
-                optimizer=trainer.optimizer,
-                device=trainer.student.device,
-                include_rng=False,
-            )
-            logger.info("restored checkpoint %s", target_checkpoint)
-        else:
-            logger.warning(
-                "no checkpoint found under %s; evaluating the freshly initialized student",
-                paths.checkpoints,
-            )
+        state = load_checkpoint(
+            target_checkpoint,
+            backend=trainer.student,
+            optimizer=None,
+            device=trainer.student.device,
+            include_optimizer=False,
+            include_rng=False,
+            expected_identity=(trainer._checkpoint_identity() if validated.identity else None),
+        )
+        trainer._apply_checkpoint_progress(state)
+        logger.info("restored checkpoint %s", target_checkpoint)
         payload = trainer.evaluate(split=split, tag=tag, write=True)
-        payload["checkpoint"] = str(target_checkpoint) if target_checkpoint else None
+        payload["checkpoint"] = str(target_checkpoint)
+        payload["checkpoint_digest"] = validated.content_digest
+        payload["checkpoint_integrity"] = validated.integrity
+        payload["checkpoint_global_step"] = validated.state.global_step
         payload["run_dir"] = str(paths.root)
         destination = Path(out) if out else paths.root / f"eval.{tag}.json"
         write_json(destination, payload)

--- a/src/miniverl/evaluation/export.py
+++ b/src/miniverl/evaluation/export.py
@@ -83,6 +83,25 @@ def export_run(
         ),
         avg_turns=float(final["avg_turns"]),
         avg_tool_calls=float(final["avg_tool_calls"]),
+        **{
+            key: int(final[key]) if final.get(key) is not None else None
+            for key in (
+                "assistant_turns",
+                "emitted_tool_calls",
+                "parsed_tool_calls",
+                "tool_execution_successes",
+                "tool_execution_errors",
+                "unknown_tool_calls",
+                "parse_errors",
+                "repeated_call_terminations",
+                "final_answers_emitted",
+                "final_answers_format_valid",
+                "final_answers_verified",
+            )
+        },
+        parse_valid_tool_call_rate=finite_or_none(final.get("parse_valid_tool_call_rate")),
+        tool_execution_success_rate=finite_or_none(final.get("tool_execution_success_rate")),
+        tool_execution_error_rate=finite_or_none(final.get("tool_execution_error_rate")),
         tool_call_count=(
             int(final["tool_call_count"]) if final.get("tool_call_count") is not None else None
         ),

--- a/src/miniverl/evaluation/schema.py
+++ b/src/miniverl/evaluation/schema.py
@@ -189,6 +189,21 @@ class ArmResult(BaseModel):
     lenient_diagnostic_success_rate: float | None = None
     avg_turns: float
     avg_tool_calls: float
+    assistant_turns: int | None = None
+    emitted_tool_calls: int | None = None
+    parsed_tool_calls: int | None = None
+    tool_execution_successes: int | None = None
+    tool_execution_errors: int | None = None
+    unknown_tool_calls: int | None = None
+    parse_errors: int | None = None
+    repeated_call_terminations: int | None = None
+    final_answers_emitted: int | None = None
+    final_answers_format_valid: int | None = None
+    final_answers_verified: int | None = None
+    parse_valid_tool_call_rate: float | None = None
+    tool_execution_success_rate: float | None = None
+    tool_execution_error_rate: float | None = None
+    # Deprecated aliases for schema-v1/v2 benchmark readers.
     tool_call_count: int | None = None
     valid_tool_call_rate: float | None = None
     invalid_tool_call_rate: float

--- a/src/miniverl/losses/chunked.py
+++ b/src/miniverl/losses/chunked.py
@@ -141,12 +141,20 @@ class LossOutput:
     loss: float
     num_positions: int
     total_weight: float
-    per_token: torch.Tensor
+    per_token_objective: torch.Tensor
+    per_token_divergence: torch.Tensor | None = None
     per_token_ce: torch.Tensor | None = None
     teacher_entropy: torch.Tensor | None = None
     grad_hidden: torch.Tensor | None = None
     num_chunks: int = 0
     metrics: dict[str, float] = field(default_factory=dict)
+
+    @property
+    def per_token(self) -> torch.Tensor:
+        """Backward-compatible divergence view; use explicit component fields."""
+        if self.per_token_divergence is not None:
+            return self.per_token_divergence
+        return torch.zeros_like(self.per_token_objective)
 
 
 def _cross_entropy(student_logits: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
@@ -213,8 +221,15 @@ def chunked_selected_position_loss(
             loss=0.0,
             num_positions=0,
             total_weight=0.0,
-            per_token=torch.zeros(0, dtype=torch.float32, device=device),
-            per_token_ce=torch.zeros(0, dtype=torch.float32, device=device),
+            per_token_objective=torch.zeros(0, dtype=torch.float32, device=device),
+            per_token_divergence=(
+                torch.zeros(0, dtype=torch.float32, device=device) if provider is not None else None
+            ),
+            per_token_ce=(
+                torch.zeros(0, dtype=torch.float32, device=device)
+                if provider is None or ce_weight > 0.0
+                else None
+            ),
             teacher_entropy=torch.zeros(0, dtype=torch.float32, device=device)
             if collect_teacher_entropy
             else None,
@@ -234,7 +249,8 @@ def chunked_selected_position_loss(
     work = hidden_states.detach().requires_grad_(True) if use_two_stage else hidden_states
 
     loss_value = 0.0
-    per_token_parts: list[torch.Tensor] = []
+    objective_parts: list[torch.Tensor] = []
+    divergence_parts: list[torch.Tensor] = []
     ce_parts: list[torch.Tensor] = []
     entropy_parts: list[torch.Tensor] = []
     num_chunks = 0
@@ -268,8 +284,11 @@ def chunked_selected_position_loss(
             (chunk_loss * loss_scale).backward()
         loss_value += float(chunk_loss.detach())
 
-        per_token_parts.append(divergence.detach())
-        ce_parts.append(ce.detach())
+        objective_parts.append(combined.detach())
+        if provider is not None:
+            divergence_parts.append(divergence.detach())
+        if provider is None or ce_weight > 0.0:
+            ce_parts.append(ce.detach())
         if collect_teacher_entropy and provider is not None:
             entropy_parts.append(provider.teacher_entropy(start, end).detach())
 
@@ -286,7 +305,8 @@ def chunked_selected_position_loss(
         loss=loss_value,
         num_positions=n,
         total_weight=float(w.sum()),
-        per_token=torch.cat(per_token_parts) if per_token_parts else torch.zeros(0),
+        per_token_objective=(torch.cat(objective_parts) if objective_parts else torch.zeros(0)),
+        per_token_divergence=(torch.cat(divergence_parts) if divergence_parts else None),
         per_token_ce=torch.cat(ce_parts) if ce_parts else None,
         teacher_entropy=torch.cat(entropy_parts) if entropy_parts else None,
         grad_hidden=grad_hidden,

--- a/src/miniverl/models/adapter_io.py
+++ b/src/miniverl/models/adapter_io.py
@@ -40,12 +40,29 @@ _POLICY_EVAL_FIELDS = (
     "tasks",
     "strict_task_success_rate",
     "lenient_diagnostic_success_rate",
+    "parse_valid_tool_call_rate",
+    "tool_execution_success_rate",
+    "tool_execution_error_rate",
+    "emitted_tool_calls",
+    "parsed_tool_calls",
     "valid_tool_call_rate",
     "tool_call_count",
     "final_answer_format_validity_rate",
     "avg_turns",
     "protocol_token_accuracy",
     "policy_competence_measurement_status",
+)
+_V1_POLICY_EVAL_FIELDS = tuple(
+    field
+    for field in _POLICY_EVAL_FIELDS
+    if field
+    not in {
+        "parse_valid_tool_call_rate",
+        "tool_execution_success_rate",
+        "tool_execution_error_rate",
+        "emitted_tool_calls",
+        "parsed_tool_calls",
+    }
 )
 
 
@@ -186,6 +203,7 @@ def validate_teacher_adapter(
     teacher: TeacherModelConfig,
     *,
     tokenizer_fingerprint: str,
+    protocol_version: str | None = None,
     local_files_only: bool = False,
 ) -> ValidatedTeacherAdapter:
     """Validate compatibility before the adapter can supervise training."""
@@ -239,6 +257,13 @@ def validate_teacher_adapter(
             hint=f"expected {expected_tokenizer[:16]}..., got {tokenizer_fingerprint[:16]}...",
         )
 
+    training_task = manifest.get("training_task") or {}
+    recorded_protocol = training_task.get("protocol_version")
+    if recorded_protocol is None:
+        legacy_protocol = training_task.get("protocol")
+        recorded_protocol = (
+            "v1" if legacy_protocol in (None, "miniverl_tool_protocol_v1") else str(legacy_protocol)
+        )
     policy_evaluation = manifest.get("policy_evaluation")
     if adapter.require_policy_evaluation:
         if not isinstance(policy_evaluation, dict):
@@ -249,7 +274,27 @@ def validate_teacher_adapter(
                     "SFT loss is not a teacher-competence measurement"
                 ),
             )
-        missing_metrics = [field for field in _POLICY_EVAL_FIELDS if field not in policy_evaluation]
+        evaluated_protocol = policy_evaluation.get(
+            "protocol_version",
+            recorded_protocol,
+        )
+        if protocol_version and evaluated_protocol != protocol_version:
+            raise BackendError(
+                f"teacher adapter competence was evaluated on protocol "
+                f"{evaluated_protocol!r}, not requested protocol {protocol_version!r}",
+                hint=(
+                    f"record an independent {protocol_version} policy evaluation, or use "
+                    f"environment.params.protocol_version: {evaluated_protocol}"
+                ),
+            )
+        # The immutable v0.2 protocol-teacher is a v1 artifact created before
+        # v0.2.1 split emitted, parsed and executed tool events. Its original
+        # competence record remains sufficient for v1 only. New protocol
+        # artifacts must carry the precise counters and rates.
+        required_fields = (
+            _V1_POLICY_EVAL_FIELDS if evaluated_protocol == "v1" else _POLICY_EVAL_FIELDS
+        )
+        missing_metrics = [field for field in required_fields if field not in policy_evaluation]
         if missing_metrics:
             raise BackendError(
                 "teacher adapter policy evaluation is incomplete: " + ", ".join(missing_metrics)
@@ -300,6 +345,7 @@ def validate_teacher_adapter(
             else None
         ),
         "policy_evaluation": policy_evaluation,
+        "protocol_version": recorded_protocol,
     }
     return ValidatedTeacherAdapter(
         provenance=provenance,
@@ -378,11 +424,13 @@ def export_adapter(
     }
     env = collect_environment()
     policy_evaluation = None
+    protocol_version = str(config.environment.params.get("protocol_version", "v1"))
     if paths.eval_json.is_file():
         summary = read_json(paths.eval_json)
         final_eval = summary.get("eval") if isinstance(summary, dict) else None
         if isinstance(final_eval, dict):
             policy_evaluation = {field: final_eval.get(field) for field in _POLICY_EVAL_FIELDS}
+            policy_evaluation["protocol_version"] = protocol_version
     manifest = {
         "schema_version": 1,
         "miniverl_version": __version__,
@@ -398,7 +446,8 @@ def export_adapter(
         "training_task": {
             "environment": config.environment.name,
             "difficulty": config.environment.difficulty,
-            "protocol": "miniverl_tool_protocol_v1",
+            "protocol": f"miniverl_tool_protocol_{protocol_version}",
+            "protocol_version": protocol_version,
             "mode": config.run.mode.value,
         },
         "policy_evaluation": policy_evaluation,

--- a/src/miniverl/models/factory.py
+++ b/src/miniverl/models/factory.py
@@ -9,7 +9,7 @@ from miniverl.agent.transcript import TokenizerLike
 from miniverl.config.models import ModelBackend, ModelsConfig, RunConfig
 from miniverl.errors import ConfigError, TokenizerMismatchError
 from miniverl.models.base import CausalLMBackend
-from miniverl.models.tokenizers import HFTokenizerAdapter, ToyTokenizer
+from miniverl.models.tokenizers import HFTokenizerAdapter, ToyTokenizer, assert_same_tokenizer
 from miniverl.utils.lazy import have_module
 
 __all__ = ["BackendBundle", "resolve_device", "build_tokenizer", "build_student", "build_teacher"]
@@ -75,14 +75,19 @@ def build_tokenizer(config: RunConfig, *, local_files_only: bool = False) -> Tok
         local_files_only=local_files_only,
     )
     teacher_id = teacher.tokenizer_id or teacher.model_id
-    if teacher_id != (student.tokenizer_id or student.model_id):
+    student_id = student.tokenizer_id or student.model_id
+    student_revision = student.tokenizer_revision or student.revision
+    teacher_revision = teacher.tokenizer_revision or teacher.revision
+    if (teacher_id, teacher_revision) != (student_id, student_revision):
         teacher_tok = HFTokenizerAdapter.load(
             teacher_id,
-            revision=teacher.tokenizer_revision or teacher.revision,
+            revision=teacher_revision,
             trust_remote_code=teacher.trust_remote_code,
             local_files_only=local_files_only,
         )
-        if teacher_tok.fingerprint != student_tok.fingerprint:
+        try:
+            assert_same_tokenizer(student_tok, teacher_tok)
+        except TokenizerMismatchError as exc:
             raise TokenizerMismatchError(
                 f"the student tokenizer ({student.tokenizer_id or student.model_id}) and the "
                 f"teacher tokenizer ({teacher_id}) tokenize differently",
@@ -90,7 +95,7 @@ def build_tokenizer(config: RunConfig, *, local_files_only: bool = False) -> Tok
                 "teacher from the same model family, e.g. Qwen/Qwen3-0.6B with "
                 "Qwen/Qwen3-1.7B. Cross-tokenizer distillation is a roadmap item "
                 "(docs/limitations.md).",
-            )
+            ) from exc
     return student_tok
 
 
@@ -167,4 +172,5 @@ def build_teacher(
         tokenizer=tokenizer,
         trainable=False,
         local_files_only=local_files_only,
+        protocol_version=str(config.environment.params.get("protocol_version", "v1")),
     )

--- a/src/miniverl/models/hf.py
+++ b/src/miniverl/models/hf.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Any
 
 import torch
@@ -173,6 +174,7 @@ class HFBackend(CausalLMBackend):
         tokenizer: TokenizerLike,
         trainable: bool,
         local_files_only: bool = False,
+        protocol_version: str | None = None,
     ) -> HFBackend:
         """Load a model from a local path or the Hub."""
         transformers = require_transformers("Loading a Hugging Face causal LM")
@@ -187,6 +189,7 @@ class HFBackend(CausalLMBackend):
                 spec.adapter,
                 spec,
                 tokenizer_fingerprint=tokenizer.fingerprint,
+                protocol_version=protocol_version,
                 local_files_only=local_files_only,
             )
             adapter_provenance = validated_adapter.provenance
@@ -209,8 +212,22 @@ class HFBackend(CausalLMBackend):
             kwargs["quantization_config"] = quant_config
             kwargs["device_map"] = {"": device}
         try:
-            model = transformers.AutoModelForCausalLM.from_pretrained(spec.model_id, **kwargs)
-        except OSError as exc:
+            model_source = spec.model_id
+            if local_files_only and not Path(spec.model_id).exists():
+                # Resolve the cached snapshot before entering Transformers.
+                # Some Transformers/Hub version combinations perform an
+                # adapter-discovery HEAD request even when the top-level model
+                # load received local_files_only=True.  A concrete snapshot
+                # path makes the zero-network contract unambiguous.
+                from huggingface_hub import snapshot_download
+
+                model_source = snapshot_download(
+                    repo_id=spec.model_id,
+                    revision=spec.revision,
+                    local_files_only=True,
+                )
+            model = transformers.AutoModelForCausalLM.from_pretrained(model_source, **kwargs)
+        except (OSError, ValueError) as exc:
             revision = f" at revision {spec.revision!r}" if spec.revision else ""
             preload = f"hf download {spec.model_id}"
             if spec.revision:
@@ -428,10 +445,28 @@ class HFBackend(CausalLMBackend):
     def load_trainable_state_dict(self, state: dict[str, torch.Tensor]) -> None:
         """Restore trainable weights in place."""
         own = dict(self.model.named_parameters())
-        missing = [k for k in state if k not in own]
+        expected = {name for name, parameter in own.items() if parameter.requires_grad}
+        unknown = sorted(set(state).difference(expected))
+        missing = sorted(expected.difference(state))
+        if unknown:
+            raise BackendError(
+                f"checkpoint contains {len(unknown)} unknown parameter names, e.g. {unknown[0]}",
+                hint="the checkpoint was written by a different model or LoRA config",
+            )
         if missing:
             raise BackendError(
-                f"checkpoint contains {len(missing)} unknown parameter names, e.g. {missing[0]}",
+                f"checkpoint is missing {len(missing)} trainable parameters, e.g. {missing[0]}",
+                hint="the checkpoint is incomplete or was written by a different LoRA config",
+            )
+        mismatched = [
+            (name, tuple(value.shape), tuple(own[name].shape))
+            for name, value in state.items()
+            if value.shape != own[name].shape
+        ]
+        if mismatched:
+            name, actual, expected_shape = mismatched[0]
+            raise BackendError(
+                f"checkpoint parameter {name!r} has shape {actual}, expected {expected_shape}",
                 hint="the checkpoint was written by a different model or LoRA config",
             )
         with torch.no_grad():

--- a/src/miniverl/models/tokenizers.py
+++ b/src/miniverl/models/tokenizers.py
@@ -30,6 +30,7 @@ __all__ = [
     "ToyTokenizer",
     "HFTokenizerAdapter",
     "tokenizer_fingerprint",
+    "tokenizer_structural_digest",
     "PROBE_TEXT",
     "TOY_SPECIAL_TOKENS",
 ]
@@ -145,6 +146,42 @@ def tokenizer_fingerprint(payload: dict[str, Any]) -> str:
     return hashlib.sha256(blob.encode("utf-8")).hexdigest()
 
 
+def tokenizer_structural_digest(tokenizer: Any) -> str:
+    """Incrementally hash tokenizer structure without exposing local file paths."""
+    digest = hashlib.sha256()
+
+    def update(name: str, value: Any) -> None:
+        digest.update(name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(
+            json.dumps(
+                value,
+                sort_keys=True,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                default=str,
+            ).encode("utf-8")
+        )
+        digest.update(b"\0")
+
+    get_vocab = getattr(tokenizer, "get_vocab", None)
+    vocab = get_vocab() if callable(get_vocab) else {}
+    update("vocab", sorted((str(token), int(token_id)) for token, token_id in vocab.items()))
+    get_added_vocab = getattr(tokenizer, "get_added_vocab", None)
+    added = get_added_vocab() if callable(get_added_vocab) else {}
+    update("added_vocab", sorted((str(token), int(token_id)) for token, token_id in added.items()))
+    update("special_tokens_map", getattr(tokenizer, "special_tokens_map", {}))
+    update("tokenizer_class", type(tokenizer).__name__)
+    backend = getattr(tokenizer, "backend_tokenizer", None)
+    backend_to_str = getattr(backend, "to_str", None)
+    update(
+        "backend_tokenizer",
+        backend_to_str() if callable(backend_to_str) else None,
+    )
+    update("tokenizer_config", getattr(tokenizer, "init_kwargs", {}))
+    return digest.hexdigest()
+
+
 class ToyTokenizer:
     """Reversible greedy-longest-match tokenizer over a tiny fixed vocabulary.
 
@@ -186,6 +223,16 @@ class ToyTokenizer:
         self.fingerprint = tokenizer_fingerprint(
             {"kind": "toy", "version": 1, "vocab": self._vocab}
         )
+        self.identity = {
+            "behavioral_fingerprint_v1": self.fingerprint,
+            "structural_digest_v2": tokenizer_fingerprint(
+                {"kind": "toy", "version": 2, "vocab": self._vocab}
+            ),
+            "tokenizer_class": type(self).__name__,
+            "length": len(self._vocab),
+            "base_vocab_size": len(self._vocab),
+            "added_vocab_size": 0,
+        }
 
     # -- TokenizerLike --------------------------------------------------
 
@@ -268,6 +315,18 @@ class HFTokenizerAdapter:
                 "probe": probe_ids,
             }
         )
+        get_vocab = getattr(tokenizer, "get_vocab", None)
+        get_added_vocab = getattr(tokenizer, "get_added_vocab", None)
+        base_vocab = get_vocab() if callable(get_vocab) else {}
+        added_vocab = get_added_vocab() if callable(get_added_vocab) else {}
+        self.identity = {
+            "behavioral_fingerprint_v1": self.fingerprint,
+            "structural_digest_v2": tokenizer_structural_digest(tokenizer),
+            "tokenizer_class": type(tokenizer).__name__,
+            "length": len(tokenizer),
+            "base_vocab_size": len(base_vocab),
+            "added_vocab_size": len(added_vocab),
+        }
 
     @classmethod
     def load(
@@ -330,7 +389,16 @@ class HFTokenizerAdapter:
 
 def assert_same_tokenizer(student: Any, teacher: Any) -> None:
     """Raise unless the two adapters have identical fingerprints."""
-    if student.fingerprint != teacher.fingerprint:
+    student_identity = getattr(student, "identity", {})
+    teacher_identity = getattr(teacher, "identity", {})
+    student_structural = student_identity.get("structural_digest_v2")
+    teacher_structural = teacher_identity.get("structural_digest_v2")
+    same = (
+        student_structural == teacher_structural
+        if student_structural and teacher_structural
+        else student.fingerprint == teacher.fingerprint
+    )
+    if not same:
         raise TokenizerMismatchError(
             "student and teacher tokenizers are not identical "
             f"({student.fingerprint[:12]}... vs {teacher.fingerprint[:12]}...)",

--- a/src/miniverl/models/toy.py
+++ b/src/miniverl/models/toy.py
@@ -364,9 +364,23 @@ class ToyBackend(CausalLMBackend):
     def load_trainable_state_dict(self, state: dict[str, torch.Tensor]) -> None:
         """Restore trainable parameters in place."""
         own = dict(self.model.named_parameters())
-        missing = [k for k in state if k not in own]
+        expected = {name for name, parameter in own.items() if parameter.requires_grad}
+        unknown = sorted(set(state).difference(expected))
+        missing = sorted(expected.difference(state))
+        if unknown:
+            raise BackendError(f"unknown trainable parameter names in state dict: {unknown[:5]}")
         if missing:
-            raise BackendError(f"unknown parameter names in state dict: {missing[:5]}")
+            raise BackendError(f"state dict is missing trainable parameters: {missing[:5]}")
+        mismatched = [
+            (name, tuple(value.shape), tuple(own[name].shape))
+            for name, value in state.items()
+            if value.shape != own[name].shape
+        ]
+        if mismatched:
+            name, actual, expected_shape = mismatched[0]
+            raise BackendError(
+                f"trainable parameter {name!r} has shape {actual}, expected {expected_shape}"
+            )
         with torch.no_grad():
             for name, value in state.items():
                 own[name].copy_(value.to(own[name].device, own[name].dtype))

--- a/src/miniverl/reporting/data.py
+++ b/src/miniverl/reporting/data.py
@@ -280,7 +280,11 @@ class ReportData:
                         "tasks": payload.get("tasks"),
                         "success_rate": payload.get("success_rate"),
                         "avg_turns": payload.get("avg_turns"),
-                        "invalid_tool_call_rate": payload.get("invalid_tool_call_rate"),
+                        "parse_valid_tool_call_rate": payload.get(
+                            "parse_valid_tool_call_rate",
+                            payload.get("valid_tool_call_rate"),
+                        ),
+                        "tool_execution_success_rate": payload.get("tool_execution_success_rate"),
                         "generated_tokens_per_task": payload.get("generated_tokens_per_task"),
                         "rollout_tokens_per_second": payload.get("rollout_tokens_per_second"),
                     }

--- a/src/miniverl/reporting/markdown.py
+++ b/src/miniverl/reporting/markdown.py
@@ -60,17 +60,20 @@ def render_markdown(data: ReportData) -> str:
         "",
         "## Results",
         "",
-        "| checkpoint | step | tasks | success | avg turns | invalid calls | gen tokens/task |",
-        "| --- | --- | --- | --- | --- | --- | --- |",
+        "| checkpoint | step | tasks | success | avg turns | parse-valid calls | "
+        "execution success | gen tokens/task |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- |",
     ]
     for row in data.baseline_comparison():
         lines.append(
             f"| {row['label']} | {row['global_step']} | {row['tasks']} | "
             f"{_pct(row['success_rate'])} | {_num(row['avg_turns'], 2)} | "
-            f"{_pct(row['invalid_tool_call_rate'])} | {_num(row['generated_tokens_per_task'], 1)} |"
+            f"{_pct(row['parse_valid_tool_call_rate'])} | "
+            f"{_pct(row['tool_execution_success_rate'])} | "
+            f"{_num(row['generated_tokens_per_task'], 1)} |"
         )
     if not data.baseline_comparison():
-        lines.append("| _no evaluation recorded_ | | | | | | |")
+        lines.append("| _no evaluation recorded_ | | | | | | | |")
 
     lines += [
         "",

--- a/src/miniverl/reporting/templates/report.html.j2
+++ b/src/miniverl/reporting/templates/report.html.j2
@@ -87,7 +87,8 @@ footer { margin-top: 48px; padding-top: 14px; border-top: 1px solid var(--line);
 <table>
   <thead><tr>
     <th>checkpoint</th><th class="num">step</th><th class="num">policy v</th><th class="num">tasks</th>
-    <th class="num">success</th><th class="num">avg turns</th><th class="num">invalid calls</th>
+    <th class="num">success</th><th class="num">avg turns</th><th class="num">parse-valid calls</th>
+    <th class="num">execution success</th>
     <th class="num">gen tokens/task</th><th class="num">rollout tok/s</th>
   </tr></thead>
   <tbody>
@@ -99,7 +100,8 @@ footer { margin-top: 48px; padding-top: 14px; border-top: 1px solid var(--line);
       <td class="num">{{ row.tasks }}</td>
       <td class="num">{{ pct(row.success_rate) }}</td>
       <td class="num">{{ num(row.avg_turns, 2) }}</td>
-      <td class="num">{{ pct(row.invalid_tool_call_rate) }}</td>
+      <td class="num">{{ pct(row.parse_valid_tool_call_rate) }}</td>
+      <td class="num">{{ pct(row.tool_execution_success_rate) }}</td>
       <td class="num">{{ num(row.generated_tokens_per_task, 1) }}</td>
       <td class="num">{{ num(row.rollout_tokens_per_second, 1) }}</td>
     </tr>

--- a/src/miniverl/schemas/cache.py
+++ b/src/miniverl/schemas/cache.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 __all__ = [
     "CACHE_SCHEMA_VERSION",
+    "READABLE_CACHE_SCHEMA_VERSIONS",
     "CacheEntryMeta",
     "CacheShardMeta",
     "CacheIndex",
@@ -21,7 +22,8 @@ __all__ = [
     "CacheCompressionStats",
 ]
 
-CACHE_SCHEMA_VERSION = 1
+CACHE_SCHEMA_VERSION = 2
+READABLE_CACHE_SCHEMA_VERSIONS = frozenset({1, CACHE_SCHEMA_VERSION})
 
 
 class CacheEntryMeta(BaseModel):
@@ -42,6 +44,7 @@ class CacheEntryMeta(BaseModel):
     tensor_keys: list[str]
     checksum: str
     selected_span_types: dict[str, int] = Field(default_factory=dict)
+    ordered_span_types: list[str] | None = None
 
 
 class CacheShardMeta(BaseModel):
@@ -65,6 +68,8 @@ class CacheIndex(BaseModel):
     teacher_model_id: str
     teacher_model_revision: str | None = None
     tokenizer_fingerprint: str
+    tokenizer_identity: dict[str, Any] = Field(default_factory=dict)
+    teacher_adapter_provenance: dict[str, Any] | None = None
     vocab_size: int = Field(gt=0)
     top_k: int = Field(ge=1)
     temperature: float = Field(gt=0.0)
@@ -75,6 +80,8 @@ class CacheIndex(BaseModel):
 
     @model_validator(mode="after")
     def _validate(self) -> CacheIndex:
+        if self.schema_version not in READABLE_CACHE_SCHEMA_VERSIONS:
+            raise ValueError(f"unsupported cache schema_version {self.schema_version}")
         if self.top_k > self.vocab_size:
             raise ValueError(f"top_k={self.top_k} exceeds vocab_size={self.vocab_size}")
         for traj_id, entry in self.entries.items():

--- a/src/miniverl/schemas/trajectory.py
+++ b/src/miniverl/schemas/trajectory.py
@@ -200,6 +200,17 @@ class Trajectory(BaseModel):
     termination_reason: TerminationReason
     generated_token_count: int = Field(ge=0, default=0)
     invalid_tool_calls: int = Field(ge=0, default=0)
+    assistant_turns: int | None = Field(default=None, ge=0)
+    emitted_tool_calls: int | None = Field(default=None, ge=0)
+    parsed_tool_calls: int | None = Field(default=None, ge=0)
+    tool_execution_successes: int | None = Field(default=None, ge=0)
+    tool_execution_errors: int | None = Field(default=None, ge=0)
+    unknown_tool_calls: int | None = Field(default=None, ge=0)
+    parse_errors: int | None = Field(default=None, ge=0)
+    repeated_call_terminations: int | None = Field(default=None, ge=0)
+    final_answers_emitted: int | None = Field(default=None, ge=0)
+    final_answers_format_valid: int | None = Field(default=None, ge=0)
+    final_answers_verified: int | None = Field(default=None, ge=0)
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     # -- validation ----------------------------------------------------

--- a/src/miniverl/training/__init__.py
+++ b/src/miniverl/training/__init__.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from miniverl.training.checkpoint import CheckpointState, load_checkpoint, save_checkpoint
+from miniverl.training.checkpoint import (
+    CheckpointState,
+    ValidatedCheckpoint,
+    latest_checkpoint,
+    load_checkpoint,
+    save_checkpoint,
+    validate_checkpoint,
+)
 from miniverl.training.memory import MemoryPlan, resolve_strategy, run_with_oom_retry
 from miniverl.training.optim import LearningRateSchedule, build_optimizer
 from miniverl.training.trainer import OPDTrainer, TrainResult, TrainSample
@@ -15,8 +22,11 @@ __all__ = [
     "resolve_strategy",
     "run_with_oom_retry",
     "CheckpointState",
+    "ValidatedCheckpoint",
     "save_checkpoint",
     "load_checkpoint",
+    "validate_checkpoint",
+    "latest_checkpoint",
     "LearningRateSchedule",
     "build_optimizer",
 ]

--- a/src/miniverl/training/checkpoint.py
+++ b/src/miniverl/training/checkpoint.py
@@ -1,41 +1,43 @@
-"""Pickle-free checkpointing and resume.
+"""Pickle-free, checksummed and atomic checkpointing.
 
-A checkpoint directory holds three files::
-
-    checkpoints/step-000012/
-      adapter.safetensors      # trainable weights only
-      optimizer.safetensors    # optimizer moment tensors
-      state.json               # everything that is not a tensor
-
-Tensors go through safetensors and structure goes through JSON, so loading a
-checkpoint cannot execute code.  ``torch.save`` is never used.
-
-What is restored
-----------------
-Trainable weights, optimizer moments and hyper-parameter groups, the LR
-scheduler, the gradient scaler, the global step, the policy version, the task
-sampler position and every RNG state.  ``tests/integration/test_resume.py``
-runs the same schedule with and without an interruption and asserts the final
-parameters match bit-for-bit.
+A complete checkpoint contains trainable weights, JSON training state and a
+manifest written last. Optimizer tensors are optional because an optimizer may
+not have accumulated moments yet. New checkpoints are checksummed; v0.2
+checkpoints without a manifest remain readable and are explicitly reported as
+``legacy_unchecksummed``.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
+import shutil
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from miniverl.errors import CheckpointError
-from miniverl.utils.runs import write_text
+from miniverl.utils.runs import canonical_json, utc_now, write_text
 from miniverl.utils.seeding import RngSnapshot
 
-__all__ = ["CheckpointState", "save_checkpoint", "load_checkpoint", "list_checkpoints"]
+__all__ = [
+    "CheckpointState",
+    "ValidatedCheckpoint",
+    "latest_checkpoint",
+    "list_checkpoints",
+    "load_checkpoint",
+    "save_checkpoint",
+    "validate_checkpoint",
+]
 
 _ADAPTER = "adapter.safetensors"
 _OPTIMIZER = "optimizer.safetensors"
 _STATE = "state.json"
+_MANIFEST = "checkpoint.json"
 CHECKPOINT_SCHEMA_VERSION = 1
+CHECKPOINT_MANIFEST_SCHEMA_VERSION = 1
 
 
 @dataclass
@@ -46,7 +48,12 @@ class CheckpointState:
     miniverl_version: str = ""
     global_step: int = 0
     policy_version: int = 0
+    # Explicit name used by v0.2.1+. ``policy_version`` remains the
+    # backward-compatible serialized alias.
+    parameter_version: int | None = None
     cycle: int = 0
+    rollout_iteration: int | None = None
+    rollout_policy_version: int | None = None
     task_cursor: int = 0
     scheduler: dict[str, Any] = field(default_factory=dict)
     scaler: dict[str, Any] | None = None
@@ -55,16 +62,29 @@ class CheckpointState:
     optimizer_scalars: dict[str, Any] = field(default_factory=dict)
     rng: dict[str, Any] = field(default_factory=dict)
     config_digest: str = ""
+    resolved_config_digest: str = ""
+    offline_dataset_digest: str = ""
     metrics: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        """JSON-friendly view."""
+        """Return a JSON-friendly view."""
         return {
             "schema_version": self.schema_version,
             "miniverl_version": self.miniverl_version,
             "global_step": self.global_step,
             "policy_version": self.policy_version,
+            "parameter_version": (
+                self.policy_version if self.parameter_version is None else self.parameter_version
+            ),
             "cycle": self.cycle,
+            "rollout_iteration": (
+                self.cycle if self.rollout_iteration is None else self.rollout_iteration
+            ),
+            "rollout_policy_version": (
+                self.policy_version
+                if self.rollout_policy_version is None
+                else self.rollout_policy_version
+            ),
             "task_cursor": self.task_cursor,
             "scheduler": self.scheduler,
             "scaler": self.scaler,
@@ -73,19 +93,37 @@ class CheckpointState:
             "optimizer_scalars": self.optimizer_scalars,
             "rng": self.rng,
             "config_digest": self.config_digest,
+            "resolved_config_digest": self.resolved_config_digest,
+            "offline_dataset_digest": self.offline_dataset_digest,
             "metrics": self.metrics,
         }
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> CheckpointState:
-        """Rebuild from :meth:`to_dict` output."""
+        """Rebuild from :meth:`to_dict` output, including v0.2 state files."""
         version = payload.get("schema_version")
         if version != CHECKPOINT_SCHEMA_VERSION:
             raise CheckpointError(
                 f"checkpoint schema_version {version!r} is not readable by this build "
                 f"(expected {CHECKPOINT_SCHEMA_VERSION})"
             )
+        fields = cls.__dataclass_fields__
+        unknown = sorted(set(payload).difference(fields))
+        if unknown:
+            raise CheckpointError(f"checkpoint state has unknown fields: {', '.join(unknown)}")
         return cls(**payload)
+
+
+@dataclass(frozen=True)
+class ValidatedCheckpoint:
+    """Validated checkpoint metadata, before any model state is mutated."""
+
+    path: Path
+    state: CheckpointState
+    integrity: str
+    content_digest: str
+    identity: dict[str, Any] = field(default_factory=dict)
+    manifest: dict[str, Any] | None = None
 
 
 def _split_optimizer_state(
@@ -94,6 +132,8 @@ def _split_optimizer_state(
     """Separate an optimizer state dict into tensors, groups and scalars."""
     import torch
 
+    if optimizer is None:
+        return {}, [], {}, []
     state = optimizer.state_dict()
     tensors: dict[str, Any] = {}
     scalars: dict[str, Any] = {}
@@ -106,7 +146,7 @@ def _split_optimizer_state(
                 tensors[key] = value.detach().to("cpu").contiguous()
             else:
                 scalars[key] = value
-    groups = [dict(g) for g in state.get("param_groups", [])]
+    groups = [dict(group) for group in state.get("param_groups", [])]
     return tensors, groups, scalars, keys
 
 
@@ -116,6 +156,10 @@ def _rebuild_optimizer_state(
     keys: list[str],
     groups: list[dict[str, Any]],
 ) -> dict[str, Any]:
+    groups = [dict(group) for group in groups]
+    for group in groups:
+        if isinstance(group.get("betas"), list):
+            group["betas"] = tuple(group["betas"])
     state: dict[int, dict[str, Any]] = {}
     for key in keys:
         param_id_text, name = key.split("|", 1)
@@ -130,6 +174,62 @@ def _rebuild_optimizer_state(
     return {"state": state, "param_groups": groups}
 
 
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _file_record(path: Path) -> dict[str, Any]:
+    return {"bytes": path.stat().st_size, "sha256": _sha256_file(path)}
+
+
+def _content_digest(
+    *,
+    state: CheckpointState,
+    files: dict[str, dict[str, Any]],
+    identity: dict[str, Any],
+) -> str:
+    payload = {
+        "state": state.to_dict(),
+        "files": files,
+        "identity": identity,
+    }
+    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def _sync_file(path: Path) -> None:
+    try:
+        with path.open("rb") as handle:
+            os.fsync(handle.fileno())
+    except OSError:
+        # Some Windows/OneDrive filesystem combinations reject fsync on a
+        # read-only descriptor. The manifest-last + sibling-directory swap
+        # still prevents a partial checkpoint from becoming discoverable.
+        if os.name != "nt":
+            raise
+
+
+def _replace_directory_atomically(source: Path, target: Path) -> None:
+    """Swap a complete sibling directory into place, restoring on failure."""
+    backup: Path | None = None
+    if target.exists():
+        if not target.is_dir() or target.is_symlink():
+            raise CheckpointError(f"checkpoint target is not a safe directory: {target}")
+        backup = target.with_name(f".{target.name}.backup-{uuid.uuid4().hex}")
+        target.replace(backup)
+    try:
+        source.replace(target)
+    except Exception:
+        if backup is not None and backup.exists() and not target.exists():
+            backup.replace(target)
+        raise
+    if backup is not None:
+        shutil.rmtree(backup)
+
+
 def save_checkpoint(
     directory: str | Path,
     *,
@@ -137,31 +237,194 @@ def save_checkpoint(
     optimizer: Any,
     state: CheckpointState,
     rng: RngSnapshot,
+    identity: dict[str, Any] | None = None,
 ) -> Path:
-    """Write a complete, resumable checkpoint."""
+    """Write a complete checkpoint to a sibling temporary directory, then swap."""
     from safetensors.torch import save_file
 
     target = Path(directory)
-    target.mkdir(parents=True, exist_ok=True)
-
-    if trainable_state:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary = target.with_name(f".{target.name}.tmp-{uuid.uuid4().hex}")
+    temporary.mkdir()
+    checkpoint_identity = dict(identity or {})
+    try:
+        if not trainable_state:
+            raise CheckpointError(
+                "cannot save a checkpoint without trainable weights",
+                hint="verify that the student exposes a non-empty trainable_state_dict",
+            )
         save_file(
-            {k: v.contiguous() for k, v in trainable_state.items()},
-            str(target / _ADAPTER),
+            {key: value.detach().to("cpu").contiguous() for key, value in trainable_state.items()},
+            str(temporary / _ADAPTER),
             metadata={"miniverl": "adapter"},
         )
-    tensors, groups, scalars, keys = _split_optimizer_state(optimizer)
-    if tensors:
-        save_file(tensors, str(target / _OPTIMIZER), metadata={"miniverl": "optimizer"})
-    state.optimizer_param_groups = groups
-    state.optimizer_scalars = {k: _jsonable(v) for k, v in scalars.items()}
-    state.optimizer_state_keys = keys
-    state.rng = rng.to_dict()
-    write_text(
-        target / _STATE,
-        json.dumps(state.to_dict(), indent=2, sort_keys=True, default=_jsonable) + "\n",
-    )
+        tensors, groups, scalars, keys = _split_optimizer_state(optimizer)
+        if tensors:
+            save_file(
+                tensors,
+                str(temporary / _OPTIMIZER),
+                metadata={"miniverl": "optimizer"},
+            )
+        state.optimizer_param_groups = groups
+        state.optimizer_scalars = {key: _jsonable(value) for key, value in scalars.items()}
+        state.optimizer_state_keys = keys
+        state.rng = rng.to_dict()
+        write_text(
+            temporary / _STATE,
+            json.dumps(state.to_dict(), indent=2, sort_keys=True, default=_jsonable) + "\n",
+        )
+
+        files = {
+            path.name: _file_record(path) for path in sorted(temporary.iterdir()) if path.is_file()
+        }
+        manifest = {
+            "schema_version": CHECKPOINT_MANIFEST_SCHEMA_VERSION,
+            "complete": True,
+            "created_at": utc_now(),
+            "miniverl_version": state.miniverl_version,
+            "global_step": state.global_step,
+            "policy_version": state.policy_version,
+            "parameter_version": (
+                state.policy_version if state.parameter_version is None else state.parameter_version
+            ),
+            "rollout_iteration": (
+                state.cycle if state.rollout_iteration is None else state.rollout_iteration
+            ),
+            "rollout_policy_version": (
+                state.policy_version
+                if state.rollout_policy_version is None
+                else state.rollout_policy_version
+            ),
+            "config_digest": state.config_digest,
+            "resolved_config_digest": state.resolved_config_digest,
+            "offline_dataset_digest": state.offline_dataset_digest,
+            "identity": checkpoint_identity,
+            "files": files,
+            "content_digest": _content_digest(
+                state=state,
+                files=files,
+                identity=checkpoint_identity,
+            ),
+        }
+        write_text(
+            temporary / _MANIFEST,
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        )
+        for path in temporary.iterdir():
+            if path.is_file():
+                _sync_file(path)
+        validate_checkpoint(temporary)
+        _replace_directory_atomically(temporary, target)
+    except Exception:
+        if temporary.exists():
+            shutil.rmtree(temporary)
+        raise
     return target
+
+
+def validate_checkpoint(directory: str | Path) -> ValidatedCheckpoint:
+    """Validate completeness and checksums without mutating a backend."""
+    target = Path(directory)
+    if not target.is_dir():
+        raise CheckpointError(f"checkpoint directory not found: {target}")
+    state_path = target / _STATE
+    if not state_path.is_file():
+        raise CheckpointError(
+            f"{target} is not a miniVERL checkpoint (missing {_STATE})",
+            hint="pass a directory such as runs/<run-id>/checkpoints/step-000010",
+        )
+    try:
+        state_payload = json.loads(state_path.read_text(encoding="utf-8"))
+        state = CheckpointState.from_dict(state_payload)
+    except CheckpointError:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError, TypeError) as exc:
+        raise CheckpointError(f"cannot read checkpoint state {state_path}: {exc}") from exc
+
+    adapter_path = target / _ADAPTER
+    if not adapter_path.is_file():
+        raise CheckpointError(f"checkpoint is incomplete (missing {_ADAPTER}): {target}")
+
+    manifest_path = target / _MANIFEST
+    if not manifest_path.is_file():
+        files = {
+            path.name: _file_record(path) for path in sorted(target.iterdir()) if path.is_file()
+        }
+        return ValidatedCheckpoint(
+            path=target,
+            state=state,
+            integrity="legacy_unchecksummed",
+            content_digest=_content_digest(state=state, files=files, identity={}),
+        )
+
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError, TypeError) as exc:
+        raise CheckpointError(f"cannot read checkpoint manifest {manifest_path}: {exc}") from exc
+    if manifest.get("schema_version") != CHECKPOINT_MANIFEST_SCHEMA_VERSION:
+        raise CheckpointError(
+            f"checkpoint manifest schema_version {manifest.get('schema_version')!r} "
+            f"is not readable (expected {CHECKPOINT_MANIFEST_SCHEMA_VERSION})"
+        )
+    if manifest.get("complete") is not True:
+        raise CheckpointError(f"checkpoint manifest is not marked complete: {target}")
+    files = manifest.get("files")
+    if not isinstance(files, dict):
+        raise CheckpointError(f"checkpoint manifest has no valid files table: {target}")
+    for required in (_ADAPTER, _STATE):
+        if required not in files:
+            raise CheckpointError(
+                f"checkpoint manifest is incomplete (missing {required}): {target}"
+            )
+    for name, expected in files.items():
+        path = target / name
+        if not isinstance(name, str) or Path(name).name != name or not isinstance(expected, dict):
+            raise CheckpointError(f"checkpoint manifest contains an unsafe file entry: {name!r}")
+        if not path.is_file():
+            raise CheckpointError(f"checkpoint file listed in manifest is missing: {name}")
+        actual_bytes = path.stat().st_size
+        expected_bytes = expected.get("bytes")
+        if actual_bytes != expected_bytes:
+            raise CheckpointError(
+                f"checkpoint checksum validation failed for {name}: "
+                f"size {actual_bytes} != {expected_bytes}"
+            )
+        actual_sha256 = _sha256_file(path)
+        if actual_sha256 != expected.get("sha256"):
+            raise CheckpointError(f"checkpoint checksum validation failed for {name}")
+    if manifest.get("global_step") != state.global_step:
+        raise CheckpointError("checkpoint manifest and state disagree on global_step")
+    if manifest.get("policy_version") != state.policy_version:
+        raise CheckpointError("checkpoint manifest and state disagree on policy_version")
+    parameter_version = (
+        state.policy_version if state.parameter_version is None else state.parameter_version
+    )
+    if manifest.get("parameter_version", parameter_version) != parameter_version:
+        raise CheckpointError("checkpoint manifest and state disagree on parameter_version")
+    rollout_iteration = state.cycle if state.rollout_iteration is None else state.rollout_iteration
+    if manifest.get("rollout_iteration", rollout_iteration) != rollout_iteration:
+        raise CheckpointError("checkpoint manifest and state disagree on rollout_iteration")
+    rollout_policy_version = (
+        state.policy_version
+        if state.rollout_policy_version is None
+        else state.rollout_policy_version
+    )
+    if manifest.get("rollout_policy_version", rollout_policy_version) != rollout_policy_version:
+        raise CheckpointError("checkpoint manifest and state disagree on rollout_policy_version")
+    identity = manifest.get("identity", {})
+    if not isinstance(identity, dict):
+        raise CheckpointError("checkpoint manifest identity must be an object")
+    actual_digest = _content_digest(state=state, files=files, identity=identity)
+    if actual_digest != manifest.get("content_digest"):
+        raise CheckpointError("checkpoint manifest content checksum is inconsistent")
+    return ValidatedCheckpoint(
+        path=target,
+        state=state,
+        integrity="checksummed_v1",
+        content_digest=actual_digest,
+        identity=identity,
+        manifest=manifest,
+    )
 
 
 def load_checkpoint(
@@ -172,60 +435,103 @@ def load_checkpoint(
     device: str = "cpu",
     include_optimizer: bool = True,
     include_rng: bool = True,
+    expected_config_digest: str | None = None,
+    expected_identity: dict[str, Any] | None = None,
 ) -> CheckpointState:
-    """Restore weights, optimizer state and RNG from a checkpoint directory.
-
-    ``include_optimizer=False`` loads *weights only*.  The benchmark harness
-    uses that so every arm starts from identical parameters without inheriting
-    the cold start's Adam momentum, which would otherwise advantage whichever
-    arm most resembles the cold start.
-    """
+    """Validate fully, then restore weights and optional optimizer/RNG state."""
     from safetensors.torch import load_file
 
     from miniverl.utils.seeding import restore_rng
 
-    target = Path(directory)
-    state_path = target / _STATE
-    if not state_path.is_file():
+    validated = validate_checkpoint(directory)
+    state = validated.state
+    if expected_config_digest and state.config_digest != expected_config_digest:
         raise CheckpointError(
-            f"{target} is not a miniVERL checkpoint (missing {_STATE})",
-            hint="pass a directory such as runs/<run-id>/checkpoints/step-000010",
+            "the checkpoint was written by a different configuration",
+            hint="resume with the original config.resolved.yaml",
         )
-    state = CheckpointState.from_dict(json.loads(state_path.read_text(encoding="utf-8")))
+    if expected_identity:
+        mismatches = {
+            key: (validated.identity.get(key), value)
+            for key, value in expected_identity.items()
+            if validated.identity.get(key) != value
+        }
+        if mismatches:
+            details = ", ".join(
+                f"{key}: checkpoint={actual!r}, current={expected!r}"
+                for key, (actual, expected) in sorted(mismatches.items())
+            )
+            raise CheckpointError(f"checkpoint identity mismatch ({details})")
 
-    adapter_path = target / _ADAPTER
-    if adapter_path.is_file():
-        backend.load_trainable_state_dict(load_file(str(adapter_path), device=device))
-
+    target = validated.path
+    adapter = load_file(str(target / _ADAPTER), device=device)
+    optimizer_state: dict[str, Any] | None = None
     if include_optimizer:
+        if optimizer is None:
+            raise CheckpointError(
+                "optimizer restoration was requested but no optimizer was provided"
+            )
         optimizer_path = target / _OPTIMIZER
         tensors = load_file(str(optimizer_path), device=device) if optimizer_path.is_file() else {}
         if state.optimizer_state_keys:
-            optimizer.load_state_dict(
-                _rebuild_optimizer_state(
-                    tensors,
-                    state.optimizer_scalars,
-                    state.optimizer_state_keys,
-                    state.optimizer_param_groups,
-                )
+            optimizer_state = _rebuild_optimizer_state(
+                tensors,
+                state.optimizer_scalars,
+                state.optimizer_state_keys,
+                state.optimizer_param_groups,
             )
+
+    backend.load_trainable_state_dict(adapter)
+    if optimizer_state is not None:
+        optimizer.load_state_dict(optimizer_state)
     if include_rng and state.rng:
         restore_rng(RngSnapshot.from_dict(state.rng))
     return state
 
 
 def list_checkpoints(directory: str | Path) -> list[Path]:
-    """Sorted checkpoint directories under ``directory``."""
+    """Return valid checkpoint directories sorted by state step, then name."""
     root = Path(directory)
     if not root.is_dir():
         return []
-    return sorted(p for p in root.iterdir() if p.is_dir() and (p / _STATE).is_file())
+    validated: list[ValidatedCheckpoint] = []
+    for path in root.iterdir():
+        if not path.is_dir() or path.name.startswith(".") or ".tmp-" in path.name:
+            continue
+        if not (path / _STATE).is_file():
+            continue
+        validated.append(validate_checkpoint(path))
+    return [
+        item.path
+        for item in sorted(validated, key=lambda item: (item.state.global_step, item.path.name))
+    ]
 
 
 def latest_checkpoint(directory: str | Path) -> Path | None:
-    """Most recent checkpoint, or ``None``."""
-    entries = list_checkpoints(directory)
-    return entries[-1] if entries else None
+    """Select the unique highest state step, preferring ``final`` for duplicates."""
+    root = Path(directory)
+    if not root.is_dir():
+        return None
+    candidates: list[ValidatedCheckpoint] = []
+    for path in root.iterdir():
+        if not path.is_dir() or path.name.startswith(".") or ".tmp-" in path.name:
+            continue
+        if not (path / _STATE).is_file():
+            continue
+        candidates.append(validate_checkpoint(path))
+    if not candidates:
+        return None
+    highest_step = max(item.state.global_step for item in candidates)
+    highest = [item for item in candidates if item.state.global_step == highest_step]
+    digests = {item.content_digest for item in highest}
+    if len(digests) > 1:
+        names = ", ".join(sorted(item.path.name for item in highest))
+        raise CheckpointError(
+            f"ambiguous checkpoints at step {highest_step}: {names}",
+            hint="select the intended directory explicitly with --resume-from",
+        )
+    final = next((item.path for item in highest if item.path.name == "final"), None)
+    return final or sorted((item.path for item in highest), key=lambda path: path.name)[-1]
 
 
 def _jsonable(value: Any) -> Any:
@@ -236,5 +542,5 @@ def _jsonable(value: Any) -> Any:
         except Exception:  # pragma: no cover - defensive
             return str(value)
     if isinstance(value, (list, tuple)):
-        return [_jsonable(v) for v in value]
+        return [_jsonable(item) for item in value]
     return value

--- a/src/miniverl/training/offline_dataset.py
+++ b/src/miniverl/training/offline_dataset.py
@@ -1,0 +1,166 @@
+"""Content-addressed fixed dataset artifacts for exact offline-KD resume."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING, Any
+
+from miniverl.cache.store import TeacherCache, sha256_file
+from miniverl.errors import CheckpointError
+from miniverl.trajectory.io import read_trajectories, write_trajectories
+from miniverl.utils.runs import canonical_json, utc_now, write_json
+
+if TYPE_CHECKING:
+    from miniverl.config.models import RunConfig
+    from miniverl.schemas.trajectory import Trajectory
+    from miniverl.training.trainer import TrainSample
+    from miniverl.utils.runs import RunPaths
+
+__all__ = ["create_offline_dataset", "load_offline_dataset"]
+
+OFFLINE_DATASET_SCHEMA_VERSION = 1
+
+
+def _digest(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def _stable_identity(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": payload["schema_version"],
+        "trajectory_ids": payload["trajectory_ids"],
+        "task_ids": payload["task_ids"],
+        "split": payload["split"],
+        "seed": payload["seed"],
+        "tokenizer_identity": payload["tokenizer_identity"],
+        "policy_version": payload["policy_version"],
+        "teacher_identity": payload["teacher_identity"],
+        "trajectory_sha256": payload["files"]["trajectories.jsonl"]["sha256"],
+        "cache_entry_checksums": payload["cache_entry_checksums"],
+        "cache_shard_checksums": payload["cache_shard_checksums"],
+        "selected_positions": payload["selected_positions"],
+        "creation_policy": payload["creation_policy"],
+        "source": payload["source"],
+    }
+
+
+def create_offline_dataset(
+    paths: RunPaths,
+    *,
+    samples: list[TrainSample],
+    cache: TeacherCache,
+    config: RunConfig,
+    tokenizer_identity: dict[str, Any],
+    teacher_identity: dict[str, Any],
+) -> str:
+    """Persist the fixed ordered trajectories and a checksummed manifest once."""
+    root = paths.offline_dataset
+    if paths.offline_dataset_manifest.exists():
+        raise CheckpointError(
+            f"offline dataset already exists at {root}",
+            hint="resume and validate the existing dataset instead of regenerating it",
+        )
+    root.mkdir(parents=True, exist_ok=False)
+    trajectories = [sample.trajectory for sample in samples]
+    write_trajectories(paths.offline_dataset_trajectories, trajectories)
+    trajectory_sha, trajectory_size = sha256_file(paths.offline_dataset_trajectories)
+    cache_index = cache.path / "index.json"
+    cache_sha, cache_size = sha256_file(cache_index)
+    payload: dict[str, Any] = {
+        "schema_version": OFFLINE_DATASET_SCHEMA_VERSION,
+        "created_at": utc_now(),
+        "trajectory_ids": [trajectory.trajectory_id for trajectory in trajectories],
+        "task_ids": [trajectory.task_id for trajectory in trajectories],
+        "split": "train",
+        "seed": config.run.seed,
+        "tokenizer_identity": tokenizer_identity,
+        "policy_version": trajectories[0].policy_version if trajectories else 0,
+        "teacher_identity": teacher_identity,
+        "cache_index_digest": cache_sha,
+        "cache_entry_checksums": {
+            trajectory_id: entry.checksum
+            for trajectory_id, entry in sorted(cache.index.entries.items())
+        },
+        "cache_shard_checksums": {
+            name: shard.sha256 for name, shard in sorted(cache.index.shards.items())
+        },
+        "files": {
+            "trajectories.jsonl": {
+                "sha256": trajectory_sha,
+                "bytes": trajectory_size,
+            },
+            "teacher-cache/index.json": {
+                "sha256": cache_sha,
+                "bytes": cache_size,
+            },
+        },
+        "selected_positions": [
+            {
+                "trajectory_id": sample.trajectory.trajectory_id,
+                "count": len(sample.alignment.student_prediction_positions),
+                "positions": list(sample.alignment.student_prediction_positions),
+            }
+            for sample in samples
+        ],
+        "creation_policy": "create_once_then_validate",
+        "source": "environment_oracle",
+    }
+    payload["dataset_digest"] = _digest(_stable_identity(payload))
+    write_json(paths.offline_dataset_manifest, payload)
+    return str(payload["dataset_digest"])
+
+
+def load_offline_dataset(
+    paths: RunPaths,
+    *,
+    cache: TeacherCache,
+    expected_digest: str,
+) -> tuple[dict[str, Any], list[Trajectory]]:
+    """Validate every persisted file and return trajectories in manifest order."""
+    manifest_path = paths.offline_dataset_manifest
+    if not manifest_path.is_file():
+        raise CheckpointError(
+            f"offline-KD checkpoint requires the persisted dataset at {manifest_path}"
+        )
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise CheckpointError(f"cannot read offline dataset manifest: {exc}") from exc
+    if payload.get("schema_version") != OFFLINE_DATASET_SCHEMA_VERSION:
+        raise CheckpointError(
+            f"offline dataset schema_version {payload.get('schema_version')!r} is not readable"
+        )
+    actual_digest = _digest(_stable_identity(payload))
+    recorded_digest = payload.get("dataset_digest")
+    if actual_digest != recorded_digest or (expected_digest and actual_digest != expected_digest):
+        raise CheckpointError("offline dataset digest does not match its checkpoint")
+
+    files = payload.get("files", {})
+    for name, path in (
+        ("trajectories.jsonl", paths.offline_dataset_trajectories),
+        ("teacher-cache/index.json", cache.path / "index.json"),
+    ):
+        expected = files.get(name, {})
+        actual_sha, actual_size = sha256_file(path)
+        if actual_sha != expected.get("sha256") or actual_size != expected.get("bytes"):
+            raise CheckpointError(f"offline dataset file checksum mismatch: {name}")
+    if payload.get("cache_index_digest") != files["teacher-cache/index.json"]["sha256"]:
+        raise CheckpointError("offline dataset cache index digest is inconsistent")
+    if payload.get("cache_entry_checksums") != {
+        trajectory_id: entry.checksum
+        for trajectory_id, entry in sorted(cache.index.entries.items())
+    }:
+        raise CheckpointError("offline dataset cache entry checksums changed")
+    if payload.get("cache_shard_checksums") != {
+        name: shard.sha256 for name, shard in sorted(cache.index.shards.items())
+    }:
+        raise CheckpointError("offline dataset cache shard checksums changed")
+
+    trajectories = read_trajectories(paths.offline_dataset_trajectories)
+    trajectory_ids = [trajectory.trajectory_id for trajectory in trajectories]
+    if trajectory_ids != payload.get("trajectory_ids"):
+        raise CheckpointError("offline dataset trajectory order does not match its manifest")
+    if [trajectory.task_id for trajectory in trajectories] != payload.get("task_ids"):
+        raise CheckpointError("offline dataset task order does not match its manifest")
+    return payload, trajectories

--- a/src/miniverl/training/trainer.py
+++ b/src/miniverl/training/trainer.py
@@ -44,7 +44,14 @@ from miniverl.config.models import (
 )
 from miniverl.environments.base import Task, ToolEnvironment, make_splits
 from miniverl.environments.registry import make_environment
-from miniverl.errors import ConfigError, LifecycleError, MiniVerlError
+from miniverl.errors import (
+    BackendError,
+    CheckpointError,
+    ConfigError,
+    GpuMemoryError,
+    LifecycleError,
+    MiniVerlError,
+)
 from miniverl.models.factory import build_student, build_teacher, build_tokenizer, resolve_device
 from miniverl.schemas.alignment import AlignmentMap
 from miniverl.schemas.trajectory import Trajectory
@@ -66,8 +73,16 @@ from miniverl.trajectory.io import append_trajectories
 from miniverl.utils import gpu
 from miniverl.utils.env import collect_environment
 from miniverl.utils.logging import EventLog, get_logger
-from miniverl.utils.runs import JsonlWriter, RunPaths, make_run_id, utc_now, write_json, write_text
-from miniverl.utils.seeding import capture_rng, seed_everything
+from miniverl.utils.runs import (
+    JsonlWriter,
+    RunPaths,
+    make_run_id,
+    utc_now,
+    write_json,
+    write_json_atomic,
+    write_text,
+)
+from miniverl.utils.seeding import capture_rng, restore_rng, seed_everything
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from miniverl.teachers.base import TeacherScoreResult
@@ -97,6 +112,8 @@ class TrainResult:
     cycles_completed: int
     global_step: int
     policy_version: int
+    parameter_version: int
+    rollout_policy_version: int
     duration_seconds: float
     final_metrics: dict[str, Any] = field(default_factory=dict)
     eval: dict[str, Any] | None = None
@@ -110,7 +127,11 @@ class TrainResult:
             "mode": self.mode,
             "cycles_completed": self.cycles_completed,
             "global_step": self.global_step,
+            "global_optimizer_step": self.global_step,
             "policy_version": self.policy_version,
+            "parameter_version": self.parameter_version,
+            "rollout_policy_version": self.rollout_policy_version,
+            "rollout_iteration": self.cycles_completed,
             "duration_seconds": round(self.duration_seconds, 3),
             "final_metrics": self.final_metrics,
             "eval": self.eval,
@@ -133,6 +154,7 @@ class OPDTrainer:
         student: Any,
         teacher: Any | None,
         plan: MemoryPlan,
+        evaluation_only: bool = False,
     ) -> None:
         self._closed = False
         self.config = config
@@ -144,6 +166,16 @@ class OPDTrainer:
         self.student = student
         self.teacher = teacher
         self.plan = plan
+        self._started_at = utc_now()
+        if paths.manifest_start.is_file():
+            try:
+                import json
+
+                self._started_at = json.loads(paths.manifest_start.read_text(encoding="utf-8")).get(
+                    "started_at", self._started_at
+                )
+            except (OSError, UnicodeError, ValueError):
+                pass
 
         self.metrics_log = JsonlWriter(paths.metrics)
         self.events = EventLog(JsonlWriter(paths.events))
@@ -157,12 +189,19 @@ class OPDTrainer:
             self.scorer: Any = LocalTeacherScorer(
                 teacher,
                 config.loss,
-                keep_exact_resident=plan.strategy is MemoryStrategy.RESIDENT,
+                keep_exact_resident=(
+                    plan.strategy is MemoryStrategy.RESIDENT
+                    and config.run.mode is not TrainingMode.OFFLINE_KD
+                ),
                 device=plan.device,
             )
         else:
             self.scorer = None
-        self.optimizer = build_optimizer(student.trainable_parameters(), config.train)
+        self.optimizer = (
+            None
+            if evaluation_only
+            else build_optimizer(student.trainable_parameters(), config.train)
+        )
         steps_per_cycle = self.optimizer_steps_per_cycle
         total_steps = max(
             1,
@@ -175,17 +214,21 @@ class OPDTrainer:
             total_steps=total_steps,
         )
         self.global_step = 0
-        self.policy_version = 0
+        self.parameter_version = 0
         self.cycle = 0
+        self._last_rollout_policy_version = 0
         self.task_cursor = 0
         self._task_order = self._build_task_order()
         self._cache: TeacherCache | None = None
         self._offline_samples: list[TrainSample] | None = None
+        self.offline_dataset_digest = ""
         self._teacher_on_device = teacher is not None and plan.strategy is MemoryStrategy.RESIDENT
         #: First cycle `train()` will execute. Set by `load_from_checkpoint` so a
         #: resumed run continues instead of redoing completed cycles.
         self._start_cycle = 0
         self._resumed = False
+        self._resumed_from: dict[str, Any] | None = None
+        self._cycles_completed = 0
 
     # -- construction --------------------------------------------------------
 
@@ -196,6 +239,38 @@ class OPDTrainer:
         rollouts = self.config.train.rollouts_per_cycle
         return max(1, (rollouts + accum - 1) // accum)
 
+    @property
+    def policy_version(self) -> int:
+        """Deprecated alias for the exact student parameter version."""
+        return self.parameter_version
+
+    @policy_version.setter
+    def policy_version(self, value: int) -> None:
+        self.parameter_version = value
+
+    def _apply_checkpoint_progress(self, state: CheckpointState) -> None:
+        """Copy validated, non-tensor progress into this trainer.
+
+        Training resume and weights-only standalone evaluation both need the
+        evaluated model to report the checkpoint's real parameter version.
+        This helper mutates counters only; it never loads optimizer or RNG
+        state.
+        """
+        self.global_step = state.global_step
+        self.parameter_version = (
+            state.policy_version if state.parameter_version is None else state.parameter_version
+        )
+        self.cycle = state.cycle
+        self._last_rollout_policy_version = (
+            state.policy_version
+            if state.rollout_policy_version is None
+            else state.rollout_policy_version
+        )
+        self.task_cursor = state.task_cursor
+        self._cycles_completed = (
+            max(state.cycle + 1, 0) if state.rollout_iteration is None else state.rollout_iteration
+        )
+
     @classmethod
     def from_config(
         cls,
@@ -205,6 +280,10 @@ class OPDTrainer:
         run_id: str | None = None,
         local_files_only: bool = False,
         write_artifacts: bool = True,
+        overwrite: bool = False,
+        resume: str | Path | None = None,
+        resume_from: str | Path | None = None,
+        for_evaluation: bool = False,
     ) -> OPDTrainer:
         """Validate, seed, load models and create the run directory.
 
@@ -213,6 +292,21 @@ class OPDTrainer:
         evaluator uses it so re-evaluating a run cannot destroy the provenance of
         the run being evaluated.
         """
+        resume_options = int(resume is not None) + int(resume_from is not None)
+        if resume_options > 1:
+            raise ConfigError("--resume and --resume-from are mutually exclusive")
+        if overwrite and resume_options:
+            raise ConfigError("--overwrite cannot be combined with --resume or --resume-from")
+        if not write_artifacts and (overwrite or resume_options):
+            raise ConfigError(
+                "write_artifacts=False is an evaluator attachment mode and cannot resume "
+                "or overwrite a run"
+            )
+        if for_evaluation and write_artifacts:
+            raise ConfigError("for_evaluation=True requires write_artifacts=False")
+        if for_evaluation and resume_options:
+            raise ConfigError("evaluation attachment cannot use training resume options")
+
         # bitsandbytes 4-bit parameters are pinned to the device they were
         # quantized on, so a quantized model cannot be moved off the GPU and
         # back. `swap` is therefore only available for unquantized pairs.
@@ -235,8 +329,23 @@ class OPDTrainer:
 
         seed_everything(config.run.seed, deterministic=config.run.deterministic)
         resolved_id = make_run_id(config.run.name, explicit=run_id or config.run.run_id)
-        paths = RunPaths.create(output_dir or config.run.output_dir, resolved_id)
-        if write_artifacts:
+        resume_checkpoint: Path | None = None
+        if resume is not None:
+            paths = RunPaths.open(resume)
+            resolved_id = paths.root.name
+        elif resume_from is not None:
+            resume_checkpoint = Path(resume_from).resolve()
+            paths = RunPaths.open(resume_checkpoint.parent.parent)
+            resolved_id = paths.root.name
+        elif write_artifacts:
+            paths = RunPaths.create(
+                output_dir or config.run.output_dir,
+                resolved_id,
+                overwrite=overwrite,
+            )
+        else:
+            paths = RunPaths.open(Path(output_dir or config.run.output_dir) / resolved_id)
+        if write_artifacts and resume_options == 0:
             write_text(paths.config_original, config.to_yaml())
 
         environment: ToolEnvironment | None = None
@@ -278,7 +387,7 @@ class OPDTrainer:
                     "auto -> resident: a quantized model cannot be moved off the "
                     "accelerator, so swap is unavailable"
                 )
-            if config.run.mode is not TrainingMode.SFT:
+            if config.run.mode is not TrainingMode.SFT and not for_evaluation:
                 if memory_config.strategy is MemoryStrategy.AUTO and device.startswith("cuda"):
 
                     def teacher_fits() -> bool:
@@ -313,6 +422,12 @@ class OPDTrainer:
                         device=teacher_device,
                         local_files_only=local_files_only,
                     )
+                if teacher.vocab_size != student.vocab_size:
+                    raise BackendError(
+                        "student and teacher LM-head output dimensions differ "
+                        f"({student.vocab_size} vs {teacher.vocab_size})",
+                        hint="miniVERL requires a shared output vocabulary for distillation",
+                    )
 
             trainer = cls(
                 config=config,
@@ -324,9 +439,27 @@ class OPDTrainer:
                 student=student,
                 teacher=teacher,
                 plan=plan,
+                evaluation_only=for_evaluation,
             )
-            if write_artifacts:
+            if write_artifacts and resume_options == 0:
                 trainer._write_startup_artifacts()
+            elif resume_options:
+                from miniverl.training.checkpoint import latest_checkpoint
+
+                selected = resume_checkpoint or latest_checkpoint(paths.checkpoints)
+                if selected is None:
+                    raise ConfigError(
+                        f"cannot resume {paths.root}: no valid checkpoint was found",
+                        hint="pass --resume-from <checkpoint-dir> or start a new run",
+                    )
+                state = trainer.load_from_checkpoint(selected)
+                trainer.events.emit(
+                    "resume_start",
+                    checkpoint=str(selected),
+                    previous_global_step=state.global_step,
+                    previous_policy_version=state.policy_version,
+                    next_cycle=trainer._start_cycle,
+                )
             return trainer
         except BaseException:
             # Construction owns every resource it has allocated. Teardown errors
@@ -389,7 +522,29 @@ class OPDTrainer:
             resolved.loss.top_k = min(config.loss.top_k, self.student.vocab_size)
         write_text(self.paths.config_resolved, resolved.to_yaml())
         write_json(self.paths.environment, collect_environment())
-        write_json(self.paths.manifest, self.build_manifest())
+        startup = self.build_manifest()
+        startup.update(
+            {
+                "manifest_schema_version": 2,
+                "status": "running",
+                "started_at": self._started_at,
+                "original_config_digest": hashlib.sha256(
+                    self.paths.config_original.read_bytes()
+                ).hexdigest(),
+                "resolved_config_digest": hashlib.sha256(
+                    self.paths.config_resolved.read_bytes()
+                ).hexdigest(),
+                "initial_memory": self.plan.to_dict(),
+                "global_step": 0,
+                "global_optimizer_step": 0,
+                "parameter_version": 0,
+                "policy_version": 0,
+                "rollout_iteration": 0,
+                "rollout_policy_version": 0,
+            }
+        )
+        write_json_atomic(self.paths.manifest_start, startup)
+        write_json_atomic(self.paths.manifest, startup)
 
     def build_manifest(self) -> dict[str, Any]:
         """Full provenance record for the run."""
@@ -442,7 +597,7 @@ class OPDTrainer:
             "miniverl_version": __version__,
             "run_id": self.run_id,
             "run_name": config.run.name,
-            "created_at": utc_now(),
+            "created_at": self._started_at,
             "git_commit": env_info["git_commit"],
             "python_version": env_info["python_version"],
             "os": env_info["os"],
@@ -489,17 +644,136 @@ class OPDTrainer:
                     else None
                 ),
                 "tokenizer_fingerprint": self.tokenizer.fingerprint,
+                "tokenizer_identity": getattr(self.tokenizer, "identity", {}),
                 "tokenizer_vocab_size": self.tokenizer.vocab_size,
+                "student_lm_head_vocab_size": self.student.vocab_size,
+                "teacher_lm_head_vocab_size": (
+                    self.teacher.vocab_size if self.teacher is not None else None
+                ),
             },
             "objective": objective,
             "memory": self.plan.to_dict(),
+            "global_optimizer_step": self.global_step,
+            "parameter_version": self.parameter_version,
             "policy_version": self.policy_version,
+            "rollout_iteration": self._cycles_completed,
+            "rollout_policy_version": self._last_rollout_policy_version,
             "measurement_status": {
                 "cpu_metrics": "measured",
                 "cuda_metrics": "measured" if gpu.cuda_available() else "not_run_no_cuda",
                 "simulated_results": "none",
             },
         }
+
+    def _finalize_manifest(
+        self,
+        *,
+        status: str,
+        result: TrainResult | None = None,
+        error: BaseException | None = None,
+    ) -> None:
+        """Atomically combine immutable startup provenance with final run state."""
+        import json
+
+        from miniverl.cache.store import sha256_file
+        from miniverl.training.checkpoint import latest_checkpoint, validate_checkpoint
+
+        if self.paths.manifest_start.is_file():
+            manifest = json.loads(self.paths.manifest_start.read_text(encoding="utf-8"))
+            startup_digest = hashlib.sha256(self.paths.manifest_start.read_bytes()).hexdigest()
+        else:
+            # Backward-compatible finalization for a legacy run directory.
+            manifest = self.build_manifest()
+            startup_digest = None
+        now = utc_now()
+        manifest.update(
+            {
+                "manifest_schema_version": 2,
+                "status": status,
+                "started_at": self._started_at,
+                "global_step": self.global_step,
+                "global_optimizer_step": self.global_step,
+                "parameter_version": self.parameter_version,
+                "policy_version": self.policy_version,
+                "rollout_iteration": self._cycles_completed,
+                "rollout_policy_version": self._last_rollout_policy_version,
+                "cycles_completed": self._cycles_completed,
+                "actual_optimizer_updates": self.global_step,
+                "final_projection_chunk_size": self.plan.chunk_size,
+                "chunk_size_history": list(self.plan.chunk_size_history),
+                "oom_retries": self.plan.oom_retries_used,
+                "final_memory": self.plan.to_dict(),
+                "offline_dataset": (
+                    {"digest": self.offline_dataset_digest} if self.offline_dataset_digest else None
+                ),
+                "resumed_from": self._resumed_from,
+                "startup_manifest_digest": startup_digest,
+            }
+        )
+        for key in ("completed_at", "failed_at", "interrupted_at", "failure"):
+            manifest.pop(key, None)
+        if status == "completed":
+            manifest["completed_at"] = now
+        elif status == "interrupted":
+            manifest["interrupted_at"] = now
+        else:
+            manifest["failed_at"] = now
+        if error is not None:
+            manifest["failure"] = {
+                "type": type(error).__name__,
+                "message": str(error),
+            }
+
+        checkpoint_payload = None
+        selected = latest_checkpoint(self.paths.checkpoints)
+        if selected is not None:
+            validated = validate_checkpoint(selected)
+            checkpoint_payload = {
+                "directory": selected.name,
+                "global_step": validated.state.global_step,
+                "digest": validated.content_digest,
+                "integrity": validated.integrity,
+            }
+        manifest["final_checkpoint"] = checkpoint_payload
+
+        eval_payload = None
+        if self.paths.eval_json.is_file():
+            digest, size = sha256_file(self.paths.eval_json)
+            eval_payload = {
+                "file": self.paths.eval_json.name,
+                "digest": digest,
+                "bytes": size,
+            }
+        manifest["final_evaluation"] = eval_payload
+
+        required = [
+            self.paths.config_original,
+            self.paths.config_resolved,
+            self.paths.environment,
+            self.paths.manifest_start,
+        ]
+        if status == "completed":
+            required.extend([self.paths.eval_json])
+            if checkpoint_payload is None:
+                required.append(self.paths.checkpoints / "final")
+            if self.config.run.mode is TrainingMode.OFFLINE_KD and self.config.train.cycles > 0:
+                required.extend(
+                    [
+                        self.paths.offline_dataset_manifest,
+                        self.paths.offline_dataset_trajectories,
+                    ]
+                )
+        manifest["expected_artifacts"] = {path.name: path.exists() for path in required}
+        manifest["all_expected_artifacts_complete"] = (
+            status == "completed"
+            and all(manifest["expected_artifacts"].values())
+            and checkpoint_payload is not None
+        )
+        if result is not None:
+            result_payload = result.to_dict()
+            result_payload["run_dir"] = self.paths.root.name
+            manifest["result"] = result_payload
+        write_json_atomic(self.paths.manifest, manifest)
 
     # -- task sampling --------------------------------------------------------
 
@@ -602,20 +876,168 @@ class OPDTrainer:
                 if self.config.loss.mode is LossMode.EXACT_FULL_VOCAB
                 else min(self.config.loss.top_k, self.student.vocab_size)
             )
+            path = Path(self.config.cache.dir or self.paths.teacher_cache)
+            identity = {
+                "teacher_model_id": self.config.models.teacher.model_id,
+                "teacher_model_revision": self.config.models.teacher.revision,
+                "tokenizer_fingerprint": self.tokenizer.fingerprint,
+                "tokenizer_identity": getattr(self.tokenizer, "identity", {}),
+                "teacher_adapter_provenance": getattr(self.teacher, "adapter_provenance", None),
+                "vocab_size": self.student.vocab_size,
+                "top_k": top_k,
+                "temperature": self.config.loss.temperature,
+                "loss_mode": self.config.loss.mode.value,
+                "dtype": self.config.cache.dtype,
+            }
+            if (path / "index.json").is_file():
+                self._cache = TeacherCache.open(
+                    path,
+                    verify_checksums=self.config.cache.verify_checksums_on_load,
+                )
+                self._cache.assert_compatible(**identity)
+                return self._cache
             self._cache = TeacherCache.create(
-                self.config.cache.dir or self.paths.teacher_cache,
+                path,
                 miniverl_version=__version__,
-                teacher_model_id=self.config.models.teacher.model_id,
-                teacher_model_revision=self.config.models.teacher.revision,
-                tokenizer_fingerprint=self.tokenizer.fingerprint,
-                vocab_size=self.student.vocab_size,
-                top_k=top_k,
-                temperature=self.config.loss.temperature,
-                loss_mode=self.config.loss.mode.value,
-                dtype=self.config.cache.dtype,
+                **identity,
                 entries_per_shard=self.config.cache.entries_per_shard,
             )
         return self._cache
+
+    def _teacher_identity(self) -> dict[str, Any]:
+        teacher = self.config.models.teacher
+        return {
+            "model_id": teacher.model_id,
+            "revision": teacher.revision,
+            "adapter": getattr(self.teacher, "adapter_provenance", None),
+        }
+
+    def _persist_offline_dataset(self, samples: list[TrainSample]) -> None:
+        from miniverl.training.offline_dataset import create_offline_dataset
+
+        if self._cache is None:
+            raise CheckpointError("offline KD produced no teacher cache")
+        self.offline_dataset_digest = create_offline_dataset(
+            self.paths,
+            samples=samples,
+            cache=self._cache,
+            config=self.config,
+            tokenizer_identity=getattr(self.tokenizer, "identity", {}),
+            teacher_identity=self._teacher_identity(),
+        )
+        self.events.emit(
+            "offline_dataset_created",
+            dataset_digest=self.offline_dataset_digest,
+            trajectories=len(samples),
+            source="environment_oracle",
+        )
+
+    def _load_offline_dataset(self, *, expected_digest: str) -> None:
+        from miniverl.losses.bucketed import bucketed_teacher_entropy
+        from miniverl.losses.chunked import BucketedTargetProvider
+        from miniverl.teachers.base import TeacherScoreResult
+        from miniverl.training.offline_dataset import load_offline_dataset
+
+        cache = self._open_cache()
+        manifest, trajectories = load_offline_dataset(
+            self.paths,
+            cache=cache,
+            expected_digest=expected_digest,
+        )
+        if manifest.get("tokenizer_identity") != getattr(self.tokenizer, "identity", {}):
+            raise CheckpointError("offline dataset tokenizer identity changed")
+        if manifest.get("teacher_identity") != self._teacher_identity():
+            raise CheckpointError("offline dataset teacher identity changed")
+
+        privileged = self.config.models.teacher.mode is TeacherContextMode.PRIVILEGED_CONTEXT
+        task_by_id = {task.task_id: task for split in self.splits.values() for task in split}
+        samples: list[TrainSample] = []
+        for trajectory in trajectories:
+            selection = select_positions(
+                trajectory,
+                self.config.selection,
+                run_seed=self.config.run.seed,
+            )
+            teacher_view = None
+            if privileged:
+                task = task_by_id.get(trajectory.task_id)
+                if task is None:
+                    raise CheckpointError(
+                        f"offline trajectory references unknown task {trajectory.task_id!r}"
+                    )
+                teacher_view = self.runner.privileged_render(trajectory, task)
+            alignment = build_alignment_map(
+                trajectory,
+                selection.positions,
+                selection.weights,
+                teacher=teacher_view,
+            )
+            batch = cache.read(trajectory.trajectory_id, device=self.plan.device)
+            if batch.positions.tolist() != alignment.teacher_prediction_positions:
+                raise CheckpointError(
+                    f"offline target positions changed for {trajectory.trajectory_id!r}"
+                )
+            if batch.target_token_ids.tolist() != alignment.target_token_ids:
+                raise CheckpointError(
+                    f"offline target token IDs changed for {trajectory.trajectory_id!r}"
+                )
+            if batch.span_types != alignment.span_types:
+                raise CheckpointError(
+                    f"offline span order changed for {trajectory.trajectory_id!r}"
+                )
+            provider = BucketedTargetProvider(
+                topk_indices=batch.topk_indices,
+                topk_log_probs=batch.topk_log_probs,
+                tail_log_prob=batch.tail_log_prob,
+                divergence_name=self.config.loss.divergence.value,
+                temperature=self.config.loss.temperature,
+                scale_by_temperature_squared=(self.config.loss.scale_by_temperature_squared),
+                jsd_beta=self.config.loss.jsd_beta,
+                tail_epsilon=self.config.loss.tail_epsilon,
+            )
+            teacher_score = TeacherScoreResult(
+                trajectory_id=trajectory.trajectory_id,
+                policy_version=trajectory.policy_version,
+                shape="cached",
+                provider=provider,
+                target_token_ids=batch.target_token_ids,
+                weights=batch.weights,
+                span_types=list(batch.span_types),
+                teacher_entropy=bucketed_teacher_entropy(
+                    batch.topk_log_probs,
+                    batch.tail_log_prob,
+                    tail_epsilon=self.config.loss.tail_epsilon,
+                ),
+                num_positions=int(batch.positions.numel()),
+                cacheable=batch,
+                metrics={"selected_positions": float(batch.positions.numel())},
+            )
+            samples.append(
+                TrainSample(
+                    trajectory=trajectory,
+                    alignment=alignment,
+                    selection=selection,
+                    teacher=teacher_score,
+                )
+            )
+        selected = manifest.get("selected_positions", [])
+        rebuilt = [
+            {
+                "trajectory_id": sample.trajectory.trajectory_id,
+                "count": len(sample.alignment.student_prediction_positions),
+                "positions": list(sample.alignment.student_prediction_positions),
+            }
+            for sample in samples
+        ]
+        if rebuilt != selected:
+            raise CheckpointError("offline dataset selection no longer matches its manifest")
+        self._offline_samples = samples
+        self.offline_dataset_digest = expected_digest or str(manifest["dataset_digest"])
+        self.events.emit(
+            "offline_dataset_loaded",
+            dataset_digest=self.offline_dataset_digest,
+            trajectories=len(samples),
+        )
 
     def _build_samples(self, trajectories: list[Trajectory]) -> list[TrainSample]:
         """Select positions, align, and (for KD modes) score with the teacher."""
@@ -665,24 +1087,39 @@ class OPDTrainer:
 
     # -- optimization --------------------------------------------------------------
 
-    def _loss_by_span_type(self, sample: TrainSample, per_token: Any) -> dict[str, float]:
+    def _loss_by_span_type(
+        self,
+        sample: TrainSample,
+        per_token_objective: Any,
+    ) -> dict[str, list[float]]:
         totals: dict[str, list[float]] = {}
         weights = sample.alignment.token_weights
         for value, weight, span in zip(
-            per_token.tolist(), weights, sample.alignment.span_types, strict=False
+            per_token_objective.tolist(),
+            weights,
+            sample.alignment.span_types,
+            strict=True,
         ):
             entry = totals.setdefault(span, [0.0, 0.0])
             entry[0] += value * weight
             entry[1] += weight
-        return {k: (v[0] / v[1] if v[1] else 0.0) for k, v in totals.items()}
+        return totals
 
-    def _run_group(self, group: list[TrainSample], chunk_size: int) -> dict[str, Any]:
+    def _compute_group_gradients(
+        self,
+        group: list[TrainSample],
+        chunk_size: int,
+    ) -> dict[str, Any]:
+        """Retryable forward/backward phase; never mutates optimizer parameters."""
         import torch
 
         from miniverl.losses.chunked import chunked_selected_position_loss
 
         config = self.config
-        self.optimizer.zero_grad(set_to_none=True)
+        optimizer = self.optimizer
+        if optimizer is None:
+            raise LifecycleError("training gradients are unavailable in evaluation-only mode")
+        optimizer.zero_grad(set_to_none=True)
         self.student.set_train(True)
         device = self.student.device
         loss_total = 0.0
@@ -690,6 +1127,12 @@ class OPDTrainer:
         entropy_sum = 0.0
         entropy_count = 0
         span_losses: dict[str, list[float]] = {}
+        divergence_total = 0.0
+        sampled_nll_total = 0.0
+        oracle_ce_total = 0.0
+        divergence_available = False
+        sampled_nll_available = False
+        oracle_ce_available = False
         scale = 1.0 / max(len(group), 1)
 
         for sample in group:
@@ -714,39 +1157,111 @@ class OPDTrainer:
                 backward=True,
                 loss_scale=scale,
             )
-            loss_total += output.loss * scale
+            loss_total += float(output.loss) * scale
             positions_total += output.num_positions
-            for name, value in self._loss_by_span_type(sample, output.per_token).items():
-                span_losses.setdefault(name, []).append(value)
+            for name, (numerator, denominator) in self._loss_by_span_type(
+                sample,
+                output.per_token_objective,
+            ).items():
+                entry = span_losses.setdefault(name, [0.0, 0.0])
+                entry[0] += numerator
+                entry[1] += denominator
+            weight_tensor = weights.to(torch.float32)
+            tensor_denominator = weight_tensor.sum().clamp_min(1e-12)
+            if output.per_token_divergence is not None:
+                divergence_available = True
+                divergence_total += (
+                    float(
+                        (output.per_token_divergence.to(device) * weight_tensor).sum()
+                        / tensor_denominator
+                    )
+                    * scale
+                )
+            if output.per_token_ce is not None:
+                component = (
+                    float(
+                        (output.per_token_ce.to(device) * weight_tensor).sum() / tensor_denominator
+                    )
+                    * scale
+                )
+                if provider is None:
+                    oracle_ce_available = True
+                    oracle_ce_total += component
+                else:
+                    sampled_nll_available = True
+                    sampled_nll_total += component
             if sample.teacher is not None and sample.teacher.teacher_entropy.numel():
                 entropy_sum += float(sample.teacher.teacher_entropy.sum())
                 entropy_count += int(sample.teacher.teacher_entropy.numel())
             del hidden, output
 
-        grad_norm = float(
-            torch.nn.utils.clip_grad_norm_(
-                self.student.trainable_parameters(), config.train.max_grad_norm
-            )
-        )
-        lr = self.schedule.lr_at(self.global_step)
-        for group_params in self.optimizer.param_groups:
-            group_params["lr"] = lr
-        self.optimizer.step()
-        self.optimizer.zero_grad(set_to_none=True)
-
         return {
             "loss": loss_total,
-            "grad_norm": grad_norm,
-            "lr": lr,
             "selected_positions": positions_total,
             "trajectories_in_step": len(group),
             "teacher_entropy_mean": (entropy_sum / entropy_count) if entropy_count else None,
-            "loss_by_span_type": {k: sum(v) / len(v) for k, v in sorted(span_losses.items()) if v},
+            "divergence_loss": divergence_total if divergence_available else None,
+            "sampled_token_nll_loss": (sampled_nll_total if sampled_nll_available else None),
+            "oracle_ce_loss": oracle_ce_total if oracle_ce_available else None,
+            "loss_by_span_type": {
+                name: numerator / denominator if denominator else 0.0
+                for name, (numerator, denominator) in sorted(span_losses.items())
+            },
         }
+
+    def _commit_update(self) -> dict[str, float]:
+        """Non-retryable optimizer commit; ``step`` is invoked at most once."""
+        import torch
+
+        optimizer = self.optimizer
+        if optimizer is None:
+            raise LifecycleError("optimizer commits are unavailable in evaluation-only mode")
+        grad_norm = float(
+            torch.nn.utils.clip_grad_norm_(
+                self.student.trainable_parameters(),
+                self.config.train.max_grad_norm,
+            )
+        )
+        lr = self.schedule.lr_at(self.global_step)
+        for group_params in optimizer.param_groups:
+            group_params["lr"] = lr
+        try:
+            optimizer.step()
+        except (RuntimeError, MemoryError) as exc:
+            optimizer.zero_grad(set_to_none=True)
+            if gpu.is_oom_error(exc):
+                raise GpuMemoryError(
+                    "CUDA ran out of memory inside optimizer.step; the update may have "
+                    "partially allocated optimizer state and was not retried.",
+                    hint=(
+                        "reducing loss.chunk_size cannot fix optimizer-state allocation. "
+                        "Use a smaller model or optimizer, QLoRA/quantization, or an "
+                        "8-bit optimizer, then restart from the last complete checkpoint. "
+                        f"Original error: {exc}"
+                    ),
+                ) from exc
+            raise
+        optimizer.zero_grad(set_to_none=True)
+        return {"grad_norm": grad_norm, "lr": lr}
 
     def _optimize(self, samples: list[TrainSample], *, phase: str) -> list[dict[str, Any]]:
         accum = self.config.train.gradient_accumulation_steps
         records: list[dict[str, Any]] = []
+        optimizer = self.optimizer
+        if optimizer is None:
+            raise LifecycleError("optimization is unavailable in evaluation-only mode")
+        rollout_versions = {
+            int(sample.trajectory.policy_version)
+            for sample in samples
+            if getattr(sample, "trajectory", None) is not None
+        }
+        if len(rollout_versions) > 1:
+            raise LifecycleError(
+                "one optimizer pass cannot mix trajectories from multiple parameter versions"
+            )
+        rollout_policy_version = (
+            next(iter(rollout_versions)) if rollout_versions else self.parameter_version
+        )
         for start in range(0, len(samples), accum):
             group = samples[start : start + accum]
             if not group:
@@ -754,9 +1269,10 @@ class OPDTrainer:
             if self.config.memory.reset_peak_stats_each_cycle:
                 gpu.reset_peak_stats()
             started = time.perf_counter()
+            retry_rng = capture_rng()
 
             def run(chunk: int, batch: list[TrainSample] = group) -> dict[str, Any]:
-                return self._run_group(batch, chunk)
+                return self._compute_group_gradients(batch, chunk)
 
             def note_retry(old_chunk: int, new_chunk: int) -> None:
                 self.events.emit(
@@ -766,8 +1282,9 @@ class OPDTrainer:
                     note="objective unchanged; only the projection chunk size shrank",
                 )
 
-            def clear_grads() -> None:
-                self.optimizer.zero_grad(set_to_none=True)
+            def clear_grads(snapshot: Any = retry_rng) -> None:
+                optimizer.zero_grad(set_to_none=True)
+                restore_rng(snapshot)
 
             record = run_with_oom_retry(
                 run,
@@ -776,14 +1293,20 @@ class OPDTrainer:
                 on_retry=note_retry,
                 cleanup=clear_grads,
             )
+            record.update(self._commit_update())
+            self.global_step += 1
+            self.parameter_version += 1
             elapsed = max(time.perf_counter() - started, 1e-9)
             record.update(
                 {
                     "phase": phase,
                     "cycle": self.cycle,
+                    "rollout_iteration": self.cycle,
                     "step": self.global_step,
+                    "global_optimizer_step": self.global_step,
+                    "parameter_version": self.parameter_version,
                     "policy_version": self.policy_version,
-                    "rollout_policy_version": self.policy_version,
+                    "rollout_policy_version": rollout_policy_version,
                     "seconds": round(elapsed, 4),
                     "train_selected_tokens_per_second": record["selected_positions"] / elapsed,
                     "projection_chunk_size": self.plan.chunk_size,
@@ -793,7 +1316,6 @@ class OPDTrainer:
             )
             self.metrics_log.write(record)
             records.append(record)
-            self.global_step += 1
             if self.global_step % self.config.train.log_every_steps == 0:
                 logger.info(
                     "%s step %d cycle %d loss %.4f lr %.2e positions %d",
@@ -835,8 +1357,34 @@ class OPDTrainer:
     # -- public API -----------------------------------------------------------------
 
     def train(self) -> TrainResult:
-        """Run the configured schedule and return a summary."""
+        """Run training and finalize the public manifest for every exit state."""
         self._ensure_open("train")
+        try:
+            result = self._train_impl()
+        except KeyboardInterrupt as exc:
+            try:
+                self._finalize_manifest(status="interrupted", error=exc)
+            except BaseException as manifest_error:
+                logger.warning(
+                    "manifest finalization failed while preserving KeyboardInterrupt: %s",
+                    manifest_error,
+                )
+            raise
+        except BaseException as exc:
+            try:
+                self._finalize_manifest(status="failed", error=exc)
+            except BaseException as manifest_error:
+                logger.warning(
+                    "manifest finalization failed while preserving %s: %s",
+                    type(exc).__name__,
+                    manifest_error,
+                )
+            raise
+        self._finalize_manifest(status="completed", result=result)
+        return result
+
+    def _train_impl(self) -> TrainResult:
+        """Run the configured schedule and return a summary."""
         config = self.config
         started = time.perf_counter()
         self.events.emit(
@@ -865,7 +1413,8 @@ class OPDTrainer:
                 ),
             )
 
-        self._prepare_toy_teacher()
+        if not (config.run.mode is TrainingMode.OFFLINE_KD and self._offline_samples is not None):
+            self._prepare_toy_teacher()
 
         baseline = None
         if self._resumed:
@@ -888,6 +1437,7 @@ class OPDTrainer:
         for cycle in range(self._start_cycle, config.train.cycles):
             self.cycle = cycle
             last_records = self._run_cycle()
+            self._cycles_completed = cycle + 1
             if (
                 config.eval.enabled
                 and config.train.eval_every_cycles
@@ -895,7 +1445,11 @@ class OPDTrainer:
                 and cycle + 1 < config.train.cycles
             ):
                 self.evaluate(tag=f"cycle{cycle + 1}")
-            if config.train.save_every_cycles and (cycle + 1) % config.train.save_every_cycles == 0:
+            if (
+                config.train.save_every_cycles
+                and (cycle + 1) % config.train.save_every_cycles == 0
+                and cycle + 1 < config.train.cycles
+            ):
                 self.save_checkpoint()
 
         final_eval = self.evaluate(tag="final") if config.eval.enabled else None
@@ -909,6 +1463,8 @@ class OPDTrainer:
             cycles_completed=config.train.cycles,
             global_step=self.global_step,
             policy_version=self.policy_version,
+            parameter_version=self.parameter_version,
+            rollout_policy_version=self._last_rollout_policy_version,
             duration_seconds=duration,
             final_metrics=last_records[-1] if last_records else {},
             eval=final_eval,
@@ -922,7 +1478,11 @@ class OPDTrainer:
             "run_end",
             run_id=self.run_id,
             steps=self.global_step,
+            global_optimizer_step=self.global_step,
+            parameter_version=self.parameter_version,
             policy_version=self.policy_version,
+            rollout_iteration=self._cycles_completed,
+            rollout_policy_version=self._last_rollout_policy_version,
             seconds=round(duration, 2),
             success_rate=(final_eval or {}).get("success_rate"),
         )
@@ -937,7 +1497,6 @@ class OPDTrainer:
             samples = self._build_samples_ce_only(trajectories)
             self._optimize(samples, phase="sft_warmup")
             self.events.emit("sft_warmup_cycle", cycle=index, trajectories=stats.rollouts)
-        self.policy_version += 1
         self.cycle = 0
 
     def _build_samples_ce_only(self, trajectories: list[Trajectory]) -> list[TrainSample]:
@@ -954,9 +1513,12 @@ class OPDTrainer:
         config = self.config
         mode = config.run.mode
         cycle_started = time.perf_counter()
+        rollout_policy_version = self.parameter_version
 
         if mode is TrainingMode.OFFLINE_KD and self._offline_samples is not None:
             samples = self._offline_samples
+            if samples:
+                rollout_policy_version = samples[0].trajectory.policy_version
             stats = RolloutStats()
             self.events.emit(
                 "offline_kd_reuse",
@@ -969,6 +1531,8 @@ class OPDTrainer:
             oracle = mode in (TrainingMode.SFT, TrainingMode.OFFLINE_KD)
             rollout_started = time.perf_counter()
             trajectories, stats = self._collect(tasks, oracle=oracle)
+            if trajectories:
+                rollout_policy_version = trajectories[0].policy_version
             rollout_seconds = max(time.perf_counter() - rollout_started, 1e-9)
 
             if mode is TrainingMode.SFT or self.teacher is None:
@@ -993,7 +1557,10 @@ class OPDTrainer:
             self.events.emit(
                 "rollouts_collected",
                 cycle=self.cycle,
+                rollout_iteration=self.cycle,
                 policy_version=self.policy_version,
+                parameter_version=self.parameter_version,
+                rollout_policy_version=rollout_policy_version,
                 trajectories=stats.rollouts,
                 success_rate=round(stats.to_dict()["success_rate"], 4),
                 generated_tokens=stats.generated_tokens,
@@ -1001,6 +1568,7 @@ class OPDTrainer:
             )
             if mode is TrainingMode.OFFLINE_KD:
                 self._offline_samples = samples
+                self._persist_offline_dataset(samples)
 
         if not samples:
             # A selector can legitimately find nothing -- `tool_and_final` on a
@@ -1009,7 +1577,10 @@ class OPDTrainer:
             self.events.emit(
                 "cycle_skipped_no_selected_positions",
                 cycle=self.cycle,
+                rollout_iteration=self.cycle,
                 policy_version=self.policy_version,
+                parameter_version=self.parameter_version,
+                rollout_policy_version=rollout_policy_version,
                 selector=config.selection.selector.value,
                 trajectories=stats.rollouts,
                 note=(
@@ -1035,8 +1606,12 @@ class OPDTrainer:
         cycle_metrics: dict[str, Any] = {
             "phase": f"{config.run.mode.value}_cycle",
             "cycle": self.cycle,
+            "rollout_iteration": self.cycle,
             "step": self.global_step,
+            "global_optimizer_step": self.global_step,
+            "parameter_version": self.parameter_version,
             "policy_version": self.policy_version,
+            "rollout_policy_version": rollout_policy_version,
             "seconds": round(time.perf_counter() - cycle_started, 3),
             "rollouts": stats.to_dict(),
             "selection": selection_stats,
@@ -1047,14 +1622,18 @@ class OPDTrainer:
             cycle_metrics["cache"] = self._cache.stats().model_dump(mode="json")
         self.metrics_log.write(cycle_metrics)
 
-        if mode is TrainingMode.OPD:
-            self.policy_version += 1
-            if self._cache is not None and config.cache.keep_cycles:
-                removed = self._cache.prune_before(self.policy_version - config.cache.keep_cycles)
+        self._last_rollout_policy_version = rollout_policy_version
+        if mode is TrainingMode.OPD and self._cache is not None and config.cache.keep_cycles:
+            versions = sorted(self._cache.index.policy_versions())
+            if len(versions) > config.cache.keep_cycles:
+                removed = self._cache.prune_before(versions[-config.cache.keep_cycles])
                 if removed:
                     self.events.emit("cache_pruned", removed=removed)
-        elif mode is TrainingMode.SFT:
-            self.policy_version += 1
+        # A rollout iteration is complete only after optimization (including a
+        # legitimate no-op) and cycle metrics have both finished. Keeping the
+        # counter here also makes an explicit checkpoint taken between public
+        # train() calls resume at the next iteration.
+        self._cycles_completed = max(self._cycles_completed, self.cycle + 1)
         return records
 
     def _write_token_analysis(self, samples: list[TrainSample]) -> int:
@@ -1183,7 +1762,18 @@ class OPDTrainer:
         limit = config.effective_eval_tasks if tasks is None else len(pool)
         pool = pool[:limit]
         if not pool:
-            return {"tag": tag, "tasks": 0, "success_rate": 0.0, "note": "no eval tasks"}
+            return {
+                "tag": tag,
+                "tasks": 0,
+                "success_rate": 0.0,
+                "global_step": self.global_step,
+                "global_optimizer_step": self.global_step,
+                "policy_version": self.policy_version,
+                "parameter_version": self.parameter_version,
+                "rollout_iteration": self._cycles_completed,
+                "rollout_policy_version": self._last_rollout_policy_version,
+                "note": "no eval tasks",
+            }
 
         self.student.set_train(False)
         gpu.reset_peak_stats()
@@ -1215,7 +1805,11 @@ class OPDTrainer:
             "split": chosen_split,
             "tasks": len(pool),
             "policy_version": self.policy_version,
+            "parameter_version": self.parameter_version,
             "global_step": self.global_step,
+            "global_optimizer_step": self.global_step,
+            "rollout_iteration": self._cycles_completed,
+            "rollout_policy_version": self._last_rollout_policy_version,
             "temperature": config.eval.temperature,
             "seconds": round(elapsed, 3),
             "rollout_tokens_per_second": round(stats.generated_tokens / elapsed, 2),
@@ -1231,6 +1825,15 @@ class OPDTrainer:
                 ),
                 "valid_tool_call_rate": (
                     "measured" if stats.tool_calls + stats.invalid_tool_calls else "not_observed"
+                ),
+                "parse_valid_tool_call_rate": (
+                    "measured" if stats.emitted_tool_calls else "not_observed"
+                ),
+                "tool_execution_success_rate": (
+                    "measured" if stats.parsed_tool_calls else "not_observed"
+                ),
+                "tool_execution_error_rate": (
+                    "measured" if stats.parsed_tool_calls else "not_observed"
                 ),
                 "final_answer_format_validity_rate": "measured",
                 "protocol_token_accuracy": (
@@ -1254,6 +1857,22 @@ class OPDTrainer:
     def _config_digest(self) -> str:
         return hashlib.sha256(self.config.to_yaml().encode("utf-8")).hexdigest()
 
+    def _resolved_config_digest(self) -> str:
+        if self.paths.config_resolved.is_file():
+            return hashlib.sha256(self.paths.config_resolved.read_bytes()).hexdigest()
+        return self._config_digest()
+
+    def _checkpoint_identity(self) -> dict[str, Any]:
+        student = self.config.models.student
+        return {
+            "backend": self.config.models.backend.value,
+            "student_model_id": student.model_id,
+            "student_revision": student.revision,
+            "tokenizer_identity": student.tokenizer_id or student.model_id,
+            "tokenizer_revision": student.tokenizer_revision or student.revision,
+            "lora": student.lora.model_dump(mode="json"),
+        }
+
     def save_checkpoint(self, *, name: str | None = None) -> Path:
         """Write a resumable checkpoint."""
         self._ensure_open("save_checkpoint")
@@ -1263,10 +1882,15 @@ class OPDTrainer:
             miniverl_version=__version__,
             global_step=self.global_step,
             policy_version=self.policy_version,
+            parameter_version=self.parameter_version,
             cycle=self.cycle,
+            rollout_iteration=self._cycles_completed,
+            rollout_policy_version=self._last_rollout_policy_version,
             task_cursor=self.task_cursor,
             scheduler=self.schedule.state_dict(),
             config_digest=self._config_digest(),
+            resolved_config_digest=self._resolved_config_digest(),
+            offline_dataset_digest=self.offline_dataset_digest,
         )
         save_checkpoint(
             target,
@@ -1274,6 +1898,7 @@ class OPDTrainer:
             optimizer=self.optimizer,
             state=state,
             rng=capture_rng(),
+            identity=self._checkpoint_identity(),
         )
         self.events.emit("checkpoint_saved", path=str(target), step=self.global_step)
         return target
@@ -1281,25 +1906,54 @@ class OPDTrainer:
     def load_from_checkpoint(self, directory: str | Path) -> CheckpointState:
         """Restore a checkpoint into this trainer."""
         self._ensure_open("load_from_checkpoint")
+        from miniverl.training.checkpoint import validate_checkpoint
+
+        validated = validate_checkpoint(directory)
+        digest = self._config_digest()
+        if validated.state.config_digest and validated.state.config_digest != digest:
+            raise ConfigError(
+                "the checkpoint was written by a different configuration",
+                hint="resume with the run's config.resolved.yaml, not a modified recipe",
+            )
+        identity = self._checkpoint_identity()
+        if validated.identity:
+            mismatches = {
+                key: (validated.identity.get(key), value)
+                for key, value in identity.items()
+                if validated.identity.get(key) != value
+            }
+            if mismatches:
+                details = ", ".join(
+                    f"{key}: checkpoint={actual!r}, current={expected!r}"
+                    for key, (actual, expected) in sorted(mismatches.items())
+                )
+                raise ConfigError(f"checkpoint model/tokenizer identity mismatch ({details})")
+        if self.config.run.mode is TrainingMode.OFFLINE_KD:
+            if not validated.state.offline_dataset_digest:
+                raise ConfigError(
+                    "offline-KD checkpoint has no persisted dataset identity",
+                    hint="restart this legacy run; exact offline-KD resume requires v0.2.1 artifacts",
+                )
+            self._load_offline_dataset(
+                expected_digest=validated.state.offline_dataset_digest,
+            )
         state = load_checkpoint(
             directory,
             backend=self.student,
             optimizer=self.optimizer,
             device=self.student.device,
+            expected_config_digest=digest,
+            expected_identity=identity if validated.identity else None,
         )
-        digest = self._config_digest()
-        if state.config_digest and state.config_digest != digest:
-            raise ConfigError(
-                "the checkpoint was written by a different configuration",
-                hint="resume with the run's config.resolved.yaml, not a modified recipe",
-            )
-        self.global_step = state.global_step
-        self.policy_version = state.policy_version
-        self.cycle = state.cycle
-        self.task_cursor = state.task_cursor
-        # `state.cycle` is the last cycle that ran, so resume at the next one.
-        self._start_cycle = max(state.cycle + 1, 0)
+        self._apply_checkpoint_progress(state)
+        self._start_cycle = self._cycles_completed
         self._resumed = True
+        self._resumed_from = {
+            "directory": Path(directory).name,
+            "global_step": validated.state.global_step,
+            "digest": validated.content_digest,
+            "integrity": validated.integrity,
+        }
         if state.scheduler:
             self.schedule = LearningRateSchedule.from_state_dict(state.scheduler)
         self.events.emit("checkpoint_loaded", path=str(directory), step=self.global_step)
@@ -1346,16 +2000,17 @@ class OPDTrainer:
         optimizer = self.optimizer
         self.optimizer = None
         if optimizer is not None:
+            owned_optimizer: Any = optimizer
             cleanup(
                 "optimizer gradient clear",
-                lambda: optimizer.zero_grad(set_to_none=True),
+                lambda: owned_optimizer.zero_grad(set_to_none=True),
             )
 
             def clear_optimizer() -> None:
-                optimizer.state.clear()
-                for group in optimizer.param_groups:
+                owned_optimizer.state.clear()
+                for group in owned_optimizer.param_groups:
                     group["params"] = []
-                optimizer.param_groups.clear()
+                owned_optimizer.param_groups.clear()
 
             cleanup("optimizer state clear", clear_optimizer)
         optimizer = None

--- a/src/miniverl/utils/runs.py
+++ b/src/miniverl/utils/runs.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from miniverl.errors import RunNotFoundError
+from miniverl.errors import RunDirectoryError, RunNotFoundError
 
 __all__ = [
     "RunPaths",
@@ -20,6 +22,7 @@ __all__ = [
     "canonical_json",
     "write_text",
     "write_json",
+    "write_json_atomic",
     "read_json",
 ]
 
@@ -32,12 +35,13 @@ def utc_now() -> str:
 
 
 def make_run_id(name: str, *, explicit: str | None = None) -> str:
-    """Build a filesystem-safe run id."""
+    """Build a filesystem-safe, collision-resistant run id."""
     if explicit:
         return _SAFE.sub("-", explicit).strip("-") or "run"
-    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S-%f")
+    suffix = uuid.uuid4().hex[:8]
     slug = _SAFE.sub("-", name).strip("-").lower() or "run"
-    return f"{stamp}-{slug}"
+    return f"{stamp}-{suffix}-{slug}"
 
 
 @dataclass(frozen=True)
@@ -47,13 +51,72 @@ class RunPaths:
     root: Path
 
     @classmethod
-    def create(cls, output_dir: str | Path, run_id: str) -> RunPaths:
-        """Create the directory tree for a new run."""
-        root = Path(output_dir) / run_id
-        root.mkdir(parents=True, exist_ok=True)
+    def create(
+        cls,
+        output_dir: str | Path,
+        run_id: str,
+        *,
+        overwrite: bool = False,
+    ) -> RunPaths:
+        """Exclusively create a new run, optionally replacing one whole run.
+
+        Creation is intentionally not idempotent. Reusing a directory would let
+        append-only JSONL logs and old checkpoints become part of a different
+        logical execution. Resume paths must use :meth:`open` instead.
+        """
+        output_root = Path(output_dir).resolve()
+        output_root.mkdir(parents=True, exist_ok=True)
+        root = (output_root / run_id).resolve()
+        if root.parent != output_root or root == output_root:
+            raise RunDirectoryError(
+                f"refusing unsafe run directory outside the configured output root: {root}",
+                hint="choose a simple --run-id without path separators",
+            )
+
+        replaced: Path | None = None
+        try:
+            root.mkdir(exist_ok=False)
+        except FileExistsError as exc:
+            if not overwrite:
+                raise RunDirectoryError(
+                    f"run directory already exists: {root}",
+                    hint=(
+                        "use --resume <run-dir> to continue the same run, or "
+                        "--overwrite to replace the whole run explicitly"
+                    ),
+                ) from exc
+            if root.is_symlink() or not root.is_dir():
+                raise RunDirectoryError(
+                    f"refusing to overwrite suspicious run path: {root}",
+                    hint="remove the path manually after verifying it is safe",
+                ) from exc
+            replaced = output_root / f".{root.name}.overwrite-{uuid.uuid4().hex}"
+            root.rename(replaced)
+            try:
+                root.mkdir(exist_ok=False)
+            except BaseException:
+                replaced.rename(root)
+                raise
+
         paths = cls(root)
-        paths.teacher_cache.mkdir(parents=True, exist_ok=True)
-        paths.checkpoints.mkdir(parents=True, exist_ok=True)
+        try:
+            paths.teacher_cache.mkdir()
+            paths.checkpoints.mkdir()
+        except BaseException:
+            if replaced is not None:
+                shutil.rmtree(root, ignore_errors=True)
+                replaced.rename(root)
+            raise
+        if replaced is not None:
+            try:
+                shutil.rmtree(replaced)
+            except BaseException as exc:
+                shutil.rmtree(root, ignore_errors=True)
+                replaced.rename(root)
+                raise RunDirectoryError(
+                    f"could not safely remove the replaced run directory: {replaced}",
+                    hint="inspect and remove the temporary directory before retrying",
+                ) from exc
         return paths
 
     @classmethod
@@ -90,6 +153,11 @@ class RunPaths:
         return self.root / "manifest.json"
 
     @property
+    def manifest_start(self) -> Path:
+        """Immutable startup provenance, separate from final mutable state."""
+        return self.root / "manifest.start.json"
+
+    @property
     def environment(self) -> Path:
         """Machine and package description."""
         return self.root / "environment.json"
@@ -118,6 +186,21 @@ class RunPaths:
     def teacher_cache(self) -> Path:
         """Teacher-target cache directory."""
         return self.root / "teacher-cache"
+
+    @property
+    def offline_dataset(self) -> Path:
+        """Persisted fixed trajectories and targets for offline KD."""
+        return self.root / "offline-dataset"
+
+    @property
+    def offline_dataset_manifest(self) -> Path:
+        """Integrity and provenance record for the fixed offline dataset."""
+        return self.offline_dataset / "manifest.json"
+
+    @property
+    def offline_dataset_trajectories(self) -> Path:
+        """Stable ordered trajectory set reused by every offline-KD cycle."""
+        return self.offline_dataset / "trajectories.jsonl"
 
     @property
     def checkpoints(self) -> Path:
@@ -225,6 +308,24 @@ def write_text(path: str | Path, text: str) -> Path:
 def write_json(path: str | Path, payload: Any) -> Path:
     """Write pretty-printed JSON in the canonical form."""
     return write_text(path, canonical_json(payload))
+
+
+def _replace_file(source: Path, target: Path) -> None:
+    source.replace(target)
+
+
+def write_json_atomic(path: str | Path, payload: Any) -> Path:
+    """Write canonical JSON to a sibling temporary file and atomically replace."""
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary = target.with_name(f".{target.name}.tmp-{uuid.uuid4().hex}")
+    try:
+        write_text(temporary, canonical_json(payload))
+        _replace_file(temporary, target)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+    return target
 
 
 def read_json(path: str | Path) -> Any:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -305,6 +305,24 @@ def test_train_dry_run_rejects_a_missing_recipe(tmp_path: Path) -> None:
     assert "not found" in _collapse(result.output)
 
 
+@pytest.mark.parametrize(
+    "options",
+    [
+        ("--resume", "run", "--resume-from", "run/checkpoints/final"),
+        ("--resume", "run", "--overwrite"),
+        ("--resume-from", "run/checkpoints/final", "--run-id", "other"),
+    ],
+)
+def test_train_rejects_mutually_exclusive_run_lifecycle_options(
+    options: tuple[str, ...],
+) -> None:
+    result = _invoke("train", str(TOY_RECIPE), "--dry-run", *options)
+    assert result.exit_code != 0
+    assert "cannot be combined" in _collapse(result.output) or "mutually exclusive" in _collapse(
+        result.output
+    )
+
+
 # --------------------------------------------------------------------- schema
 
 
@@ -548,3 +566,25 @@ def test_export_benchmark_matches_the_published_schema(demo_run: Path) -> None:
     serialized = json.dumps(payload["result"])
     assert str(demo_run) not in serialized, "the submission leaks a local path"
     assert demo_run.as_posix() not in serialized
+
+
+@requires_torch
+@pytest.mark.torch
+def test_demo_rerun_refuses_without_modifying_any_existing_artifact(demo_run: Path) -> None:
+    before = {
+        path.relative_to(demo_run).as_posix(): path.read_bytes()
+        for path in demo_run.rglob("*")
+        if path.is_file()
+    }
+
+    result = _invoke("demo", "--output", str(demo_run), "--fast", "--json")
+
+    assert result.exit_code != 0
+    assert "--overwrite" in _collapse(result.output)
+    assert "--resume" in _collapse(result.output)
+    after = {
+        path.relative_to(demo_run).as_posix(): path.read_bytes()
+        for path in demo_run.rglob("*")
+        if path.is_file()
+    }
+    assert after == before

--- a/tests/integration/test_checkpoint_integrity.py
+++ b/tests/integration/test_checkpoint_integrity.py
@@ -1,0 +1,166 @@
+"""Checkpoint selection, integrity, atomicity and legacy compatibility."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from miniverl.errors import CheckpointError
+from tests.conftest import requires_torch
+
+pytestmark = [requires_torch, pytest.mark.torch]
+
+torch = pytest.importorskip("torch")
+
+
+class _Backend:
+    def __init__(self) -> None:
+        self.loaded: dict[str, Any] | None = None
+
+    def load_trainable_state_dict(self, state: dict[str, Any]) -> None:
+        if set(state) != {"weight"}:
+            raise CheckpointError(f"unexpected trainable keys: {sorted(state)}")
+        self.loaded = state
+
+
+def _write_checkpoint(
+    path: Path,
+    *,
+    step: int,
+    weight: float = 1.0,
+) -> Path:
+    from miniverl.training.checkpoint import CheckpointState, save_checkpoint
+    from miniverl.utils.seeding import capture_rng
+
+    parameter = torch.nn.Parameter(torch.tensor([weight]))
+    optimizer = torch.optim.AdamW([parameter], lr=0.01)
+    return save_checkpoint(
+        path,
+        trainable_state={"weight": parameter.detach().clone()},
+        optimizer=optimizer,
+        state=CheckpointState(
+            miniverl_version="0.2.1.dev0",
+            global_step=step,
+            policy_version=step,
+            cycle=max(step - 1, 0),
+            config_digest="config-a",
+        ),
+        rng=capture_rng(),
+        identity={"student_model_id": "toy-student", "tokenizer_identity": "toy-v2"},
+    )
+
+
+def test_latest_checkpoint_prefers_final_when_it_is_the_highest_step(tmp_path: Path) -> None:
+    from miniverl.training.checkpoint import latest_checkpoint
+
+    root = tmp_path / "checkpoints"
+    _write_checkpoint(root / "step-000008", step=8)
+    _write_checkpoint(root / "step-000016", step=16)
+    _write_checkpoint(root / "final", step=20)
+
+    assert latest_checkpoint(root) == root / "final"
+
+
+def test_latest_checkpoint_uses_state_step_instead_of_lexicographic_name(
+    tmp_path: Path,
+) -> None:
+    from miniverl.training.checkpoint import latest_checkpoint
+
+    root = tmp_path / "checkpoints"
+    _write_checkpoint(root / "final", step=10)
+    _write_checkpoint(root / "step-000016", step=16)
+
+    assert latest_checkpoint(root) == root / "step-000016"
+
+
+def test_latest_checkpoint_rejects_ambiguous_same_step_content(tmp_path: Path) -> None:
+    from miniverl.training.checkpoint import latest_checkpoint
+
+    root = tmp_path / "checkpoints"
+    _write_checkpoint(root / "candidate-a", step=12, weight=1.0)
+    _write_checkpoint(root / "candidate-b", step=12, weight=2.0)
+
+    with pytest.raises(CheckpointError, match="ambiguous"):
+        latest_checkpoint(root)
+
+
+def test_incomplete_temporary_checkpoint_is_ignored(tmp_path: Path) -> None:
+    from miniverl.training.checkpoint import latest_checkpoint
+
+    root = tmp_path / "checkpoints"
+    expected = _write_checkpoint(root / "step-000004", step=4)
+    temporary = root / ".step-000999.tmp-deadbeef"
+    temporary.mkdir()
+    (temporary / "state.json").write_text('{"global_step": 999}', encoding="utf-8")
+
+    assert latest_checkpoint(root) == expected
+
+
+def test_checkpoint_checksum_corruption_is_detected_before_loading(tmp_path: Path) -> None:
+    from miniverl.training.checkpoint import load_checkpoint
+
+    checkpoint = _write_checkpoint(tmp_path / "checkpoint", step=3)
+    with (checkpoint / "adapter.safetensors").open("ab") as handle:
+        handle.write(b"corruption")
+
+    with pytest.raises(CheckpointError, match="checksum"):
+        load_checkpoint(
+            checkpoint,
+            backend=_Backend(),
+            optimizer=None,
+            include_optimizer=False,
+            include_rng=False,
+        )
+
+
+def test_missing_trainable_weights_are_rejected(tmp_path: Path) -> None:
+    from miniverl.training.checkpoint import load_checkpoint
+
+    checkpoint = _write_checkpoint(tmp_path / "checkpoint", step=3)
+    (checkpoint / "adapter.safetensors").unlink()
+
+    with pytest.raises(CheckpointError, match=r"adapter\.safetensors"):
+        load_checkpoint(
+            checkpoint,
+            backend=_Backend(),
+            optimizer=None,
+            include_optimizer=False,
+            include_rng=False,
+        )
+
+
+def test_failed_atomic_save_preserves_the_previous_complete_checkpoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import miniverl.training.checkpoint as checkpoint_module
+
+    target = _write_checkpoint(tmp_path / "checkpoint", step=2, weight=1.0)
+    before = {path.name: path.read_bytes() for path in target.iterdir() if path.is_file()}
+
+    def fail_write(*_args: Any, **_kwargs: Any) -> Path:
+        raise OSError("injected state write failure")
+
+    monkeypatch.setattr(checkpoint_module, "write_text", fail_write)
+    with pytest.raises(OSError, match="injected"):
+        _write_checkpoint(target, step=3, weight=2.0)
+
+    after = {path.name: path.read_bytes() for path in target.iterdir() if path.is_file()}
+    assert after == before
+    assert not list(tmp_path.glob(".checkpoint.tmp-*"))
+
+
+def test_manifestless_v02_checkpoint_is_labeled_legacy_unchecksummed(
+    tmp_path: Path,
+) -> None:
+    from miniverl.training.checkpoint import validate_checkpoint
+
+    checkpoint = _write_checkpoint(tmp_path / "checkpoint", step=2)
+    (checkpoint / "checkpoint.json").unlink()
+
+    validated = validate_checkpoint(checkpoint)
+
+    assert validated.integrity == "legacy_unchecksummed"
+    assert validated.state.global_step == 2

--- a/tests/integration/test_hf_backend_offline.py
+++ b/tests/integration/test_hf_backend_offline.py
@@ -410,6 +410,7 @@ def test_hub_teacher_adapter_downloads_and_validates_miniverl_manifest(
     assert provenance["revision"] == "a" * 40
     assert provenance["weights_sha256"] == manifest["checksums"]["adapter_model.safetensors"]
     assert provenance["policy_evaluation"]["strict_task_success_rate"] == pytest.approx(0.75)
+    assert "parse_valid_tool_call_rate" not in provenance["policy_evaluation"]
     assert provenance.snapshot_dir == adapter
     assert policies == [True, True, True]
 
@@ -428,6 +429,54 @@ def test_hub_teacher_adapter_downloads_and_validates_miniverl_manifest(
     )
     assert online.snapshot_dir == provenance.snapshot_dir
     assert policies == [False, False, False]
+
+
+@requires_peft
+def test_v2_teacher_competence_requires_precise_tool_event_metrics(
+    local_teacher_adapter,
+    tiny_tokenizer,
+):
+    from miniverl.config.models import TeacherAdapterConfig, TeacherModelConfig
+    from miniverl.errors import BackendError
+    from miniverl.models.adapter_io import ADAPTER_MANIFEST, validate_teacher_adapter
+    from miniverl.utils.runs import read_json, write_json
+
+    base, adapter, _ = local_teacher_adapter
+    manifest = read_json(adapter / ADAPTER_MANIFEST)
+    manifest["training_task"] = {"protocol_version": "v2"}
+    manifest["policy_evaluation"] = {
+        "tag": "final",
+        "split": "test",
+        "tasks": 8,
+        "strict_task_success_rate": 0.75,
+        "lenient_diagnostic_success_rate": 0.75,
+        "valid_tool_call_rate": 1.0,
+        "tool_call_count": 16,
+        "final_answer_format_validity_rate": 1.0,
+        "avg_turns": 3.0,
+        "protocol_token_accuracy": None,
+        "policy_competence_measurement_status": {
+            "strict_task_success_rate": "measured_primary",
+            "protocol_token_accuracy": "not_applicable_free_running",
+        },
+    }
+    write_json(adapter / ADAPTER_MANIFEST, manifest)
+
+    with pytest.raises(
+        BackendError,
+        match="policy evaluation is incomplete: parse_valid_tool_call_rate",
+    ):
+        validate_teacher_adapter(
+            TeacherAdapterConfig(
+                path=str(adapter),
+                require_policy_evaluation=True,
+                minimum_strict_success_rate=0.5,
+            ),
+            TeacherModelConfig(model_id=str(base)),
+            tokenizer_fingerprint=tiny_tokenizer.fingerprint,
+            protocol_version="v2",
+            local_files_only=True,
+        )
 
 
 @requires_peft
@@ -730,6 +779,11 @@ def test_headline_teacher_gate_requires_recorded_policy_competence(
         "tasks": 8,
         "strict_task_success_rate": 0.75,
         "lenient_diagnostic_success_rate": 0.75,
+        "parse_valid_tool_call_rate": 1.0,
+        "tool_execution_success_rate": 1.0,
+        "tool_execution_error_rate": 0.0,
+        "emitted_tool_calls": 16,
+        "parsed_tool_calls": 16,
         "valid_tool_call_rate": 1.0,
         "tool_call_count": 16,
         "final_answer_format_validity_rate": 1.0,

--- a/tests/integration/test_manifest_lifecycle.py
+++ b/tests/integration/test_manifest_lifecycle.py
@@ -1,0 +1,93 @@
+"""Run manifests distinguish immutable startup provenance from final state."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import requires_torch
+from tests.integration.test_resume_and_swap import _config
+
+pytestmark = [requires_torch, pytest.mark.torch]
+
+pytest.importorskip("torch")
+
+
+def test_successful_training_finalizes_manifest_without_changing_startup(
+    tmp_path: Path,
+) -> None:
+    from miniverl.trainer import OPDTrainer
+
+    trainer = OPDTrainer.from_config(
+        _config(tmp_path, train={"cycles": 1}),
+        run_id="manifest-complete",
+    )
+    startup_bytes = trainer.paths.manifest_start.read_bytes()
+    result = trainer.train()
+    manifest = json.loads(trainer.paths.manifest.read_text(encoding="utf-8"))
+
+    assert trainer.paths.manifest_start.read_bytes() == startup_bytes
+    assert manifest["status"] == "completed"
+    assert manifest["started_at"]
+    assert manifest["completed_at"]
+    assert manifest["global_step"] == result.global_step
+    assert manifest["actual_optimizer_updates"] == result.global_step
+    assert manifest["final_memory"]["projection_chunk_size"] == trainer.plan.chunk_size
+    assert manifest["final_checkpoint"]["integrity"] == "checksummed_v1"
+    assert len(manifest["final_checkpoint"]["digest"]) == 64
+    assert manifest["all_expected_artifacts_complete"] is True
+    trainer.close()
+
+
+def test_training_failure_is_recorded_without_hiding_the_original_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from miniverl.trainer import OPDTrainer
+
+    trainer = OPDTrainer.from_config(
+        _config(tmp_path, train={"cycles": 1}),
+        run_id="manifest-failed",
+    )
+    startup_bytes = trainer.paths.manifest_start.read_bytes()
+
+    def fail_cycle():
+        raise RuntimeError("injected training failure")
+
+    monkeypatch.setattr(trainer, "_run_cycle", fail_cycle)
+    with pytest.raises(RuntimeError, match="injected training failure"):
+        trainer.train()
+
+    manifest = json.loads(trainer.paths.manifest.read_text(encoding="utf-8"))
+    assert trainer.paths.manifest_start.read_bytes() == startup_bytes
+    assert manifest["status"] == "failed"
+    assert manifest["failure"]["type"] == "RuntimeError"
+    assert manifest["failure"]["message"] == "injected training failure"
+    assert manifest["failed_at"]
+    trainer.close()
+
+
+def test_keyboard_interrupt_is_recorded_as_interrupted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from miniverl.trainer import OPDTrainer
+
+    trainer = OPDTrainer.from_config(
+        _config(tmp_path, train={"cycles": 1}),
+        run_id="manifest-interrupted",
+    )
+
+    def interrupt():
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(trainer, "_run_cycle", interrupt)
+    with pytest.raises(KeyboardInterrupt):
+        trainer.train()
+
+    manifest = json.loads(trainer.paths.manifest.read_text(encoding="utf-8"))
+    assert manifest["status"] == "interrupted"
+    assert manifest["failure"]["type"] == "KeyboardInterrupt"
+    trainer.close()

--- a/tests/integration/test_resume_and_swap.py
+++ b/tests/integration/test_resume_and_swap.py
@@ -124,6 +124,32 @@ def _assert_states_equal(
     assert worst <= atol, f"largest parameter difference {worst:.3e} exceeds {atol:.1e}"
 
 
+def _assert_optimizer_states_equal(a: dict[str, Any], b: dict[str, Any]) -> None:
+    assert a.keys() == b.keys()
+    assert a["param_groups"] == b["param_groups"]
+    assert a["state"].keys() == b["state"].keys()
+    for param_id in a["state"]:
+        assert a["state"][param_id].keys() == b["state"][param_id].keys()
+        for key, value in a["state"][param_id].items():
+            other = b["state"][param_id][key]
+            if isinstance(value, torch.Tensor):
+                assert torch.equal(value, other), (param_id, key)
+            else:
+                assert value == other
+
+
+def _normalized_cycle_metrics(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    normalized = []
+    for record in records:
+        if not str(record.get("phase", "")).endswith("_cycle"):
+            continue
+        item = dict(record)
+        item.pop("seconds", None)
+        item.pop("ts", None)
+        normalized.append(item)
+    return normalized
+
+
 # ------------------------------------------------------------------ resume
 
 
@@ -175,6 +201,83 @@ def test_uninterrupted_and_resumed_training_agree_exactly(tmp_path: Path):
     _assert_states_equal(reference_state, resumed_state, atol=1e-6)
 
 
+def test_offline_kd_resume_reuses_the_exact_persisted_dataset(tmp_path: Path) -> None:
+    from miniverl.cache.store import sha256_file
+    from miniverl.trainer import OPDTrainer
+    from miniverl.trajectory.io import read_trajectories
+    from miniverl.utils.runs import read_jsonl
+    from miniverl.utils.seeding import seed_everything
+
+    offline = {
+        "run": {"mode": "offline_kd"},
+        "cache": {
+            "reuse_across_policy_versions": True,
+            "strict_policy_version": False,
+            "keep_cycles": 10,
+        },
+    }
+    seed_everything(11, deterministic=True)
+    reference = OPDTrainer.from_config(_config(tmp_path, **offline), run_id="offline-reference")
+    reference.train()
+    reference_state = _flat_state(reference.student)
+    reference_optimizer = reference.optimizer.state_dict()
+    reference_step = reference.global_step
+    reference_cursor = reference.task_cursor
+    reference_metrics = read_jsonl(reference.paths.metrics)
+    reference_digest = reference.offline_dataset_digest
+    reference.close()
+
+    seed_everything(11, deterministic=True)
+    first = OPDTrainer.from_config(_config(tmp_path, **offline), run_id="offline-interrupted")
+    first._prepare_toy_teacher()
+    for cycle in range(2):
+        first.cycle = cycle
+        first._run_cycle()
+    checkpoint = first.save_checkpoint(name="interrupt")
+    dataset_manifest = first.paths.offline_dataset_manifest
+    dataset_trajectories = first.paths.offline_dataset_trajectories
+    before_files = {
+        path: path.read_bytes()
+        for path in (
+            dataset_manifest,
+            dataset_trajectories,
+            first.paths.teacher_cache / "index.json",
+        )
+    }
+    trajectory_ids = [
+        trajectory.trajectory_id for trajectory in read_trajectories(dataset_trajectories)
+    ]
+    cache_digest_before, _ = sha256_file(first.paths.teacher_cache / "index.json")
+    interrupted_root = first.paths.root
+    interrupted_digest = first.offline_dataset_digest
+    first.close()
+
+    assert checkpoint.is_dir()
+    resumed = OPDTrainer.from_config(_config(tmp_path, **offline), resume=interrupted_root)
+    assert resumed.offline_dataset_digest == interrupted_digest
+    assert resumed._offline_samples is not None
+    assert [
+        sample.trajectory.trajectory_id for sample in resumed._offline_samples
+    ] == trajectory_ids
+    resumed.train()
+
+    resumed_state = _flat_state(resumed.student)
+    resumed_optimizer = resumed.optimizer.state_dict()
+    resumed_metrics = read_jsonl(resumed.paths.metrics)
+    cache_digest_after, _ = sha256_file(resumed.paths.teacher_cache / "index.json")
+    assert all(path.read_bytes() == contents for path, contents in before_files.items())
+    assert cache_digest_after == cache_digest_before
+    assert resumed.offline_dataset_digest == reference_digest
+    assert resumed.global_step == reference_step
+    assert resumed.task_cursor == reference_cursor
+    _assert_states_equal(reference_state, resumed_state, atol=1e-6)
+    _assert_optimizer_states_equal(reference_optimizer, resumed_optimizer)
+    assert _normalized_cycle_metrics(reference_metrics) == _normalized_cycle_metrics(
+        resumed_metrics
+    )
+    resumed.close()
+
+
 def test_checkpoint_round_trip_restores_optimizer_and_schedule(tmp_path: Path):
     from miniverl.trainer import OPDTrainer
     from miniverl.training.checkpoint import load_checkpoint
@@ -219,7 +322,12 @@ def test_checkpoint_files_are_pickle_free(tmp_path: Path):
     path = trainer.save_checkpoint(name="inspect")
     trainer.close()
     names = sorted(p.name for p in path.iterdir())
-    assert names == ["adapter.safetensors", "optimizer.safetensors", "state.json"]
+    assert names == [
+        "adapter.safetensors",
+        "checkpoint.json",
+        "optimizer.safetensors",
+        "state.json",
+    ]
     # A pickle stream starts with a protocol opcode; safetensors starts with a
     # little-endian header length. Assert the files are not pickles.
     for name in ("adapter.safetensors", "optimizer.safetensors"):
@@ -228,6 +336,7 @@ def test_checkpoint_files_are_pickle_free(tmp_path: Path):
     import json
 
     json.loads((path / "state.json").read_text(encoding="utf-8"))
+    json.loads((path / "checkpoint.json").read_text(encoding="utf-8"))
 
 
 def test_resuming_a_checkpoint_from_a_different_config_is_refused(tmp_path: Path):
@@ -242,8 +351,15 @@ def test_resuming_a_checkpoint_from_a_different_config_is_refused(tmp_path: Path
     other = OPDTrainer.from_config(
         _config(tmp_path, train={"cycles": 1, "learning_rate": 0.001}), run_id="digest-b"
     )
+    before = {
+        name: tensor.detach().clone()
+        for name, tensor in other.student.trainable_state_dict().items()
+    }
     with pytest.raises(ConfigError, match="different configuration"):
         other.load_from_checkpoint(path)
+    after = other.student.trainable_state_dict()
+    assert set(after) == set(before)
+    assert all(torch.equal(before[name], after[name]) for name in before)
     other.close()
 
 
@@ -378,3 +494,130 @@ def test_a_non_oom_error_is_not_retried():
     with pytest.raises(RuntimeError, match="shape mismatch"):
         run_with_oom_retry(boom, plan=plan, memory=MemoryConfig(oom_retries=3))
     assert calls == 1, "a real bug must surface immediately, not be retried away"
+
+
+def test_retry_restores_rng_and_commits_the_optimizer_exactly_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from miniverl.trainer import OPDTrainer
+
+    config = _config(
+        tmp_path,
+        run={"mode": "sft"},
+        loss={"chunk_size": 8},
+        memory={"oom_retries": 1, "min_chunk_size": 4},
+        train={"cycles": 1},
+    )
+    reference = OPDTrainer.from_config(config, run_id="oom-reference")
+    retried = OPDTrainer.from_config(config, run_id="oom-retried")
+    reference.plan.chunk_size = 4
+    retried.plan.chunk_size = 8
+    retry_attempts = 0
+    optimizer_steps = 0
+
+    def install_compute(trainer, *, inject_oom: bool):
+        def compute(_group, _chunk: int):
+            nonlocal retry_attempts
+            trainer.optimizer.zero_grad(set_to_none=True)
+            parameter = trainer.student.trainable_parameters()[0]
+            values = torch.nn.functional.dropout(
+                parameter.reshape(-1)[:64],
+                p=0.4,
+                training=True,
+            )
+            loss = values.square().mean()
+            loss.backward()
+            if inject_oom and retry_attempts == 0:
+                retry_attempts += 1
+                raise RuntimeError("CUDA out of memory after backward")
+            return {
+                "loss": float(loss.detach()),
+                "selected_positions": 1,
+                "trajectories_in_step": 1,
+                "teacher_entropy_mean": None,
+                "loss_by_span_type": {},
+            }
+
+        monkeypatch.setattr(trainer, "_compute_group_gradients", compute)
+
+    install_compute(reference, inject_oom=False)
+    install_compute(retried, inject_oom=True)
+    original_step = retried.optimizer.step
+
+    def counted_step(*args, **kwargs):
+        nonlocal optimizer_steps
+        optimizer_steps += 1
+        return original_step(*args, **kwargs)
+
+    monkeypatch.setattr(retried.optimizer, "step", counted_step)
+    torch.manual_seed(991)
+    reference._optimize([object()], phase="test")
+    torch.manual_seed(991)
+    retried._optimize([object()], phase="test")
+
+    assert retry_attempts == 1
+    assert optimizer_steps == 1
+    assert retried.plan.chunk_size == 4
+    _assert_states_equal(
+        _flat_state(reference.student),
+        _flat_state(retried.student),
+        atol=0.0,
+    )
+    reference.close()
+    retried.close()
+
+
+def test_optimizer_step_oom_is_not_retried_and_marks_run_failed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import json
+
+    from miniverl.errors import GpuMemoryError
+    from miniverl.trainer import OPDTrainer
+
+    trainer = OPDTrainer.from_config(
+        _config(tmp_path, run={"mode": "sft"}, train={"cycles": 1}),
+        run_id="optimizer-oom",
+    )
+    step_calls = 0
+
+    def compute(_group, _chunk: int):
+        trainer.optimizer.zero_grad(set_to_none=True)
+        parameter = trainer.student.trainable_parameters()[0]
+        parameter.square().mean().backward()
+        return {
+            "loss": 1.0,
+            "selected_positions": 1,
+            "trajectories_in_step": 1,
+            "teacher_entropy_mean": None,
+            "loss_by_span_type": {},
+        }
+
+    def fail_step(*_args, **_kwargs):
+        nonlocal step_calls
+        step_calls += 1
+        with torch.no_grad():
+            trainer.student.trainable_parameters()[0].add_(1.0)
+        raise RuntimeError("CUDA out of memory allocating Adam state")
+
+    def run_cycle():
+        trainer._optimize([object()], phase="test")
+        return []
+
+    monkeypatch.setattr(trainer, "_compute_group_gradients", compute)
+    monkeypatch.setattr(trainer.optimizer, "step", fail_step)
+    monkeypatch.setattr(trainer, "_run_cycle", run_cycle)
+    with pytest.raises(GpuMemoryError, match=r"optimizer\.step"):
+        trainer.train()
+
+    manifest = json.loads(trainer.paths.manifest.read_text(encoding="utf-8"))
+    assert step_calls == 1
+    assert trainer.global_step == 0
+    assert trainer.parameter_version == 0
+    assert manifest["status"] == "failed"
+    assert manifest["parameter_version"] == 0
+    assert manifest["failure"]["type"] == "GpuMemoryError"
+    assert not (trainer.paths.checkpoints / "final").exists()
+    trainer.close()

--- a/tests/integration/test_standalone_evaluation.py
+++ b/tests/integration/test_standalone_evaluation.py
@@ -1,0 +1,93 @@
+"""Standalone evaluation must restore an exact checkpoint without training state."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from miniverl.errors import CheckpointError
+from tests.conftest import requires_torch
+from tests.integration.test_resume_and_swap import _config
+
+pytestmark = [requires_torch, pytest.mark.torch]
+
+pytest.importorskip("torch")
+
+
+def test_standalone_eval_loads_only_weights_and_records_checkpoint_digest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import safetensors.torch
+
+    import miniverl.training.trainer as trainer_module
+    from miniverl.evaluation.evaluator import evaluate_run
+    from miniverl.trainer import OPDTrainer
+    from miniverl.training.checkpoint import validate_checkpoint
+
+    trainer = OPDTrainer.from_config(
+        _config(tmp_path, train={"cycles": 1}),
+        run_id="standalone-eval",
+    )
+    trainer.train()
+    run_dir = trainer.paths.root
+    checkpoint = trainer.paths.checkpoints / "final"
+    expected = validate_checkpoint(checkpoint)
+    trainer.close()
+
+    def refuse_optimizer(*_args, **_kwargs):
+        raise AssertionError("standalone evaluation allocated an optimizer")
+
+    monkeypatch.setattr(trainer_module, "build_optimizer", refuse_optimizer)
+    original_load_file = safetensors.torch.load_file
+    loaded: list[str] = []
+
+    def record_load(path, *args, **kwargs):
+        loaded.append(Path(path).name)
+        return original_load_file(path, *args, **kwargs)
+
+    monkeypatch.setattr(safetensors.torch, "load_file", record_load)
+    payload = evaluate_run(run_dir, tasks=1)
+
+    assert loaded == ["adapter.safetensors"]
+    assert payload["checkpoint"] == str(checkpoint)
+    assert payload["checkpoint_digest"] == expected.content_digest
+    assert payload["checkpoint_integrity"] == "checksummed_v1"
+    assert payload["checkpoint_global_step"] == expected.state.global_step
+    expected_parameter_version = (
+        expected.state.policy_version
+        if expected.state.parameter_version is None
+        else expected.state.parameter_version
+    )
+    expected_rollout_iteration = (
+        max(expected.state.cycle + 1, 0)
+        if expected.state.rollout_iteration is None
+        else expected.state.rollout_iteration
+    )
+    expected_rollout_policy_version = (
+        expected.state.policy_version
+        if expected.state.rollout_policy_version is None
+        else expected.state.rollout_policy_version
+    )
+    assert payload["global_step"] == expected.state.global_step
+    assert payload["global_optimizer_step"] == expected.state.global_step
+    assert payload["parameter_version"] == expected_parameter_version
+    assert payload["policy_version"] == expected_parameter_version
+    assert payload["rollout_iteration"] == expected_rollout_iteration
+    assert payload["rollout_policy_version"] == expected_rollout_policy_version
+
+
+def test_standalone_eval_refuses_a_run_without_a_checkpoint(tmp_path: Path) -> None:
+    from miniverl.evaluation.evaluator import evaluate_run
+    from miniverl.trainer import OPDTrainer
+
+    trainer = OPDTrainer.from_config(
+        _config(tmp_path, train={"cycles": 0}),
+        run_id="no-checkpoint",
+    )
+    run_dir = trainer.paths.root
+    trainer.close()
+
+    with pytest.raises(CheckpointError, match="no checkpoint"):
+        evaluate_run(run_dir)

--- a/tests/integration/test_toy_pipeline.py
+++ b/tests/integration/test_toy_pipeline.py
@@ -242,9 +242,10 @@ def test_a_selector_that_finds_nothing_says_so_instead_of_doing_nothing(tmp_path
     are no *critical* tokens to supervise. The run must complete with zero
     optimizer steps AND record why, rather than looking like a normal cycle.
     """
-    trainer, result = _train(
-        _config(tmp_path, selection={"selector": "tool_and_final"}), "sel-empty"
-    )
+    from miniverl.trainer import OPDTrainer
+
+    config = _config(tmp_path, selection={"selector": "tool_and_final"})
+    trainer, result = _train(config, "sel-empty")
     assert result.global_step == 0
     events = [
         json.loads(line) for line in trainer.paths.events.read_text(encoding="utf-8").splitlines()
@@ -253,6 +254,50 @@ def test_a_selector_that_finds_nothing_says_so_instead_of_doing_nothing(tmp_path
     assert skipped, "an empty selection must be announced"
     assert skipped[0]["selector"] == "tool_and_final"
     assert "zero optimizer steps" in skipped[0]["note"]
+    assert result.parameter_version == 0
+    assert result.policy_version == 0
+    assert result.global_step == 0
+
+    resumed = OPDTrainer.from_config(config, run_id="sel-empty-resumed")
+    state = resumed.load_from_checkpoint(trainer.paths.checkpoints / "final")
+    assert state.global_step == 0
+    assert state.parameter_version == 0
+    resumed_result = resumed.train()
+    assert resumed_result.global_step == 0
+    assert resumed_result.parameter_version == 0
+    resumed.close()
+
+
+def test_replay_records_one_rollout_version_and_each_successful_parameter_version(
+    tmp_path: Path,
+):
+    """Two optimizer groups consume one rollout batch without relabelling it."""
+    trainer, result = _train(
+        _config(
+            tmp_path,
+            train={
+                "cycles": 1,
+                "rollouts_per_cycle": 4,
+                "gradient_accumulation_steps": 2,
+                "opd_freshness": "replay",
+            },
+            eval={"enabled": False},
+            report={"enabled": False},
+        ),
+        "version-replay",
+    )
+    metrics = [
+        json.loads(line) for line in trainer.paths.metrics.read_text(encoding="utf-8").splitlines()
+    ]
+    updates = [record for record in metrics if record.get("phase") == "opd"]
+
+    assert result.global_step == 2
+    assert result.parameter_version == 2
+    assert result.policy_version == 2
+    assert [record["global_optimizer_step"] for record in updates] == [1, 2]
+    assert [record["parameter_version"] for record in updates] == [1, 2]
+    assert {record["rollout_policy_version"] for record in updates} == {0}
+    assert result.rollout_policy_version == 0
 
 
 def test_sft_warmup_then_opd(tmp_path: Path):

--- a/tests/unit/test_agent_event_metrics.py
+++ b/tests/unit/test_agent_event_metrics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from types import SimpleNamespace
 
 import pytest
 
@@ -14,25 +15,17 @@ from miniverl.environments.calculator import CalculatorEnvironment
 from miniverl.errors import ToolEnvironmentError
 from miniverl.models.base import GenerationOutput
 from miniverl.models.tokenizers import ToyTokenizer
-from miniverl.models.toy import ToyBackend
 from miniverl.schemas.trajectory import SpanType, TerminationReason
 
 
-class _ScriptedBackend(ToyBackend):
+class _ScriptedBackend:
     def __init__(self, outputs: Sequence[tuple[str, str]]) -> None:
         self._outputs = list(outputs)
         self._output_index = 0
-        tokenizer = ToyTokenizer()
-        super().__init__(
-            tokenizer=tokenizer,
-            model_id="scripted",
-            seed=0,
-            hidden_size=16,
-            num_layers=1,
-            num_heads=2,
-            intermediate_size=32,
-            max_position_embeddings=2048,
-        )
+        self.tokenizer = ToyTokenizer()
+        self.model_id = "scripted"
+        self.model_revision = None
+        self.capabilities = SimpleNamespace(name=self.model_id)
 
     def generate(self, prefix_token_ids, **kwargs) -> GenerationOutput:
         del prefix_token_ids, kwargs

--- a/tests/unit/test_agent_event_metrics.py
+++ b/tests/unit/test_agent_event_metrics.py
@@ -1,0 +1,233 @@
+"""Agent metrics count protocol, execution, and answer events separately."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+
+from miniverl.agent.loop import RolloutRunner, RolloutStats
+from miniverl.agent.protocol import render_final, render_tool_call
+from miniverl.config.models import RolloutConfig
+from miniverl.environments.base import Observation, StepResult, Task, ToolCall
+from miniverl.environments.calculator import CalculatorEnvironment
+from miniverl.errors import ToolEnvironmentError
+from miniverl.models.base import GenerationOutput
+from miniverl.models.tokenizers import ToyTokenizer
+from miniverl.models.toy import ToyBackend
+from miniverl.schemas.trajectory import SpanType, TerminationReason
+
+
+class _ScriptedBackend(ToyBackend):
+    def __init__(self, outputs: Sequence[tuple[str, str]]) -> None:
+        self._outputs = list(outputs)
+        self._output_index = 0
+        tokenizer = ToyTokenizer()
+        super().__init__(
+            tokenizer=tokenizer,
+            model_id="scripted",
+            seed=0,
+            hidden_size=16,
+            num_layers=1,
+            num_heads=2,
+            intermediate_size=32,
+            max_position_embeddings=2048,
+        )
+
+    def generate(self, prefix_token_ids, **kwargs) -> GenerationOutput:
+        del prefix_token_ids, kwargs
+        text, stop_reason = self._outputs[self._output_index]
+        self._output_index += 1
+        return GenerationOutput(
+            token_ids=self.tokenizer.encode(text),
+            text=text,
+            stop_reason=stop_reason,
+            matched_stop=None,
+        )
+
+
+def _run(
+    outputs: Sequence[tuple[str, str]],
+    *,
+    environment: CalculatorEnvironment | None = None,
+    max_parse_errors: int = 2,
+    max_repeated_calls: int = 2,
+):
+    runner = RolloutRunner(
+        backend=_ScriptedBackend(outputs),
+        environment=environment or CalculatorEnvironment(prompt_style="compact"),
+        config=RolloutConfig(
+            max_turns=len(outputs),
+            max_new_tokens_per_turn=512,
+            max_total_tokens=1600,
+            max_parse_errors=max_parse_errors,
+            max_repeated_calls=max_repeated_calls,
+        ),
+    )
+    task = Task(task_id="metrics", prompt="Compute 1 + 1.", answer="2")
+    return runner.rollout(task, policy_version=0, seed=0)
+
+
+@pytest.mark.parametrize(
+    ("answer", "solved", "format_valid"),
+    [
+        ("2", True, 1),
+        ("3", False, 1),
+        ("not-a-number", False, 0),
+    ],
+)
+def test_final_answer_format_is_distinct_from_correctness(
+    answer: str, solved: bool, format_valid: int
+) -> None:
+    trajectory = _run([(render_final(answer), "stop_sequence")])
+
+    assert trajectory.verification is not None
+    assert trajectory.verification.solved is solved
+    assert trajectory.final_answers_emitted == 1
+    assert trajectory.final_answers_verified == 1
+    assert trajectory.final_answers_format_valid == format_valid
+
+    stats = RolloutStats()
+    stats.observe(trajectory)
+    metrics = stats.to_dict()
+    assert metrics["final_answer_format_validity_rate"] == pytest.approx(format_valid)
+
+
+def test_no_final_and_verifier_exception_do_not_claim_format_validity() -> None:
+    no_final = _run([("I give up.", "eos")])
+    assert no_final.termination_reason is TerminationReason.EOS_WITHOUT_FINAL
+    assert no_final.final_answers_emitted == 0
+    assert no_final.final_answers_verified == 0
+    assert no_final.final_answers_format_valid == 0
+
+    class _BrokenVerifier(CalculatorEnvironment):
+        def verify(self, answer: str):
+            del answer
+            raise ToolEnvironmentError("verifier unavailable")
+
+    verifier_error = _run(
+        [(render_final("2"), "stop_sequence")],
+        environment=_BrokenVerifier(prompt_style="compact"),
+    )
+    assert verifier_error.termination_reason is TerminationReason.ENVIRONMENT_ERROR
+    assert verifier_error.final_answers_emitted == 1
+    assert verifier_error.final_answers_verified == 0
+    assert verifier_error.final_answers_format_valid == 0
+
+
+@pytest.mark.parametrize(
+    ("call", "unknown"),
+    [
+        (render_tool_call("calculator", {}), 0),
+        (render_tool_call("missing_tool", {}), 1),
+    ],
+)
+def test_parsed_execution_failure_is_one_call_and_one_execution_error(
+    call: str, unknown: int
+) -> None:
+    trajectory = _run([(call, "stop_sequence")])
+
+    assert trajectory.emitted_tool_calls == 1
+    assert trajectory.parsed_tool_calls == 1
+    assert trajectory.tool_execution_successes == 0
+    assert trajectory.tool_execution_errors == 1
+    assert trajectory.unknown_tool_calls == unknown
+    assert trajectory.parse_errors == 0
+
+    stats = RolloutStats()
+    stats.observe(trajectory)
+    metrics = stats.to_dict()
+    assert metrics["parse_valid_tool_call_rate"] == pytest.approx(1.0)
+    assert metrics["tool_execution_success_rate"] == pytest.approx(0.0)
+    assert metrics["tool_execution_error_rate"] == pytest.approx(1.0)
+
+
+def test_environment_exception_is_an_execution_error_not_a_parse_error() -> None:
+    class _BrokenTool(CalculatorEnvironment):
+        def step(self, call: ToolCall) -> StepResult:
+            del call
+            raise ToolEnvironmentError("executor unavailable")
+
+    trajectory = _run(
+        [(render_tool_call("calculator", {"expression": "1 + 1"}), "stop_sequence")],
+        environment=_BrokenTool(prompt_style="compact"),
+    )
+    assert trajectory.termination_reason is TerminationReason.ENVIRONMENT_ERROR
+    assert trajectory.emitted_tool_calls == 1
+    assert trajectory.parsed_tool_calls == 1
+    assert trajectory.tool_execution_errors == 1
+    assert trajectory.parse_errors == 0
+
+
+def test_repeated_call_termination_does_not_invent_an_execution_error() -> None:
+    call = render_tool_call("calculator", {"expression": "1 + 1"})
+    trajectory = _run(
+        [(call, "stop_sequence"), (call, "stop_sequence")],
+        max_repeated_calls=1,
+    )
+    assert trajectory.termination_reason is TerminationReason.REPEATED_CALL_LIMIT
+    assert trajectory.emitted_tool_calls == 2
+    assert trajectory.parsed_tool_calls == 2
+    assert trajectory.tool_execution_successes == 1
+    assert trajectory.tool_execution_errors == 0
+    assert trajectory.repeated_call_terminations == 1
+
+
+@pytest.mark.parametrize(
+    ("limit", "outputs", "expected_errors"),
+    [
+        (0, [("unparseable", "length")], 1),
+        (2, [("first", "length"), ("second", "length")], 2),
+    ],
+)
+def test_parse_error_limit_terminates_when_configured_count_is_reached(
+    limit: int, outputs: Sequence[tuple[str, str]], expected_errors: int
+) -> None:
+    trajectory = _run(outputs, max_parse_errors=limit)
+    assert trajectory.termination_reason is TerminationReason.PARSE_ERROR_LIMIT
+    assert trajectory.parse_errors == expected_errors
+    assert trajectory.tool_execution_errors == 0
+    assert trajectory.parsed_tool_calls == 0
+
+
+def test_reset_observation_is_authoritative_and_reset_runs_once_per_episode() -> None:
+    class _DynamicReset(CalculatorEnvironment):
+        reset_calls = 0
+
+        def reset(self, task: Task) -> Observation:
+            super().reset(task)
+            self.reset_calls += 1
+            return Observation(text=f"dynamic observation for {task.task_id}", state_id="dynamic:7")
+
+        def user_prompt(self, task: Task) -> str:
+            del task
+            return "stale compatibility prompt"
+
+    environment = _DynamicReset(prompt_style="compact")
+    backend = _ScriptedBackend([(render_final("2"), "stop_sequence")])
+    runner = RolloutRunner(
+        backend=backend,
+        environment=environment,
+        config=RolloutConfig(max_turns=1, max_new_tokens_per_turn=512, max_total_tokens=1600),
+    )
+    task = Task(
+        task_id="dynamic",
+        prompt="ignored",
+        answer="2",
+        metadata={"kind": "arithmetic", "expression": "1 + 1"},
+    )
+
+    policy = runner.rollout(task, policy_version=0, seed=0)
+    assert environment.reset_calls == 1
+    user_span = next(span for span in policy.spans if span.span_type is SpanType.USER)
+    user_text = backend.tokenizer.decode(policy.token_ids[user_span.start : user_span.end])
+    assert "dynamic observation for dynamic" in user_text
+    assert "stale compatibility prompt" not in user_text
+    assert user_span.env_state_id == "dynamic:7"
+    assert policy.metadata["initial_observation_state_id"] == "dynamic:7"
+
+    oracle = runner.oracle_rollout(task)
+    assert environment.reset_calls == 2
+    oracle_user = next(span for span in oracle.spans if span.span_type is SpanType.USER)
+    assert oracle_user.env_state_id == "dynamic:7"
+    assert oracle.metadata["initial_observation_state_id"] == "dynamic:7"

--- a/tests/unit/test_benchmark_v2.py
+++ b/tests/unit/test_benchmark_v2.py
@@ -11,7 +11,7 @@ import pytest
 import yaml
 
 from miniverl.config import TrainingMode
-from miniverl.errors import ConfigError
+from miniverl.errors import ConfigError, RunDirectoryError
 from miniverl.evaluation.benchmark import (
     _training_accounting,
     portable_payload,
@@ -227,6 +227,13 @@ def test_schema_v2_benchmark_runs_end_to_end_and_writes_provenance(tmp_path: Pat
     assert persisted.common_resolved_config_digest == result.common_resolved_config_digest
     assert persisted.common_declared_config == persisted.common_resolved_config
     assert persisted.common_declared_config_digest == persisted.common_resolved_config_digest
+
+    with pytest.raises(RunDirectoryError, match="already exists"):
+        run_benchmark(spec, output_dir=tmp_path / "benchmarks")
+
+    resumed = run_benchmark(spec, output_dir=tmp_path / "benchmarks", resume=True)
+    assert len(resumed.arms) == 1
+    assert resumed.arms[0].run_id == arm.run_id
 
 
 def _metrics(tmp_path: Path, rows: list[dict[str, Any]]) -> Any:

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -98,7 +98,7 @@ def test_float16_round_trip_stays_within_its_documented_precision(tmp_path: Path
 
 
 def test_exact_zero_tail_survives_storage(tmp_path: Path):
-    """``k == V`` yields ``-inf``; it must come back as an effectively-zero tail."""
+    """``k == V`` yields ``-inf`` and must round-trip as exact empty mass."""
     cache = TeacherCache.create(
         tmp_path / "tc",
         miniverl_version="0.1.0",
@@ -134,8 +134,151 @@ def test_exact_zero_tail_survives_storage(tmp_path: Path):
     )
     cache.flush()
     loaded = cache.read("t")
-    assert bool(torch.isfinite(loaded.tail_log_prob).all())
-    assert float(loaded.tail_log_prob.exp().max()) == pytest.approx(0.0, abs=1e-12)
+    assert bool(torch.isneginf(loaded.tail_log_prob).all())
+
+
+def test_ordered_span_types_survive_a_heterogeneous_round_trip(tmp_path: Path) -> None:
+    cache = _cache(tmp_path / "tc")
+    batch = _batch("ordered", positions=5)
+    batch.span_types = [
+        "assistant_text",
+        "assistant_final",
+        "assistant_tool_call",
+        "assistant_text",
+        "assistant_final",
+    ]
+    cache.write(batch, selector="hybrid")
+    cache.flush()
+
+    assert cache.read("ordered").span_types == batch.span_types
+
+
+def test_exact_full_vocab_refuses_a_lossy_float16_cache(tmp_path: Path) -> None:
+    with pytest.raises(CacheError, match=r"exact_full_vocab.*float32"):
+        TeacherCache.create(
+            tmp_path / "tc",
+            miniverl_version="0.2.1.dev0",
+            teacher_model_id="toy",
+            teacher_model_revision=None,
+            tokenizer_fingerprint="fp",
+            vocab_size=VOCAB,
+            top_k=VOCAB,
+            temperature=1.0,
+            loss_mode="exact_full_vocab",
+            dtype="float16",
+        )
+
+
+@pytest.mark.parametrize("divergence", ["forward_kl", "reverse_kl", "jsd"])
+def test_exact_full_vocab_cached_provider_matches_resident_exact_provider(
+    tmp_path: Path,
+    divergence: str,
+) -> None:
+    from miniverl.losses.bucketed import teacher_topk_targets
+    from miniverl.losses.chunked import BucketedTargetProvider, ExactTargetProvider
+
+    generator = torch.Generator().manual_seed(44)
+    teacher_logits = torch.randn(4, 17, generator=generator)
+    student_logits = torch.randn(4, 17, generator=generator)
+    indices, log_probs, tail = teacher_topk_targets(teacher_logits, top_k=17)
+    cache = TeacherCache.create(
+        tmp_path / "exact",
+        miniverl_version="0.2.1.dev0",
+        teacher_model_id="teacher",
+        teacher_model_revision="rev",
+        tokenizer_fingerprint="fp",
+        vocab_size=17,
+        top_k=17,
+        temperature=1.0,
+        loss_mode="exact_full_vocab",
+        dtype="float32",
+    )
+    cache.write(
+        TeacherTargetBatch(
+            trajectory_id="exact",
+            policy_version=0,
+            positions=torch.arange(4),
+            topk_indices=indices,
+            topk_log_probs=log_probs,
+            tail_log_prob=tail,
+            target_token_ids=torch.zeros(4, dtype=torch.long),
+            weights=torch.ones(4),
+            temperature=1.0,
+            top_k=17,
+            span_types=["assistant_final"] * 4,
+        ),
+        selector="all_model_tokens",
+        tail_is_exact_zero=True,
+    )
+    cache.flush()
+    loaded = cache.read("exact")
+
+    resident = ExactTargetProvider(
+        teacher_logits_fn=lambda start, end: teacher_logits[start:end],
+        divergence_name=divergence,
+    )
+    cached = BucketedTargetProvider(
+        topk_indices=loaded.topk_indices,
+        topk_log_probs=loaded.topk_log_probs,
+        tail_log_prob=loaded.tail_log_prob,
+        divergence_name=divergence,
+    )
+    assert torch.allclose(
+        resident.divergence(0, 4, student_logits),
+        cached.divergence(0, 4, student_logits),
+        atol=1e-6,
+        rtol=1e-6,
+    )
+
+
+def test_cache_identity_includes_teacher_adapter_provenance(tmp_path: Path) -> None:
+    provenance = {
+        "source": "hub",
+        "identity": "owner/adapter",
+        "revision": "a" * 40,
+        "weights_sha256": "b" * 64,
+        "manifest_digest": "c" * 64,
+        "base_model_revision": "d" * 40,
+    }
+    cache = TeacherCache.create(
+        tmp_path / "tc",
+        miniverl_version="0.2.1.dev0",
+        teacher_model_id="teacher",
+        teacher_model_revision="d" * 40,
+        tokenizer_fingerprint="fp",
+        tokenizer_identity={"structural_digest_v2": "e" * 64},
+        teacher_adapter_provenance=provenance,
+        vocab_size=VOCAB,
+        top_k=TOP_K,
+        temperature=1.0,
+        loss_mode="bucketed_topk_tail",
+    )
+    cache.assert_compatible(
+        teacher_model_id="teacher",
+        teacher_model_revision="d" * 40,
+        tokenizer_fingerprint="fp",
+        tokenizer_identity={"structural_digest_v2": "e" * 64},
+        teacher_adapter_provenance=provenance,
+        vocab_size=VOCAB,
+        top_k=TOP_K,
+        temperature=1.0,
+        loss_mode="bucketed_topk_tail",
+        dtype="float32",
+    )
+    changed = {**provenance, "revision": "f" * 40}
+    with pytest.raises(StaleCacheError, match="teacher_adapter_provenance"):
+        cache.assert_compatible(
+            teacher_model_id="teacher",
+            teacher_model_revision="d" * 40,
+            tokenizer_fingerprint="fp",
+            tokenizer_identity={"structural_digest_v2": "e" * 64},
+            teacher_adapter_provenance=changed,
+            vocab_size=VOCAB,
+            top_k=TOP_K,
+            temperature=1.0,
+            loss_mode="bucketed_topk_tail",
+            dtype="float32",
+        )
 
 
 def test_sharding_is_deterministic_and_index_stays_consistent(tmp_path: Path):

--- a/tests/unit/test_chunked_equivalence.py
+++ b/tests/unit/test_chunked_equivalence.py
@@ -172,6 +172,110 @@ def test_all_zero_weights_give_a_safe_zero_loss():
     assert float(backbone.linear.weight.grad.abs().sum()) == pytest.approx(0.0, abs=1e-9)
 
 
+def test_per_token_components_for_pure_sft_are_explicit() -> None:
+    from miniverl.losses.chunked import chunked_selected_position_loss
+
+    inputs, backbone, lm_head, _, weights, targets = _setup(n=7)
+    output = chunked_selected_position_loss(
+        hidden_states=backbone(inputs),
+        lm_head=lm_head,
+        weights=weights,
+        provider=None,
+        target_token_ids=targets,
+        ce_weight=1.0,
+        chunk_size=3,
+    )
+    assert output.per_token_divergence is None
+    assert output.per_token_ce is not None
+    assert torch.equal(output.per_token_objective, output.per_token_ce)
+    assert len(output.per_token_objective) == 7
+    expected = float((output.per_token_objective * weights).sum() / weights.sum())
+    assert output.loss == pytest.approx(expected, abs=1e-6)
+
+
+def test_per_token_components_for_pure_and_mixed_distillation() -> None:
+    from miniverl.losses.chunked import ExactTargetProvider, chunked_selected_position_loss
+
+    inputs, backbone, lm_head, teacher_logits, weights, targets = _setup(n=9)
+    provider = ExactTargetProvider(teacher_logits_fn=lambda start, end: teacher_logits[start:end])
+    pure = chunked_selected_position_loss(
+        hidden_states=backbone(inputs),
+        lm_head=lm_head,
+        weights=weights,
+        provider=provider,
+        target_token_ids=targets,
+        ce_weight=0.0,
+        chunk_size=4,
+    )
+    assert pure.per_token_divergence is not None
+    assert pure.per_token_ce is None
+    assert torch.equal(pure.per_token_objective, pure.per_token_divergence)
+
+    mixed = chunked_selected_position_loss(
+        hidden_states=backbone(inputs),
+        lm_head=lm_head,
+        weights=weights,
+        provider=provider,
+        target_token_ids=targets,
+        ce_weight=0.25,
+        chunk_size=4,
+    )
+    assert mixed.per_token_divergence is not None
+    assert mixed.per_token_ce is not None
+    expected_tokens = 0.75 * mixed.per_token_divergence + 0.25 * mixed.per_token_ce
+    assert torch.allclose(mixed.per_token_objective, expected_tokens)
+    expected_loss = float((expected_tokens * weights).sum() / weights.sum())
+    assert mixed.loss == pytest.approx(expected_loss, abs=1e-6)
+
+
+def test_empty_batch_preserves_component_applicability() -> None:
+    from miniverl.losses.chunked import ExactTargetProvider, chunked_selected_position_loss
+
+    empty_hidden = torch.zeros(0, 3)
+    head = torch.nn.Linear(3, 5)
+    provider = ExactTargetProvider(teacher_logits_fn=lambda _start, _end: torch.zeros(0, 5))
+    output = chunked_selected_position_loss(
+        hidden_states=empty_hidden,
+        lm_head=head,
+        weights=torch.zeros(0),
+        provider=provider,
+        chunk_size=2,
+    )
+    assert output.per_token_objective.numel() == 0
+    assert output.per_token_divergence is not None
+    assert output.per_token_divergence.numel() == 0
+    assert output.per_token_ce is None
+
+
+def test_span_objective_aggregation_uses_token_weights_and_strict_lengths() -> None:
+    from types import SimpleNamespace
+
+    from miniverl.trainer import OPDTrainer
+
+    sample = SimpleNamespace(
+        alignment=SimpleNamespace(
+            token_weights=[1.0, 9.0],
+            span_types=["assistant_final", "assistant_final"],
+        )
+    )
+    totals = OPDTrainer._loss_by_span_type(
+        None,
+        sample,
+        torch.tensor([10.0, 0.0]),
+    )
+    assert totals["assistant_final"] == [10.0, 10.0]
+    assert totals["assistant_final"][0] / totals["assistant_final"][1] == pytest.approx(1.0)
+
+    broken = SimpleNamespace(
+        alignment=SimpleNamespace(
+            token_weights=[1.0],
+            span_types=["assistant_final", "assistant_text"],
+        )
+    )
+    with pytest.raises(ValueError, match="zip"):
+        OPDTrainer._loss_by_span_type(None, broken, torch.tensor([1.0, 2.0]))
+
+
 def test_empty_selection_is_a_documented_no_op():
     from miniverl.losses.chunked import ExactTargetProvider, chunked_selected_position_loss
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -191,7 +191,10 @@ def test_toy_cpu_recipe_is_parsed_into_the_expected_typed_values() -> None:
 
     assert config.environment.name == "calculator"
     assert config.environment.difficulty == "easy"
-    assert config.environment.params == {"prompt_style": "compact"}
+    assert config.environment.params == {
+        "prompt_style": "compact",
+        "protocol_version": "v1",
+    }
     assert config.environment.train_tasks == raw["environment"]["train_tasks"]
     assert config.environment.eval_tasks == 24
     assert config.environment.test_tasks == 24

--- a/tests/unit/test_environments.py
+++ b/tests/unit/test_environments.py
@@ -742,7 +742,10 @@ def test_make_environment_passes_params_through(name: str) -> None:
     with environment(name, tolerance=0.25) as env:
         assert env.name == name
         assert env.params["tolerance"] == pytest.approx(0.25)
-        assert env.describe() == {"name": name, "params": {"tolerance": 0.25}}
+        assert env.describe() == {
+            "name": name,
+            "params": {"tolerance": 0.25, "protocol_version": "v1"},
+        }
 
 
 # -- J. prompt style -----------------------------------------------------

--- a/tests/unit/test_inspection_reporting.py
+++ b/tests/unit/test_inspection_reporting.py
@@ -356,6 +356,8 @@ def _eval_json() -> dict[str, Any]:
             "success_rate": 0.25,
             "avg_turns": 2.5,
             "invalid_tool_call_rate": 0.125,
+            "parse_valid_tool_call_rate": 0.875,
+            "tool_execution_success_rate": 0.8,
             "generated_tokens_per_task": 40.0,
             "rollout_tokens_per_second": 90.0,
         },
@@ -367,6 +369,8 @@ def _eval_json() -> dict[str, Any]:
             "success_rate": 0.5,
             "avg_turns": 2.0,
             "invalid_tool_call_rate": 0.0,
+            "parse_valid_tool_call_rate": 1.0,
+            "tool_execution_success_rate": 1.0,
             "generated_tokens_per_task": 32.0,
             "rollout_tokens_per_second": 110.0,
         },
@@ -892,8 +896,8 @@ def test_render_markdown_has_the_run_and_a_results_row(report_data: ReportData) 
     text = render_markdown(report_data)
 
     assert f"# miniVERL run `{RUN_ID}`" in text
-    assert "| before training | 0 | 4 | 25.0% | 2.50 | 12.5% | 40.0 |" in text
-    assert "| after training | 4 | 4 | 50.0% | 2.00 | 0.0% | 32.0 |" in text
+    assert "| before training | 0 | 4 | 25.0% | 2.50 | 87.5% | 80.0% | 40.0 |" in text
+    assert "| after training | 4 | 4 | 50.0% | 2.00 | 100.0% | 100.0% | 32.0 |" in text
     assert "_no evaluation recorded_" not in text
     assert "- mode: **opd**  (genuine on-policy distillation)" in text
 
@@ -911,7 +915,7 @@ def test_render_markdown_placeholder_row_without_eval(synthetic_run: Path) -> No
     (synthetic_run / "eval.json").unlink()
     text = render_markdown(ReportData.from_run(synthetic_run))
 
-    assert "| _no evaluation recorded_ | | | | | | |" in text
+    assert "| _no evaluation recorded_ | | | | | | | |" in text
 
 
 def test_render_summary_json_top_level_keys(report_data: ReportData) -> None:

--- a/tests/unit/test_model_state_loading.py
+++ b/tests/unit/test_model_state_loading.py
@@ -1,0 +1,56 @@
+"""Trainable checkpoint tensors are validated completely before mutation."""
+
+from __future__ import annotations
+
+import pytest
+
+from miniverl.errors import BackendError
+from tests.conftest import requires_torch
+
+pytestmark = [requires_torch, pytest.mark.torch]
+
+torch = pytest.importorskip("torch")
+
+
+def _backend():
+    from miniverl.models.tokenizers import ToyTokenizer
+    from miniverl.models.toy import ToyBackend
+
+    return ToyBackend(
+        tokenizer=ToyTokenizer(),
+        model_id="state-test",
+        hidden_size=16,
+        num_layers=1,
+        num_heads=2,
+        intermediate_size=32,
+        max_position_embeddings=128,
+    )
+
+
+def test_missing_trainable_key_is_rejected_before_any_parameter_changes() -> None:
+    backend = _backend()
+    original = backend.trainable_state_dict()
+    incomplete = {name: tensor.clone() for name, tensor in original.items()}
+    changed = next(iter(incomplete))
+    incomplete[changed].add_(1)
+    incomplete.pop(next(reversed(incomplete)))
+
+    with pytest.raises(BackendError, match="missing"):
+        backend.load_trainable_state_dict(incomplete)
+
+    restored = backend.trainable_state_dict()
+    assert all(torch.equal(original[name], restored[name]) for name in original)
+
+
+def test_shape_mismatch_is_rejected_before_any_parameter_changes() -> None:
+    backend = _backend()
+    original = backend.trainable_state_dict()
+    malformed = {name: tensor.clone() for name, tensor in original.items()}
+    changed = next(iter(malformed))
+    malformed[changed] = malformed[changed].reshape(-1)[:1]
+
+    with pytest.raises(BackendError, match="shape"):
+        backend.load_trainable_state_dict(malformed)
+
+    restored = backend.trainable_state_dict()
+    assert all(torch.equal(original[name], restored[name]) for name in original)

--- a/tests/unit/test_offline_contract.py
+++ b/tests/unit/test_offline_contract.py
@@ -60,6 +60,12 @@ def test_train_cli_passes_offline_policy_to_trainer(tmp_path: Path, monkeypatch)
         def close(self) -> None:
             return None
 
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            self.close()
+
     def from_config(*args, **kwargs):
         seen.append(kwargs["local_files_only"])
         return FakeTrainer()
@@ -107,6 +113,7 @@ def test_evaluate_run_passes_offline_policy_to_reconstructed_trainer(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
+    import miniverl.training.checkpoint as checkpoint_module
     from miniverl.config import RunConfig
     from miniverl.trainer import OPDTrainer
 
@@ -133,6 +140,8 @@ def test_evaluate_run_passes_offline_policy_to_reconstructed_trainer(
     )
     (run_dir / "config.resolved.yaml").write_text(config.to_yaml(), encoding="utf-8")
     (run_dir / "manifest.json").write_text("{}", encoding="utf-8")
+    checkpoint = run_dir / "checkpoints" / "final"
+    checkpoint.mkdir(parents=True)
     seen: list[bool] = []
 
     class FakeTrainer:
@@ -142,18 +151,33 @@ def test_evaluate_run_passes_offline_policy_to_reconstructed_trainer(
         def evaluate(self, **kwargs):
             return {"split": kwargs.get("split") or "test"}
 
+        def _apply_checkpoint_progress(self, state) -> None:
+            assert state.global_step == 2
+
         def close(self) -> None:
             return None
 
     def from_config(*args, **kwargs):
         seen.append(kwargs["local_files_only"])
+        assert kwargs["for_evaluation"] is True
         return FakeTrainer()
 
     monkeypatch.setattr(OPDTrainer, "from_config", staticmethod(from_config))
+    state = SimpleNamespace(resolved_config_digest="", global_step=2)
+    validated = SimpleNamespace(
+        state=state,
+        identity={},
+        content_digest="a" * 64,
+        integrity="checksummed_v1",
+    )
+    monkeypatch.setattr(checkpoint_module, "latest_checkpoint", lambda _root: checkpoint)
+    monkeypatch.setattr(checkpoint_module, "validate_checkpoint", lambda _path: validated)
+    monkeypatch.setattr(checkpoint_module, "load_checkpoint", lambda *_args, **_kwargs: state)
     payload = evaluate_run(run_dir, local_files_only=True)
 
     assert seen == [True]
     assert payload["split"] == "test"
+    assert payload["checkpoint_digest"] == "a" * 64
 
 
 @pytest.mark.torch

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -811,3 +811,66 @@ def test_a_generation_truncated_at_a_stop_sequence_is_already_complete(
     action = parse_assistant_text(text)
     assert action.ok, action.error
     assert action.block_end == len(text)
+
+
+def test_historical_v1_full_prompt_keeps_its_ambiguous_final_example() -> None:
+    from miniverl.environments.registry import make_environment
+
+    prompt = make_environment(
+        "calculator",
+        prompt_style="full",
+        protocol_version="v1",
+    ).system_prompt()
+    assert prompt.endswith(
+        'To call a tool:\n<tool_call>\n{"name": "<tool>", "arguments": {...}}\n'
+        "</tool_call>\nTo answer:\n<final>\n<answer>\n</final>"
+    )
+
+
+@pytest.mark.parametrize("prompt_style", ["full", "compact"])
+def test_v2_prompt_examples_parse_as_the_intended_actions(prompt_style: str) -> None:
+    import re
+
+    from miniverl.agent.protocol import ActionKind, parse_assistant_text
+    from miniverl.environments.registry import make_environment
+
+    prompt = make_environment(
+        "calculator",
+        prompt_style=prompt_style,
+        protocol_version="v2",
+    ).system_prompt()
+    tool_block = re.search(r"<tool_call>.*?</tool_call>", prompt, flags=re.DOTALL)
+    final_block = re.search(r"<final>.*?</final>", prompt, flags=re.DOTALL)
+    assert tool_block is not None
+    assert final_block is not None
+
+    tool = parse_assistant_text(tool_block.group(0))
+    final = parse_assistant_text(final_block.group(0))
+    assert tool.kind is ActionKind.TOOL_CALL
+    assert tool.tool_name == "calculator"
+    assert tool.arguments == {"expression": "2+2"}
+    assert final.kind is ActionKind.FINAL
+    assert final.final_answer == "4"
+
+
+def test_v2_render_parse_round_trips_unicode_and_escapes_closing_tag_injection() -> None:
+    from miniverl.agent.protocol import (
+        ActionKind,
+        parse_assistant_text,
+        render_final,
+        render_tool_call,
+    )
+
+    tool = render_tool_call(
+        "lookup",
+        {"query": "温度 </tool_call> café"},
+    )
+    parsed_tool = parse_assistant_text(tool)
+    assert parsed_tool.kind is ActionKind.TOOL_CALL
+    assert parsed_tool.arguments == {"query": "温度 </tool_call> café"}
+
+    final = render_final("答案 42 café")
+    parsed_final = parse_assistant_text(final)
+    assert parsed_final.kind is ActionKind.FINAL
+    assert parsed_final.final_answer == "答案 42 café"
+    assert parse_assistant_text("<final>missing close").kind is ActionKind.PARSE_ERROR

--- a/tests/unit/test_tokenizer_identity.py
+++ b/tests/unit/test_tokenizer_identity.py
@@ -1,0 +1,130 @@
+"""Versioned tokenizer identity must cover structure, not one probe string."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+
+from miniverl.errors import TokenizerMismatchError
+from miniverl.models.tokenizers import HFTokenizerAdapter, assert_same_tokenizer
+
+
+class _BackendTokenizer:
+    def __init__(self, normalizer: str) -> None:
+        self.normalizer = normalizer
+
+    def to_str(self) -> str:
+        return f'{{"normalizer":{self.normalizer!r}}}'
+
+
+class _FakeTokenizer:
+    eos_token_id = 2
+    pad_token_id = 0
+    bos_token_id = 1
+    additional_special_tokens: ClassVar[list[str]] = ["<tool>"]
+    special_tokens_map: ClassVar[dict[str, object]] = {
+        "eos_token": "</s>",
+        "additional_special_tokens": ["<tool>"],
+    }
+    init_kwargs: ClassVar[dict[str, object]] = {"clean_up_tokenization_spaces": False}
+
+    def __init__(
+        self,
+        *,
+        vocab: dict[str, int] | None = None,
+        added: dict[str, int] | None = None,
+        normalizer: str = "NFC",
+    ) -> None:
+        self._vocab = vocab or {
+            "<pad>": 0,
+            "<s>": 1,
+            "</s>": 2,
+            "same": 3,
+            "unprobed-a": 4,
+        }
+        self._added = added or {"<tool>": max(self._vocab.values()) + 1}
+        self.backend_tokenizer = _BackendTokenizer(normalizer)
+
+    def __len__(self) -> int:
+        return max([*self._vocab.values(), *self._added.values()]) + 1
+
+    def __call__(self, _text: str, *, add_special_tokens: bool):
+        assert add_special_tokens is False
+        return {"input_ids": [3, 2]}
+
+    def get_vocab(self) -> dict[str, int]:
+        return dict(self._vocab)
+
+    def get_added_vocab(self) -> dict[str, int]:
+        return dict(self._added)
+
+    def decode(self, token_ids, *, skip_special_tokens: bool):
+        return " ".join(str(item) for item in token_ids)
+
+    def convert_ids_to_tokens(self, token_id: int) -> str:
+        return str(token_id)
+
+
+def _adapter(**kwargs) -> HFTokenizerAdapter:
+    return HFTokenizerAdapter(_FakeTokenizer(**kwargs), "same/repo", revision="abc")
+
+
+@pytest.mark.parametrize(
+    "changed",
+    [
+        {"vocab": {"<pad>": 0, "<s>": 1, "</s>": 2, "same": 3, "unprobed-b": 4}},
+        {"added": {"<structurally-different>": 5}},
+        {"normalizer": "NFKC"},
+    ],
+)
+def test_same_probe_but_different_structure_has_a_different_v2_digest(changed) -> None:
+    baseline = _adapter()
+    candidate = _adapter(**changed)
+
+    assert baseline.fingerprint == candidate.fingerprint
+    assert baseline.identity["structural_digest_v2"] != candidate.identity["structural_digest_v2"]
+    with pytest.raises(TokenizerMismatchError):
+        assert_same_tokenizer(baseline, candidate)
+
+
+def test_identical_tokenizer_structure_has_identical_v2_identity() -> None:
+    assert _adapter().identity == _adapter().identity
+
+
+def test_same_repo_with_different_revisions_is_loaded_and_compared(monkeypatch) -> None:
+    from miniverl.config import RunConfig
+    from miniverl.models import factory
+
+    config = RunConfig.from_mapping(
+        {
+            "models": {
+                "backend": "hf",
+                "student": {"model_id": "same/repo", "revision": "student-rev"},
+                "teacher": {"model_id": "same/repo", "revision": "teacher-rev"},
+            },
+            "environment": {
+                "name": "calculator",
+                "train_tasks": 1,
+                "eval_tasks": 1,
+                "test_tasks": 1,
+            },
+        }
+    )
+    loaded: list[tuple[str, str | None]] = []
+
+    def load(model_id: str, *, revision: str | None, **_kwargs):
+        loaded.append((model_id, revision))
+        return SimpleNamespace(
+            fingerprint="same",
+            identity={"structural_digest_v2": "same"},
+        )
+
+    monkeypatch.setattr(factory.HFTokenizerAdapter, "load", load)
+    factory.build_tokenizer(config)
+
+    assert loaded == [
+        ("same/repo", "student-rev"),
+        ("same/repo", "teacher-rev"),
+    ]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -29,6 +29,7 @@ import re
 import subprocess
 import sys
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -598,12 +599,16 @@ _RUN_PATH_PROPERTIES = (
     "config_original",
     "config_resolved",
     "manifest",
+    "manifest_start",
     "environment",
     "metrics",
     "events",
     "trajectories",
     "eval_trajectories",
     "teacher_cache",
+    "offline_dataset",
+    "offline_dataset_manifest",
+    "offline_dataset_trajectories",
     "checkpoints",
     "eval_json",
     "report_html",
@@ -616,9 +621,16 @@ def test_make_run_id_sanitizes_and_timestamps(monkeypatch: pytest.MonkeyPatch) -
     from miniverl.utils.runs import make_run_id
 
     run_id = make_run_id("Qwen Calc! v2/beta")
-    assert re.fullmatch(r"\d{8}-\d{6}-qwen-calc-v2-beta", run_id), run_id
+    assert re.fullmatch(r"\d{8}-\d{6}-\d{6}-[0-9a-f]{8}-qwen-calc-v2-beta", run_id), run_id
     assert make_run_id("keep.dots_and-dashes").endswith("-keep.dots_and-dashes")
-    assert re.fullmatch(r"\d{8}-\d{6}-run", make_run_id("///"))
+    assert re.fullmatch(r"\d{8}-\d{6}-\d{6}-[0-9a-f]{8}-run", make_run_id("///"))
+
+
+def test_generated_run_ids_do_not_collide_within_one_second() -> None:
+    from miniverl.utils.runs import make_run_id
+
+    ids = {make_run_id("same-run") for _ in range(32)}
+    assert len(ids) == 32
 
 
 def test_make_run_id_honours_an_explicit_id() -> None:
@@ -719,7 +731,29 @@ def test_read_json_raises_run_not_found_for_a_missing_file(tmp_path: Path) -> No
         read_json(tmp_path / "manifest.json")
 
 
+def test_atomic_json_failure_preserves_the_previous_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import miniverl.utils.runs as runs_module
+    from miniverl.utils.runs import write_json, write_json_atomic
+
+    target = write_json(tmp_path / "manifest.json", {"status": "running"})
+    before = target.read_bytes()
+
+    def fail_replace(_source, _target):
+        raise OSError("injected atomic replace failure")
+
+    monkeypatch.setattr(runs_module, "_replace_file", fail_replace)
+    with pytest.raises(OSError, match="injected"):
+        write_json_atomic(target, {"status": "completed"})
+
+    assert target.read_bytes() == before
+    assert not list(tmp_path.glob(".manifest.json.tmp-*"))
+
+
 def test_run_paths_create_makes_the_cache_and_checkpoint_directories(tmp_path: Path) -> None:
+    from miniverl.errors import MiniVerlError
     from miniverl.utils.runs import RunPaths
 
     paths = RunPaths.create(tmp_path / "runs", "20260101-000000-demo")
@@ -727,9 +761,48 @@ def test_run_paths_create_makes_the_cache_and_checkpoint_directories(tmp_path: P
     assert paths.root.is_dir()
     assert paths.teacher_cache.is_dir()
     assert paths.checkpoints.is_dir()
-    # create() is idempotent, so a resumed run does not explode.
-    again = RunPaths.create(tmp_path / "runs", "20260101-000000-demo")
-    assert again == paths
+    marker = paths.root / "old-artifact.txt"
+    marker.write_text("must survive a refused collision", encoding="utf-8")
+
+    with pytest.raises(MiniVerlError, match="already exists") as excinfo:
+        RunPaths.create(tmp_path / "runs", "20260101-000000-demo")
+    assert "--resume" in str(excinfo.value)
+    assert "--overwrite" in str(excinfo.value)
+    assert marker.read_text(encoding="utf-8") == "must survive a refused collision"
+
+
+def test_run_paths_explicit_overwrite_replaces_the_whole_run(tmp_path: Path) -> None:
+    from miniverl.utils.runs import RunPaths
+
+    first = RunPaths.create(tmp_path / "runs", "replace-me")
+    (first.root / "events.jsonl").write_text('{"old": true}\n', encoding="utf-8")
+    (first.checkpoints / "stale").mkdir()
+
+    second = RunPaths.create(tmp_path / "runs", "replace-me", overwrite=True)
+
+    assert second == first
+    assert not second.events.exists()
+    assert not (second.checkpoints / "stale").exists()
+    assert second.teacher_cache.is_dir()
+    assert second.checkpoints.is_dir()
+    assert not list((tmp_path / "runs").glob(".replace-me.overwrite-*"))
+
+
+def test_run_paths_concurrent_creation_has_one_winner(tmp_path: Path) -> None:
+    from miniverl.errors import MiniVerlError
+    from miniverl.utils.runs import RunPaths
+
+    def create() -> str:
+        try:
+            return str(RunPaths.create(tmp_path / "runs", "contended").root)
+        except MiniVerlError:
+            return "refused"
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        outcomes = list(pool.map(lambda _index: create(), range(2)))
+
+    assert outcomes.count(str(tmp_path / "runs" / "contended")) == 1
+    assert outcomes.count("refused") == 1
 
 
 def test_every_run_path_stays_inside_the_root_and_is_unique(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- make run creation, resume and overwrite explicit and contamination-safe
- add atomic checksummed checkpoints, exact offline-KD resume and terminal manifests
- make OOM retry transactional and separate parameter, rollout and optimizer counters
- freeze historical protocol v1, add corrected v2, and make adapter competence version-aware
- correct per-token loss and agent-event metrics, cache identity/exactness, tokenizer/model checks and reset semantics
- finalize 0.2.1 metadata, documentation, figures, support boundaries and release gates

## Why

The v0.2 release exposed several places where a run could look reproducible
while silently attaching to old artifacts, selecting the wrong checkpoint,
regenerating offline data, misreporting versions or conflating emitted, parsed
and executed tool events. This PR turns those behaviors into explicit, tested
contracts without rewriting the frozen v0.2 benchmark or public
protocol-teacher adapter.

## Validation

- `ruff check .`; `ruff format --check .`; `mypy src/miniverl`; actionlint 1.7.12
- 1066 non-GPU/non-network tests passed, 87.11% branch coverage
- 5 GPU tests passed on RTX 4080
- 3 network tests passed, including the immutable Hub adapter revision
- minimum Python 3.10 / Transformers 4.51 boundary: 132 passed
- current Python 3.13 / Transformers 5.14 boundary: 132 passed
- clean wheel/sdist build and Twine check
- clean core-only and `[train]` wheel installs, including collision/overwrite and standalone eval

The frozen benchmark JSON remains byte-identical at SHA-256
`53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`.

Publication is intentionally out of scope for this PR: do not create `v0.2.1`
or trigger PyPI until explicitly authorized.
