### PR TITLE
Sync published v0.2.2 state

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,19 @@ jobs:
           VERSION="${VERSION#v}"
           python -m venv release-verify
           release-verify/bin/python -m pip install --upgrade pip
-          release-verify/bin/python -m pip install --no-cache-dir "miniverl==$VERSION"
+          for attempt in {1..12}; do
+            if release-verify/bin/python -m pip install \
+              --no-cache-dir --index-url https://pypi.org/simple \
+              "miniverl==$VERSION"; then
+              break
+            fi
+            if [ "$attempt" -eq 12 ]; then
+              echo "public simple index did not expose miniverl==$VERSION"
+              exit 1
+            fi
+            echo "public simple index is still propagating; retrying in 10 seconds"
+            sleep 10
+          done
           test "$(release-verify/bin/miniverl --version)" = "miniverl $VERSION"
           release-verify/bin/miniverl doctor --json > doctor.json
           release-verify/bin/python - <<'PY'

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -6,18 +6,21 @@ and what it printed.
 
 Last updated: 2026-07-29.
 
-## v0.2.2 single-GPU portability release candidate
+## v0.2.2 single-GPU portability release status
 
 | item | current state |
 | --- | --- |
-| integration source | `agent/single-gpu-visuals`, based on synchronized public `main` at `dcded6bd1948eb7421f89e336f611e3b0d3c0ad3` |
-| version transition | source, changelog and citation metadata identify `0.2.2`; the intended annotated tag is `v0.2.2` |
+| integration source | PR [#13](https://github.com/DaoyuanLi2816/mini-verl/pull/13), merged as `518590cb43ff788fa65f73ee9cf3a7afb6dfba5a` after all pull-request and synchronized-main checks passed |
+| version transition | `v0.2.2` was released from exact commit `518590cb43ff788fa65f73ee9cf3a7afb6dfba5a`; post-release development now identifies as `0.2.3.dev0` |
 | hardware scope | one NVIDIA CUDA GPU with no device-name allowlist; automatic dtype selects bf16 when supported and fp16 otherwise; exact fit remains model/budget dependent |
 | measured evidence | the only published real-model GPU measurements remain the RTX 4080 runs; RTX 3070, Titan V, RTX 5090 and other cards are portable code paths, not fabricated benchmark claims |
 | presentation | banner and generated benchmark SVG use a dark single-GPU visual system; grid lines begin below tick labels and diagnostic 0% controls are status pills |
 | package discovery | both READMEs, project metadata and the GitHub About homepage expose `https://pypi.org/project/miniverl/` |
 | frozen scientific artifact | `benchmarks/results/gpu-calc-hard-equal-update-v2.json` remains byte-identical at SHA-256 `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc` |
-| publication state | authorized for direct release; publish only after local gates, pull-request CI and synchronized default-branch CI pass |
+| release state | release run [`30494182647`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30494182647) passed on attempt 3 after PyPI simple-index propagation; OIDC publication, public hashes, attestations, clean install and GitHub Release all passed |
+| published wheel | [`miniverl-0.2.2-py3-none-any.whl`](https://pypi.org/project/miniverl/0.2.2/), SHA-256 `1ead97173bb11ce3da963b94f628df825a5b14648fed488cf4d88c47cba9dd59` |
+| published sdist | [`miniverl-0.2.2.tar.gz`](https://pypi.org/project/miniverl/0.2.2/), SHA-256 `3951dd4addc5d85b3e58ce72ecffac65c38bf2eab951d2c08cce8f20c886185c` |
+| exact blocker | none; public PyPI and GitHub Release artifacts are byte-identical, and clean Python 3.10 and workflow Python 3.12 core installations passed |
 
 ## Historical v0.2.1 correctness release status
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -110,12 +110,33 @@ authorization.
 
 ## After the tag
 
-Complete and check these in the post-release state-sync change:
+Publication completed on 2026-07-29:
 
-- [ ] Record the exact `v0.2.2` tag commit and release workflow run.
-- [ ] Verify public PyPI hashes, attestations and a clean core installation.
-- [ ] Verify the GitHub Release contains the identical distributions.
-- [ ] Advance development to `0.2.3.dev0`.
+- [x] Annotated tag `v0.2.2` resolves to exact validated commit
+      `518590cb43ff788fa65f73ee9cf3a7afb6dfba5a`.
+- [x] Release run
+      [`30494182647`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30494182647)
+      passed metadata, tests, build, OIDC publication, public verification and
+      GitHub Release creation.
+- [x] Public PyPI hashes and Trusted Publishing attestations passed; clean
+      Python 3.10 and workflow Python 3.12 core installs reported
+      `miniverl 0.2.2`.
+- [x] The
+      [`miniVERL v0.2.2`](https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.2.2)
+      GitHub Release contains the byte-identical wheel, sdist and `SHA256SUMS`.
+- [x] Development advanced to `0.2.3.dev0`.
+
+Published artifact identity:
+
+- `miniverl-0.2.2-py3-none-any.whl`: SHA-256
+  `1ead97173bb11ce3da963b94f628df825a5b14648fed488cf4d88c47cba9dd59`
+- `miniverl-0.2.2.tar.gz`: SHA-256
+  `3951dd4addc5d85b3e58ce72ecffac65c38bf2eab951d2c08cce8f20c886185c`
+
+The first two install-verification attempts saw PyPI's JSON/file APIs before
+the public simple index had propagated. Attempt 3 passed unchanged. The
+post-release workflow now retries that final public-index install so future
+releases do not report this expected propagation window as a package defect.
 
 ## Historical v0.2.1 record
 

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.2.2"
+__version__ = "0.2.3.dev0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

- record the verified v0.2.2 tag, release run and public artifact hashes
- advance development to 0.2.3.dev0
- retry the final PyPI simple-index install during normal propagation windows

## Validation

- v0.2.2 release run 30494182647 passed on attempt 3
- public Python 3.10 install reports miniverl 0.2.2
- 83 focused packaging, version and PyPI-verifier tests passed
- ruff, formatting, mypy and workflow YAML parsing passed