### PR TITLE
Sync published v0.2.1 state

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -12,14 +12,14 @@ Last updated: 2026-07-29.
 | --- | --- |
 | audited starting commit | public and local `main` both resolved to `5b1c043b188b30b1261e118293f6fe124e2b7acb` after `git fetch --all --prune` on 2026-07-29 |
 | integration source | branch `v0.2.1-correctness` and correctness PR [#11](https://github.com/DaoyuanLi2816/mini-verl/pull/11), created without rewriting `main` or the immutable `v0.2.0` tag; the PR remains the authoritative integration record after its source branch is deleted |
-| version transition | post-v0.2.0 work started at honest `0.2.1.dev0`; the fully gated release candidate is now `0.2.1` in source, changelog and citation metadata |
-| release state | correctness PR [#11](https://github.com/DaoyuanLi2816/mini-verl/pull/11) carries the complete candidate and records its required checks and merge state; no tag, PyPI upload or GitHub Release for `v0.2.1` exists |
-| publication authorization | absent; the release may be prepared and merged, but must not be tagged or published without explicit authorization |
+| version transition | `v0.2.1` was released from exact commit `591881b0d094f5c53ff47a9419e679b762fb44b0`; post-release development now identifies honestly as `0.2.2.dev0`, while changelog and citation metadata retain the published `0.2.1` record |
+| release state | annotated tag [`v0.2.1`](https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.2.1) resolves to `591881b0d094f5c53ff47a9419e679b762fb44b0`; release run [`30474597179`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30474597179) passed all five jobs, including OIDC publication, public verification and GitHub Release creation |
+| publication authorization | granted on 2026-07-29; the release completed through the tag-only Trusted Publishing workflow without a long-lived PyPI token |
 | frozen scientific artifact | `benchmarks/results/gpu-calc-hard-equal-update-v2.json` remains required at SHA-256 `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc` |
 | immutable protocol adapter | `DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher@23323751318135484c06c043b1f9b9e7016dd89f`; its original v1 competence record is accepted for v1 without fabricating v0.2.1 metrics, and it was neither overwritten nor retrained |
-| local wheel | `miniverl-0.2.1-py3-none-any.whl`, SHA-256 `78bdeaefc7592caaf1004eb01a2ec2ec3060fc96d5ba7853d9d499de254c080d` |
-| local sdist | `miniverl-0.2.1.tar.gz`, SHA-256 `80f890c1ab8be0ccdf6c5ce293a5c4d7bb6a6f7ab7a57db34090384fcaa7e16c` |
-| exact blocker | publication authorization is absent; after a green merge, stop before creating `v0.2.1` or triggering Trusted Publishing |
+| published wheel | [`miniverl-0.2.1-py3-none-any.whl`](https://pypi.org/project/miniverl/0.2.1/), SHA-256 `0177d50026da86047c2a03f90e7786c794b26c5b0d6fef193c58ed35c08d8cda` |
+| published sdist | [`miniverl-0.2.1.tar.gz`](https://pypi.org/project/miniverl/0.2.1/), SHA-256 `80f890c1ab8be0ccdf6c5ce293a5c4d7bb6a6f7ab7a57db34090384fcaa7e16c` |
+| exact blocker | none; PyPI and the GitHub Release expose byte-identical distributions, PyPI reports Trusted Publishing attestations, and a clean public core install passed |
 
 ### Correctness changes and evidence
 
@@ -67,14 +67,15 @@ Last updated: 2026-07-29.
   `docs/gpu-calc-hard-equal-update-v2.svg` remains generated from the frozen
   JSON and labels the cold start `NO TRAINING` and the diagnostic controls
   `PROTOCOL MISMATCH` instead of presenting inapplicable zero bars as outcomes.
-- GitHub environment `pypi` exists with a branch policy; `release.yml` still
-  uses OIDC `id-token: write`; public PyPI remains `miniverl 0.2.0`.
+- GitHub environment `pypi` exists with a branch policy; `release.yml` used
+  OIDC `id-token: write` to publish and independently verify
+  [`miniverl 0.2.1`](https://pypi.org/project/miniverl/0.2.1/).
 
 Currently failing commands: **none**.
 
-Integration record: PR #11 and its required checks are authoritative. Once
-GitHub records a green merge, no further release action is authorized: stop
-before creating `v0.2.1` or triggering Trusted Publishing.
+Publication record: PR #11, annotated tag `v0.2.1`, release run `30474597179`,
+the public PyPI files and the GitHub Release are authoritative. The published
+tag and distributions are immutable; new work proceeds from `0.2.2.dev0`.
 
 ## v0.2 release-hardening status
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,12 +1,10 @@
 # Release checklist
 
-This is the release gate for `v0.2.1`. A checked item names an invariant that
-was exercised on the release-candidate source. The tag workflow repeats the
-mechanical gates and refuses inconsistent metadata or an unchecked pre-tag
-item.
-
-Publication is intentionally separate: `v0.2.1` must not be tagged or uploaded
-until the maintainer explicitly authorizes it.
+This is the release gate and publication record for `v0.2.1`. A checked item
+names an invariant that was exercised on the release source. The tag workflow
+repeated the mechanical gates and refused inconsistent metadata or an
+unchecked pre-tag item. Publication began only after explicit maintainer
+authorization.
 
 ## Version consistency
 
@@ -108,17 +106,35 @@ until the maintainer explicitly authorizes it.
 
 ## After the tag
 
-These actions remain deliberately unchecked until publication is explicitly
-authorized:
+Publication completed on 2026-07-29:
 
-- [ ] Create annotated tag `v0.2.1` on the exact validated main commit.
-- [ ] Verify the tag workflow tests and builds the distributions once.
-- [ ] Verify OIDC publication, public PyPI hashes and attestations.
-- [ ] Verify the GitHub Release contains the same wheel, sdist and
+- [x] Create annotated tag `v0.2.1` on exact validated commit
+      `591881b0d094f5c53ff47a9419e679b762fb44b0`.
+- [x] Verify release run
+      [`30474597179`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30474597179)
+      tests and builds the distributions once.
+- [x] Verify OIDC publication, public PyPI hashes and Trusted Publishing
+      attestations for
+      [`miniverl 0.2.1`](https://pypi.org/project/miniverl/0.2.1/).
+- [x] Verify the
+      [`miniVERL v0.2.1`](https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.2.1)
+      GitHub Release contains the same wheel, sdist and
       `SHA256SUMS`.
-- [ ] Install public `miniverl==0.2.1` in a clean environment and run
-      `miniverl --version` plus `miniverl doctor --json`.
-- [ ] Open the post-release state-sync PR and bump main to `0.2.2.dev0`.
+- [x] Install public `miniverl==0.2.1` in a clean Windows environment and run
+      `miniverl --version` plus `miniverl doctor --json`; the core verdict
+      passed and Torch remained absent.
+- [x] Open the post-release state-sync change and advance development to
+      `0.2.2.dev0`.
+
+Published artifact identity:
+
+- `miniverl-0.2.1-py3-none-any.whl`: SHA-256
+  `0177d50026da86047c2a03f90e7786c794b26c5b0d6fef193c58ed35c08d8cda`
+- `miniverl-0.2.1.tar.gz`: SHA-256
+  `80f890c1ab8be0ccdf6c5ce293a5c4d7bb6a6f7ab7a57db34090384fcaa7e16c`
+
+Independent downloads from PyPI and the GitHub Release reproduced both
+digests.
 
 ## Historical v0.2.0 record
 

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.2.1"
+__version__ = "0.2.2.dev0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

- record the successful `v0.2.1` Trusted Publishing release, public artifact hashes, and release workflow
- mark every post-tag release check complete with independently verified evidence
- advance the development version to `0.2.2.dev0` while keeping the published tag and citation record immutable

## Validation

- `ruff check .`
- `ruff format --check .`
- `mypy src/miniverl`
- `pytest -q tests/unit/test_release_workflow.py tests/unit/test_pypi_release_verifier.py tests/unit/test_packaging.py` (`88 passed`)
- actionlint 1.7.12
- PyPI and GitHub Release artifacts match byte-for-byte
- clean `pip install miniverl==0.2.1`, version and doctor checks passed without Torch
- frozen benchmark SHA-256 remains `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`