### PR TITLE
Harden v0.2.3 clarity and artifact safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to miniVERL are recorded here. The format follows
 
 ## [Unreleased]
 
+### Changed
+
+- The generated GPU benchmark figure now reports measured 0% negative controls,
+  separates protocol qualification from the quantitative axis, and distinguishes
+  continuation time from the reusable protocol-teacher preparation cost.
+- The banner and bilingual onboarding now describe the device-name-agnostic
+  single-GPU CUDA path and install CUDA PyTorch before optional training extras.
+- Protocol-v2 prompt examples are generated from each environment's active
+  `ToolSpec`; the immutable protocol-v1 prompt is unchanged.
+
+### Fixed
+
+- Legacy teacher caches can no longer bypass adapter or structural-tokenizer
+  identity checks, and cache shard/index publication is crash-safe.
+- Tokenizer structural digests ignore source-location metadata, and failed
+  model construction cannot leave an orphan partial run directory.
+
 ## [0.2.2] - 2026-07-29
 
 Single-GPU portability and presentation release.
@@ -291,7 +308,8 @@ Same-tokenizer only; one trajectory per forward pass; `swap` unavailable for
 quantized models; only Qwen3 and Qwen2 architectures tested; single-seed GPU
 results. The full list is in `docs/limitations.md`.
 
-[Unreleased]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.1.0
+[0.2.0]: https://github.com/DaoyuanLi2816/mini-verl/compare/37781ef0b00f3346d4b7b40fbe4d1c0ce1355063...v0.2.0
+[0.1.0]: https://github.com/DaoyuanLi2816/mini-verl/tree/37781ef0b00f3346d4b7b40fbe4d1c0ce1355063

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ keeps the whole lifecycle in one readable single-GPU process.
 | Compressed `top-k + tail` KL and JSD | yes; the unsmoothed coarse-graining has a proven lower-bound relationship to the exact loss |
 | Privileged-context teacher with an explicit alignment map | yes |
 | Frozen standard PEFT teacher adapters with provenance and competence gates | yes |
-| Single-GPU CUDA path with automatic bf16/fp16 selection | yes; model-agnostic code path, measured reference on an RTX 4080 |
+| Single-GPU CUDA path with automatic bf16/fp16 selection | yes; device-name-agnostic CUDA path, measured reference on an RTX 4080 |
 | `resident` and `swap` memory strategies, `auto` resolution | yes, with an equivalence test |
 | Versioned, checksummed, pickle-free teacher-target cache | yes |
 | SFT / offline KD / strict OPD / explicitly labeled replay behind one trainer | yes |
@@ -115,33 +115,39 @@ keeps the whole lifecycle in one readable single-GPU process.
 
 The [public, immutable protocol-teacher adapter](https://huggingface.co/DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher)
 is the default in the single-GPU recipe. It passed an independently
-prespecified policy-competence gate before this benchmark was inspected. The
-two controls intentionally remove that guarantee: their loss decreased
-normally, but they taught the student an incompatible tool policy. This is a
-measured teacher-competence failure, not a trainer crash.
+prespecified policy-competence gate before this benchmark was inspected. Both
+controls completed normally and measured 0% in both seeds; they were neither
+configuration failures nor crashes. Both used the ambiguous historical
+protocol-v1 prompt, so 0% cannot be attributed solely to intrinsic teacher
+behaviour; it diagnoses the missing qualification gate in that setup.
 
-The historical teacher-selection gate and the downstream benchmark both used
-the same 24-task v0.2 `test` set. Candidate A was prespecified and passed on the
-first attempt, so no fallback tuning occurred, but the final set was not a
-completely untouched test set. Future teacher selection uses `eval`; downstream
-reporting uses `test`. See [limitations](docs/limitations.md).
+The historical gate and benchmark reused the same 24-task v0.2 `test` set.
+Candidate A was prespecified and passed first try (no fallback tuning), but the
+set was not untouched. Future selection uses `eval`; reporting uses `test`.
+See [limitations](docs/limitations.md).
 
-OPD still only ties SFT and takes about 6x as much training time here
-(523.8 s versus 86.4 s on average). The task saturates; two seeds do not support
-a significance claim, and no general OPD advantage is claimed. See the
+OPD only ties SFT and takes 6.1× as much continuation time here (523.8 s versus
+86.4 s). The task saturates; two seeds support neither significance nor a
+general OPD advantage. See the
 [full result and legacy transcript diagnosis](docs/rtx4080-baselines.md).
 
 ![Two-seed protocol-teacher benchmark](docs/gpu-calc-hard-equal-update-v2.svg)
 
-An older RTX 4080 pipeline smoke run used the now-preserved
-[raw-teacher control recipe](recipes/qwen_consumer_gpu_calc_raw_teacher.yaml)
-to train **Qwen3-0.6B** from **Qwen3-1.7B** in **481 s / 16 optimizer steps**,
-peaking at **4.25 GiB
-allocated / 4.76 GiB reserved**, and moved held-out greedy success from
-**0.0% to 100.0%** on 12 tasks. The 8-cycle supervised cold start did most of
-that work: the first OPD rollout batch already scored 83.3%. It demonstrates
-the pipeline end to end, not an OPD-over-SFT result. Every number is traceable
-to [`docs/rtx4080-baselines.md`](docs/rtx4080-baselines.md).
+| Artifact | Role |
+| --- | --- |
+| [Default recipe](recipes/qwen_consumer_gpu_calc.yaml) | protocol-qualified default |
+| [Schema-v2 benchmark](benchmarks/results/gpu-calc-hard-equal-update-v2.json) | frozen five-arm result |
+| [Raw-teacher recipe](recipes/qwen_consumer_gpu_calc_raw_teacher.yaml) | historical control; not default |
+
+<details>
+<summary>Historical 481-second raw-teacher smoke (schema v1)</summary>
+
+On RTX 4080, 16 updates took 481 s, peaked at **4.25/4.76 GiB
+allocated/reserved**, and moved 12-task success from **0% to 100%**. Cold start
+did most of it (first OPD batch: 83.3%); this proves the pipeline, not OPD over
+SFT. [Trace](docs/rtx4080-baselines.md).
+
+</details>
 
 ## Local toy demo
 
@@ -239,10 +245,10 @@ The recipe pins both revisions:
 | teacher | `Qwen/Qwen3-1.7B` | `70d244cc86ccca08cf5af4e1e306ecf908b1ad5e` | Apache-2.0 |
 
 Their `tokenizer.json` files are byte-identical
-(`sha256 aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4`),
-which is what makes the same-tokenizer contract hold. miniVERL verifies it at
-load time by behavioural fingerprint and refuses to run otherwise. The recipe
-also pins the [protocol-teacher adapter](https://huggingface.co/DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher)
+(`sha256 aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4`).
+New runs compare structural identity; old artifacts use the legacy fixed-probe
+behavioural fingerprint.
+The recipe also pins the [protocol-teacher adapter](https://huggingface.co/DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher)
 at revision `23323751318135484c06c043b1f9b9e7016dd89f` and requires its recorded
 strict policy success to be at least 50% before allocating the teacher.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -74,7 +74,7 @@ miniVERL 把上面每一条都变成**被代码检查的性质**，而不是注�
 | 压缩的 `top-k + tail` KL / JSD | 支持；未平滑粗粒化与精确散度的下界关系有严格证明 |
 | 特权上下文教师模式，带显式对齐表 | 支持 |
 | 标准冻结 PEFT 教师适配器，带来源记录与能力门禁 | 支持 |
-| 自动选择 bf16/fp16 的单卡 CUDA 路径 | 支持；代码路径不绑定型号，实测参考为 RTX 4080 |
+| 自动选择 bf16/fp16 的单卡 CUDA 路径 | 支持；CUDA 路径不绑定设备名称，实测参考为 RTX 4080 |
 | `resident` / `swap` 显存策略与 `auto` 解析 | 支持，并有等价性测试 |
 | 带版本号与校验和、完全不用 pickle 的教师目标缓存 | 支持 |
 | SFT / 离线 KD / 严格 OPD / 显式标注 replay 统一在一个 trainer 中 | 支持 |
@@ -101,25 +101,31 @@ miniVERL 把上面每一条都变成**被代码检查的性质**，而不是注�
 
 [公开且固定版本的协议教师适配器](https://huggingface.co/DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher)
 现在是单卡配方的默认教师。它在下游 benchmark 被查看之前，已经通过
-预先指定、独立评估的策略能力门槛。两个负对照故意去掉了这个保证：loss 正常
-下降，但教师把不兼容的工具策略教给了学生。这是实测的教师能力问题，不是
-trainer 崩溃。
+预先指定的能力门槛。两个负对照均正常完成且两个种子都是 0%；它们不是配置
+失败或崩溃。两者使用含歧义的历史 protocol-v1 prompt，故不能把 0% 只归因
+于教师内在行为；它诊断的是该设置缺少资格门禁。
 
-OPD 在这里仍然只是追平 SFT，而且平均训练时间约为 SFT 的 6 倍
-（523.8 秒对 86.4 秒）。任务已经饱和；两个种子不足以支持显著性结论，也不
-构成 OPD 普遍更优的证据。完整结果和旧实验的逐轨迹诊断见
+OPD 在这里仍然只是追平 SFT，继续训练耗时是 SFT 的 6.1 倍（523.8 秒对
+86.4 秒）。任务已经饱和；两个种子既不支持显著性结论，也不构成 OPD
+普遍更优的证据。完整结果和旧实验的逐轨迹诊断见
 [`docs/rtx4080-baselines.md`](docs/rtx4080-baselines.md)。
 
 ![双种子协议教师对照](docs/gpu-calc-hard-equal-update-v2.svg)
 
-更早的一次 RTX 4080 流水线 smoke 运行使用了现在保留的
-[原始教师对照配方](recipes/qwen_consumer_gpu_calc_raw_teacher.yaml)，用
-**Qwen3-1.7B** 蒸馏 **Qwen3-0.6B**，耗时 **481 秒 / 16 个优化步**，显存峰值为
-**4.25 GiB 已分配 / 4.76 GiB 已保留**，并在 12 个留出任务上把贪心成功率
-从 **0.0% 提升到 100.0%**。其中 8 个 cycle 的监督冷启动完成了大部分工作：
-第一批 OPD rollout 已经达到 83.3%。它证明流水线能端到端运行，而不是证明
-OPD 优于 SFT。所有数字都可追溯到
-[`docs/rtx4080-baselines.md`](docs/rtx4080-baselines.md)。
+| 产物 | 定位 |
+| --- | --- |
+| [默认配方](recipes/qwen_consumer_gpu_calc.yaml) | 协议合格 |
+| [Schema-v2 结果](benchmarks/results/gpu-calc-hard-equal-update-v2.json) | 冻结五臂对照 |
+| [Raw-teacher](recipes/qwen_consumer_gpu_calc_raw_teacher.yaml) | 历史对照；非默认 |
+
+<details>
+<summary>481 秒 smoke（v1）</summary>
+
+16 步 481 秒，峰值 **4.25/4.76 GiB 已分配/保留**，12 题
+从 **0% 到 100%**。冷启动完成了大部分工作（首批 OPD：83.3%）；这证明
+流水线，而非 OPD 优于 SFT。[追溯](docs/rtx4080-baselines.md)。
+
+</details>
 
 ## 本地玩具演示
 
@@ -175,10 +181,9 @@ tokens by span type (only assistant_* can enter the loss)
 
 ## 个人单卡快速上手
 
-默认配方使用 `device: auto` 与 `dtype: auto`：支持 bf16 的显卡自动使用 bf16，
-Titan V 等较老 CUDA 显卡自动使用 fp16。RTX 3070、Titan V、RTX 4080 和
-RTX 5090 级别显卡都走同一条代码路径；本仓库目前只有 RTX 4080 的实测结果。
-能否装下取决于显存、模型大小、驱动和 token 预算，而不是显卡的商品名。修改配方前请阅读
+默认 `device: auto` / `dtype: auto`：新卡用 bf16，Titan V 等旧卡用 fp16。
+RTX 3070、Titan V、RTX 4080、RTX 5090 走同一 CUDA 路径，但仅 4080 有实测。
+能否装下取决于显存、模型、驱动和 token 预算。修改前请阅读
 [`单卡适配指南`](docs/single-gpu-guide.md)。
 
 ```bash
@@ -201,7 +206,7 @@ miniverl report   runs/<run-id> --out runs/<run-id>/report.html
 | 学生 | `Qwen/Qwen3-0.6B` | `c1899de289a04d12100db370d81485cdf75e47ca` | Apache-2.0 |
 | 教师 | `Qwen/Qwen3-1.7B` | `70d244cc86ccca08cf5af4e1e306ecf908b1ad5e` | Apache-2.0 |
 
-两者的 `tokenizer.json` **逐字节相同**（`sha256 aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4`），这正是"同一分词器"契约成立的依据。miniVERL 在加载时用行为指纹核对，不一致就直接报错退出。
+两者的 `tokenizer.json` **逐字节相同**（`sha256 aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4`）。新运行首查结构身份；旧产物回退到固定探针行为指纹。
 
 配方还把[协议教师适配器](https://huggingface.co/DaoyuanLi/mini-verl-qwen3-1.7b-protocol-teacher)
 锁定在 revision `23323751318135484c06c043b1f9b9e7016dd89f`，并在分配教师模型

--- a/docs/banner.svg
+++ b/docs/banner.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 250" width="880" height="250"
      role="img" aria-labelledby="banner-title banner-desc">
   <title id="banner-title">miniVERL</title>
-  <desc id="banner-desc">A personal single-GPU training stack for tool-using agents.</desc>
+  <desc id="banner-desc">A single-GPU CUDA LLM post-training stack for tool-using agents.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#030711"/>
@@ -40,7 +40,7 @@
 
   <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif">
     <text x="44" y="32" font-size="10.5" font-weight="750" letter-spacing="2.15" fill="#7dd3fc">
-      PERSONAL SINGLE-GPU TRAINING
+      SINGLE-GPU LLM POST-TRAINING
     </text>
     <text x="44" y="80" font-size="45" font-weight="790" letter-spacing="-1.8" fill="#f8fafc">
       mini<tspan fill="url(#brand)">VERL</tspan>
@@ -56,22 +56,22 @@
     </text>
 
     <g font-size="11.2" font-weight="680">
-      <rect x="44" y="173" width="82" height="24" rx="12" fill="#22d3ee" fill-opacity=".12"
+      <rect x="44" y="173" width="86" height="24" rx="12" fill="#22d3ee" fill-opacity=".12"
             stroke="#67e8f9" stroke-opacity=".38"/>
-      <text x="85" y="189.5" text-anchor="middle" fill="#cffafe">one card</text>
-      <rect x="135" y="173" width="97" height="24" rx="12" fill="#60a5fa" fill-opacity=".12"
+      <text x="87" y="189.5" text-anchor="middle" fill="#cffafe">1× CUDA GPU</text>
+      <rect x="138" y="173" width="112" height="24" rx="12" fill="#60a5fa" fill-opacity=".12"
             stroke="#93c5fd" stroke-opacity=".34"/>
-      <text x="183.5" y="189.5" text-anchor="middle" fill="#dbeafe">GPU adaptive</text>
-      <rect x="241" y="173" width="91" height="24" rx="12" fill="#a78bfa" fill-opacity=".13"
+      <text x="194" y="189.5" text-anchor="middle" fill="#dbeafe">BF16 / FP16 auto</text>
+      <rect x="258" y="173" width="110" height="24" rx="12" fill="#a78bfa" fill-opacity=".13"
             stroke="#c4b5fd" stroke-opacity=".35"/>
-      <text x="286.5" y="189.5" text-anchor="middle" fill="#ede9fe">audit first</text>
+      <text x="313" y="189.5" text-anchor="middle" fill="#ede9fe">typed provenance</text>
     </g>
 
-    <rect x="44" y="208" width="288" height="27" rx="7" fill="#020617" fill-opacity=".72"
+    <rect x="44" y="208" width="324" height="27" rx="7" fill="#020617" fill-opacity=".72"
           stroke="#516381" stroke-opacity=".42"/>
     <circle cx="59" cy="221.5" r="3" fill="#22d3ee"/>
     <text x="70" y="226" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
-          font-size="11.3" fill="#dbeafe">pip install "miniverl[train,cuda]"</text>
+          font-size="11.3" fill="#dbeafe">pip install miniverl</text>
 
     <path d="M401 49 V201" fill="none" stroke="#33486d" stroke-width="2"
           stroke-linecap="round"/>
@@ -112,7 +112,7 @@
       <path d="M443 197l5-7 5 4 5-8" fill="none" stroke="#f3e8ff" stroke-width="1.8"
             stroke-linecap="round" stroke-linejoin="round"/>
       <text x="478" y="188" font-size="14" font-weight="720" fill="#f8fafc">Distill</text>
-      <text x="478" y="207" font-size="12" fill="#afbed3">Use BF16 or FP16 on the GPU you have</text>
+      <text x="478" y="207" font-size="12" fill="#afbed3">Exact or top-k + tail teacher targets</text>
     </g>
   </g>
 </svg>

--- a/docs/gpu-calc-hard-equal-update-v2.svg
+++ b/docs/gpu-calc-hard-equal-update-v2.svg
@@ -1,16 +1,16 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1120" height="664" viewBox="0 0 1120 664" role="img" aria-labelledby="benchmark-title benchmark-desc">
 <title id="benchmark-title">miniVERL protocol-teacher benchmark</title>
-<desc id="benchmark-desc">Strict held-out success and continuation train time for equal-update arms over 2 prespecified seeds. 2 completed negative-control arms without a protocol qualification gate are shown separately. The cold-start baseline has zero continuation updates.</desc>
+<desc id="benchmark-desc">Strict success on the v0.2 calculator test set and continuation train time for equal-update arms over 2 prespecified seeds. 2 completed negative-control arms without a protocol qualification gate are shown separately. The cold-start baseline has zero continuation updates.</desc>
 <style>text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,Segoe UI,sans-serif;fill:#e6edf7}.title{font-size:25px;font-weight:760;letter-spacing:-.35px}.sub{font-size:13px;fill:#91a0b8}.head{font-size:14px;font-weight:700;fill:#dce7f7}.label{font-size:14px;font-weight:580}.value{font-size:13px;font-weight:730}.axis{font-size:11.5px;fill:#9aabc3}.note{font-size:13px;fill:#8fa0b9}.section{font-size:10.5px;font-weight:760;letter-spacing:1.15px;fill:#fda4af}.badge{font-size:9px;font-weight:760;letter-spacing:.55px;fill:#fecdd3}.panel{fill:url(#panel);stroke:#263752}.track{fill:#19263c}.grid{stroke:#2b3c58;stroke-width:1}.row{fill:#ffffff;fill-opacity:.018}.dot{fill:#08101f;stroke-width:2}.pill{fill:#0b1425;stroke-width:1.4}</style>
 <defs><linearGradient id="background" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#050816"/><stop offset="58%" stop-color="#0a1224"/><stop offset="100%" stop-color="#101a34"/></linearGradient><linearGradient id="panel" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#111d34"/><stop offset="100%" stop-color="#0b1426"/></linearGradient><radialGradient id="glow" cx="80%" cy="0%" r="70%"><stop offset="0%" stop-color="#4f46e5" stop-opacity=".24"/><stop offset="100%" stop-color="#4f46e5" stop-opacity="0"/></radialGradient></defs>
 <rect width="100%" height="100%" rx="18" fill="url(#background)"/>
 <rect width="100%" height="100%" rx="18" fill="url(#glow)"/>
 <rect x=".75" y=".75" width="1118.5" height="662.5" rx="17.25" fill="none" stroke="#334663" stroke-width="1.5"/>
-<text class="title" x="36" y="42">Same strict success; protocol OPD uses 6.1× more continuation time</text>
+<text class="title" x="36" y="42">Saturated calculator task · same success, 6.1× OPD continuation time</text>
 <text class="sub" x="36" y="68">Schema v2  ·  2 prespecified seeds  ·  equal budget: 12 continuation optimizer updates</text>
 <rect class="panel" x="276" y="96" width="394" height="506" rx="14"/>
 <rect class="panel" x="694" y="96" width="390" height="506" rx="14"/>
-<text class="head" x="310" y="123">Strict held-out success</text>
+<text class="head" x="310" y="123">Strict success on v0.2 test set</text>
 <text class="head" x="728" y="123">Continuation train time</text>
 <text class="axis" x="310.0" y="151" text-anchor="middle">0%</text>
 <line class="grid" x1="310.0" y1="166" x2="310.0" y2="590"/>
@@ -68,8 +68,8 @@
 <rect class="row" x="24" y="444" width="1072" height="60" rx="10"/>
 <g data-arm="opd-raw-teacher" data-success-mean="0.000000" data-train-seconds-mean="443.953792">
 <text class="label" x="36" y="469">Raw teacher (control)</text>
-<rect class="pill" x="36" y="477" width="232" height="18" rx="9" stroke="#fb7185" stroke-opacity=".65"/>
-<text class="badge" x="152" y="489.5" text-anchor="middle">NEGATIVE CONTROL · NO PROTOCOL GATE</text>
+<rect class="pill" x="36" y="477" width="176" height="18" rx="9" stroke="#fb7185" stroke-opacity=".65"/>
+<text class="badge" x="124" y="489.5" text-anchor="middle">NEGATIVE CONTROL · UNGATED</text>
 <rect class="track" x="310" y="464" width="292" height="20" rx="5"/>
 <circle class="dot" cx="310.0" cy="469" r="3.5" stroke="#fb7185"/>
 <circle class="dot" cx="310.0" cy="479" r="3.5" stroke="#fb7185"/>
@@ -83,8 +83,8 @@
 <rect class="row" x="24" y="522" width="1072" height="60" rx="10"/>
 <g data-arm="opd-privileged-context" data-success-mean="0.000000" data-train-seconds-mean="531.523058">
 <text class="label" x="36" y="547">Privileged context (control)</text>
-<rect class="pill" x="36" y="555" width="232" height="18" rx="9" stroke="#fbbf24" stroke-opacity=".65"/>
-<text class="badge" x="152" y="567.5" text-anchor="middle">NEGATIVE CONTROL · NO PROTOCOL GATE</text>
+<rect class="pill" x="36" y="555" width="176" height="18" rx="9" stroke="#fbbf24" stroke-opacity=".65"/>
+<text class="badge" x="124" y="567.5" text-anchor="middle">NEGATIVE CONTROL · UNGATED</text>
 <rect class="track" x="310" y="542" width="292" height="20" rx="5"/>
 <circle class="dot" cx="310.0" cy="547" r="3.5" stroke="#fbbf24"/>
 <circle class="dot" cx="310.0" cy="557" r="3.5" stroke="#fbbf24"/>
@@ -95,6 +95,6 @@
 <circle class="dot" cx="957.9" cy="557" r="3.5" stroke="#fbbf24"/>
 <text class="value" x="1016" y="557">532s</text>
 </g>
-<text class="note" x="36" y="627">Protocol-teacher preparation: ~555 s once, excluded from continuation bars.</text>
+<text class="note" x="36" y="627">Teacher preparation is not included in continuation bars.</text>
 <text class="note" x="36" y="647">Bars = seed means · dots = seeds [1234, 20260727] · Source JSON SHA-256 53fc1d4d5b7adee0</text>
 </svg>

--- a/docs/gpu-calc-hard-equal-update-v2.svg
+++ b/docs/gpu-calc-hard-equal-update-v2.svg
@@ -1,17 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1120" height="664" viewBox="0 0 1120 664" role="img" aria-labelledby="benchmark-title benchmark-desc">
 <title id="benchmark-title">miniVERL protocol-teacher benchmark</title>
-<desc id="benchmark-desc">Strict held-out success and training time for equal-optimizer-update arms over 2 prespecified seeds. 2 protocol-incompatible negative controls are shown separately from the supported comparison. The cold-start baseline is labeled no training.</desc>
-<style>text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,Segoe UI,sans-serif;fill:#e6edf7}.title{font-size:25px;font-weight:760;letter-spacing:-.35px}.sub{font-size:13px;fill:#91a0b8}.head{font-size:14px;font-weight:700;fill:#dce7f7}.label{font-size:14px;font-weight:580}.value{font-size:13px;font-weight:730}.axis{font-size:11.5px;fill:#9aabc3}.note{font-size:11.5px;fill:#7f90aa}.section{font-size:10.5px;font-weight:760;letter-spacing:1.15px;fill:#fda4af}.panel{fill:url(#panel);stroke:#263752}.track{fill:#19263c}.grid{stroke:#2b3c58;stroke-width:1}.row{fill:#ffffff;fill-opacity:.018}.dot{fill:#08101f;stroke-width:2}.pill{fill:#0b1425;stroke-width:1.4}</style>
+<desc id="benchmark-desc">Strict held-out success and continuation train time for equal-update arms over 2 prespecified seeds. 2 completed negative-control arms without a protocol qualification gate are shown separately. The cold-start baseline has zero continuation updates.</desc>
+<style>text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,Segoe UI,sans-serif;fill:#e6edf7}.title{font-size:25px;font-weight:760;letter-spacing:-.35px}.sub{font-size:13px;fill:#91a0b8}.head{font-size:14px;font-weight:700;fill:#dce7f7}.label{font-size:14px;font-weight:580}.value{font-size:13px;font-weight:730}.axis{font-size:11.5px;fill:#9aabc3}.note{font-size:13px;fill:#8fa0b9}.section{font-size:10.5px;font-weight:760;letter-spacing:1.15px;fill:#fda4af}.badge{font-size:9px;font-weight:760;letter-spacing:.55px;fill:#fecdd3}.panel{fill:url(#panel);stroke:#263752}.track{fill:#19263c}.grid{stroke:#2b3c58;stroke-width:1}.row{fill:#ffffff;fill-opacity:.018}.dot{fill:#08101f;stroke-width:2}.pill{fill:#0b1425;stroke-width:1.4}</style>
 <defs><linearGradient id="background" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#050816"/><stop offset="58%" stop-color="#0a1224"/><stop offset="100%" stop-color="#101a34"/></linearGradient><linearGradient id="panel" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#111d34"/><stop offset="100%" stop-color="#0b1426"/></linearGradient><radialGradient id="glow" cx="80%" cy="0%" r="70%"><stop offset="0%" stop-color="#4f46e5" stop-opacity=".24"/><stop offset="100%" stop-color="#4f46e5" stop-opacity="0"/></radialGradient></defs>
 <rect width="100%" height="100%" rx="18" fill="url(#background)"/>
 <rect width="100%" height="100%" rx="18" fill="url(#glow)"/>
 <rect x=".75" y=".75" width="1118.5" height="662.5" rx="17.25" fill="none" stroke="#334663" stroke-width="1.5"/>
-<text class="title" x="36" y="42">Protocol-aligned OPD matches continued SFT</text>
-<text class="sub" x="36" y="68">schema v2  ·  2 prespecified seeds  ·  budget axis: optimizer_steps</text>
+<text class="title" x="36" y="42">Same strict success; protocol OPD uses 6.1× more continuation time</text>
+<text class="sub" x="36" y="68">Schema v2  ·  2 prespecified seeds  ·  equal budget: 12 continuation optimizer updates</text>
 <rect class="panel" x="276" y="96" width="394" height="506" rx="14"/>
 <rect class="panel" x="694" y="96" width="390" height="506" rx="14"/>
 <text class="head" x="310" y="123">Strict held-out success</text>
-<text class="head" x="728" y="123">Training time</text>
+<text class="head" x="728" y="123">Continuation train time</text>
 <text class="axis" x="310.0" y="151" text-anchor="middle">0%</text>
 <line class="grid" x1="310.0" y1="166" x2="310.0" y2="590"/>
 <text class="axis" x="456.0" y="151" text-anchor="middle">50%</text>
@@ -24,7 +24,7 @@
 <line class="grid" x1="866.0" y1="166" x2="866.0" y2="590"/>
 <text class="axis" x="1004.0" y="151" text-anchor="middle">600s</text>
 <line class="grid" x1="1004.0" y1="166" x2="1004.0" y2="590"/>
-<rect class="row" x="24" y="177" width="1072" height="54" rx="10"/>
+<rect class="row" x="24" y="174" width="1072" height="60" rx="10"/>
 <g data-arm="cold-start-only" data-success-mean="0.750000" data-train-seconds-mean="0.061326">
 <text class="label" x="36" y="209">Cold start</text>
 <rect class="track" x="310" y="194" width="292" height="20" rx="5"/>
@@ -32,10 +32,10 @@
 <circle class="dot" cx="529.0" cy="199" r="3.5" stroke="#94a3b8"/>
 <circle class="dot" cx="529.0" cy="209" r="3.5" stroke="#94a3b8"/>
 <text class="value" x="614" y="209">75%</text>
-<rect class="pill" x="740" y="191" width="104" height="26" rx="13" stroke="#64748b"/>
-<text class="value" x="792" y="208" text-anchor="middle" fill="#94a3b8">NO TRAINING</text>
+<rect class="pill" x="740" y="191" width="190" height="26" rx="13" stroke="#64748b"/>
+<text class="value" x="835" y="208" text-anchor="middle" fill="#94a3b8">0 CONTINUATION UPDATES</text>
 </g>
-<rect class="row" x="24" y="255" width="1072" height="54" rx="10"/>
+<rect class="row" x="24" y="252" width="1072" height="60" rx="10"/>
 <g data-arm="sft-continued" data-success-mean="1.000000" data-train-seconds-mean="86.439230">
 <text class="label" x="36" y="287">Continued SFT</text>
 <rect class="track" x="310" y="272" width="292" height="20" rx="5"/>
@@ -49,7 +49,7 @@
 <circle class="dot" cx="770.5" cy="287" r="3.5" stroke="#60a5fa"/>
 <text class="value" x="1016" y="287">86s</text>
 </g>
-<rect class="row" x="24" y="333" width="1072" height="54" rx="10"/>
+<rect class="row" x="24" y="330" width="1072" height="60" rx="10"/>
 <g data-arm="opd-protocol-sft-teacher" data-success-mean="1.000000" data-train-seconds-mean="523.820241">
 <text class="label" x="36" y="365">OPD · protocol-aligned teacher</text>
 <rect class="track" x="310" y="350" width="292" height="20" rx="5"/>
@@ -64,29 +64,37 @@
 <text class="value" x="1016" y="365">524s</text>
 </g>
 <rect x="24" y="417" width="1072" height="28" rx="14" fill="#fb7185" fill-opacity=".075" stroke="#fb7185" stroke-opacity=".16"/>
-<text class="section" x="38" y="435">DIAGNOSTIC CONTROLS · INTENTIONALLY PROTOCOL-INCOMPATIBLE TEACHERS</text>
-<rect class="row" x="24" y="447" width="1072" height="54" rx="10"/>
+<text class="section" x="38" y="435">DIAGNOSTIC NEGATIVE CONTROLS · TEACHERS NOT PROTOCOL-QUALIFIED</text>
+<rect class="row" x="24" y="444" width="1072" height="60" rx="10"/>
 <g data-arm="opd-raw-teacher" data-success-mean="0.000000" data-train-seconds-mean="443.953792">
-<text class="label" x="36" y="479">Raw teacher (control)</text>
-<rect class="pill" x="322" y="461" width="154" height="26" rx="13" stroke="#fb7185"/>
-<text class="value" x="399.0" y="478" text-anchor="middle" fill="#fb7185">PROTOCOL MISMATCH</text>
+<text class="label" x="36" y="469">Raw teacher (control)</text>
+<rect class="pill" x="36" y="477" width="232" height="18" rx="9" stroke="#fb7185" stroke-opacity=".65"/>
+<text class="badge" x="152" y="489.5" text-anchor="middle">NEGATIVE CONTROL · NO PROTOCOL GATE</text>
+<rect class="track" x="310" y="464" width="292" height="20" rx="5"/>
+<circle class="dot" cx="310.0" cy="469" r="3.5" stroke="#fb7185"/>
+<circle class="dot" cx="310.0" cy="479" r="3.5" stroke="#fb7185"/>
+<text class="value" x="614" y="479">0%</text>
 <rect class="track" x="728" y="464" width="276" height="20" rx="5"/>
 <rect x="728" y="464" width="204.2" height="20" rx="5" fill="#fb7185" opacity=".84"/>
 <circle class="dot" cx="943.6" cy="469" r="3.5" stroke="#fb7185"/>
 <circle class="dot" cx="920.9" cy="479" r="3.5" stroke="#fb7185"/>
 <text class="value" x="1016" y="479">444s</text>
 </g>
-<rect class="row" x="24" y="525" width="1072" height="54" rx="10"/>
+<rect class="row" x="24" y="522" width="1072" height="60" rx="10"/>
 <g data-arm="opd-privileged-context" data-success-mean="0.000000" data-train-seconds-mean="531.523058">
-<text class="label" x="36" y="557">Privileged context (control)</text>
-<rect class="pill" x="322" y="539" width="154" height="26" rx="13" stroke="#fbbf24"/>
-<text class="value" x="399.0" y="556" text-anchor="middle" fill="#fbbf24">PROTOCOL MISMATCH</text>
+<text class="label" x="36" y="547">Privileged context (control)</text>
+<rect class="pill" x="36" y="555" width="232" height="18" rx="9" stroke="#fbbf24" stroke-opacity=".65"/>
+<text class="badge" x="152" y="567.5" text-anchor="middle">NEGATIVE CONTROL · NO PROTOCOL GATE</text>
+<rect class="track" x="310" y="542" width="292" height="20" rx="5"/>
+<circle class="dot" cx="310.0" cy="547" r="3.5" stroke="#fbbf24"/>
+<circle class="dot" cx="310.0" cy="557" r="3.5" stroke="#fbbf24"/>
+<text class="value" x="614" y="557">0%</text>
 <rect class="track" x="728" y="542" width="276" height="20" rx="5"/>
 <rect x="728" y="542" width="244.5" height="20" rx="5" fill="#fbbf24" opacity=".84"/>
 <circle class="dot" cx="987.1" cy="547" r="3.5" stroke="#fbbf24"/>
 <circle class="dot" cx="957.9" cy="557" r="3.5" stroke="#fbbf24"/>
 <text class="value" x="1016" y="557">532s</text>
 </g>
-<text class="note" x="36" y="629">Diagnostic controls intentionally use protocol-incompatible teachers; strict success was 0% in every seed; cold start records setup only (0.06s), not a training phase.</text>
-<text class="note" x="36" y="647">Bars are seed means; hollow dots are individual seeds [1234, 20260727]. Source JSON SHA-256 53fc1d4d5b7adee0</text>
+<text class="note" x="36" y="627">Protocol-teacher preparation: ~555 s once, excluded from continuation bars.</text>
+<text class="note" x="36" y="647">Bars = seed means · dots = seeds [1234, 20260727] · Source JSON SHA-256 53fc1d4d5b7adee0</text>
 </svg>

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -21,22 +21,21 @@ code rather than documented and hoped for:
 
 - `miniverl.models.factory.build_tokenizer` returns **one** tokenizer object,
   which both backends then share. When the teacher declares a different
-  tokenizer id, that tokenizer is loaded and its behavioural fingerprint is
-  compared against the student's; any difference raises
-  `TokenizerMismatchError` before a single weight is downloaded.
+  tokenizer id, that tokenizer is loaded and
+  `miniverl.models.tokenizers.assert_same_tokenizer` is called before either
+  model is constructed. New runs compare structural identity first; any
+  difference raises `TokenizerMismatchError`.
 - `miniverl.trajectory.alignment.build_alignment_map` and
   `miniverl.teachers.local.LocalTeacherScorer.score` both re-check the
   fingerprint on the teacher render used by `privileged_context` mode.
 
-`miniverl.models.tokenizers.assert_same_tokenizer` also exists, but it has no
-call sites in `src/` or `tests/` and is not in the module's `__all__`. Do not
-rely on it; the two checks above are the ones that run.
-
-The fingerprint is a SHA-256 over the tokenizer class name, `len(tokenizer)`,
-the EOS and PAD ids, the sorted additional special tokens, and the token ids
-produced for a fixed probe string containing chat and tool markup
-(`miniverl.models.tokenizers.PROBE_TEXT`). Two tokenizers that agree on
-metadata but disagree on the probe are still rejected.
+Structural identity hashes the full vocabulary, added vocabulary, special-token
+map, backend tokenizer and behaviour-relevant tokenizer configuration. Local
+source paths are canonicalized away. The legacy fingerprint is a SHA-256 over
+the tokenizer class, length, special-token metadata and token ids produced for
+one fixed string (`miniverl.models.tokenizers.PROBE_TEXT`). It remains a
+compatibility fallback when an old artifact has no structural digest; agreement
+on that probe is not proof that two tokenizer structures are identical.
 
 The reason is structural, not incidental. A bucketed teacher target is a set of
 vocabulary **indices** plus log-probabilities; the student gathers its own

--- a/docs/single-gpu-guide.md
+++ b/docs/single-gpu-guide.md
@@ -1,6 +1,6 @@
 # Bring your own GPU
 
-miniVERL is a **personal single-GPU** training stack. It has no GPU model
+miniVERL is a **single-GPU CUDA LLM post-training** stack. It has no GPU model
 allowlist and no multi-GPU launcher: one process uses one CUDA device, while
 the model pair and sequence budget determine whether a recipe fits.
 
@@ -18,14 +18,21 @@ RTX 4080. Its portable defaults are:
 
 ## Start here
 
-Install the training stack and the CUDA quantization backend:
+First use the [PyTorch install selector](https://pytorch.org/get-started/locally/)
+to install the wheel matching your CUDA driver. The measured stack used the
+following channel; choose a different supported channel when your system needs
+one:
 
 ```bash
+python -m pip install torch --index-url https://download.pytorch.org/whl/cu130
 python -m pip install "miniverl[train,cuda]"
 miniverl doctor
 miniverl validate recipes/qwen_consumer_gpu_calc.yaml
 miniverl train recipes/qwen_consumer_gpu_calc.yaml --dry-run
 ```
+
+The `train,cuda` extra adds the training and quantization dependencies; it does
+not select a CUDA-enabled PyTorch build on its own.
 
 Then watch free memory in another terminal before the real run:
 
@@ -45,7 +52,7 @@ These are starting points, not benchmark claims:
 
 | Your card | Sensible first move | Evidence status |
 | --- | --- | --- |
-| 8–12 GiB, such as an RTX 3070 or Titan V | Try the shipped pair, but be ready to shorten token budgets or select a smaller teacher. Keep `dtype: auto`; Titan V-class hardware resolves to fp16 because it has no bf16 path. | Supported by model-agnostic code paths; not measured in this repository |
+| 8–12 GiB, such as an RTX 3070 or Titan V | Try the shipped pair, but be ready to shorten token budgets or select a smaller teacher. Keep `dtype: auto`; Titan V-class hardware resolves to fp16 because it has no bf16 path. | Supported by the device-name-agnostic CUDA path; not measured in this repository |
 | 16–24 GiB | Start with the shipped recipe unchanged. Increase budgets only after recording a successful baseline. | The exact default pair is measured on one RTX 4080 16 GiB |
 | 24–32+ GiB, such as RTX 3090/4090/5090-class cards | Use the same recipe first; extra headroom can support longer contexts, larger models, or less quantization. Change one variable at a time. | Expected from the same single-device path; not measured here |
 

--- a/scripts/publish_benchmark_artifacts.py
+++ b/scripts/publish_benchmark_artifacts.py
@@ -84,6 +84,7 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
         arms = grouped[name]
         success = [arm.strict_task_success_rate or 0.0 for arm in arms]
         seconds = [arm.train_seconds or 0.0 for arm in arms]
+        optimizer_steps = [arm.optimizer_steps or 0 for arm in arms]
         rows.append(
             {
                 "name": name,
@@ -91,6 +92,7 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
                 "success_mean": sum(success) / len(success),
                 "seconds": seconds,
                 "seconds_mean": sum(seconds) / len(seconds),
+                "optimizer_steps": optimizer_steps,
             }
         )
     display_order = {
@@ -111,6 +113,33 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
         (row["seconds_mean"] for row in rows if row["name"] == "cold-start-only"),
         None,
     )
+    row_by_name = {row["name"]: row for row in rows}
+    sft_row = row_by_name.get("sft-continued")
+    protocol_opd_row = row_by_name.get("opd-protocol-sft-teacher")
+    if (
+        sft_row is not None
+        and protocol_opd_row is not None
+        and math.isclose(sft_row["success_mean"], protocol_opd_row["success_mean"])
+        and sft_row["seconds_mean"] > 0
+    ):
+        continuation_ratio = protocol_opd_row["seconds_mean"] / sft_row["seconds_mean"]
+        title = (
+            "Same strict success; protocol OPD uses "
+            f"{continuation_ratio:.1f}× more continuation time"
+        )
+    else:
+        title = "Strict held-out success and continuation train time"
+    trained_step_counts = {
+        int(step)
+        for row in rows
+        if row["name"] != "cold-start-only"
+        for step in row["optimizer_steps"]
+    }
+    if len(trained_step_counts) == 1:
+        (trained_steps,) = trained_step_counts
+        budget_description = f"equal budget: {trained_steps} continuation optimizer updates"
+    else:
+        budget_description = "equal continuation budget by optimizer updates"
 
     width = 1120
     diagnostic_gap = 36 if diagnostic_start is not None else 0
@@ -147,16 +176,16 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
     )
     svg += line('<title id="benchmark-title">miniVERL protocol-teacher benchmark</title>')
     desc = (
-        "Strict held-out success and training time for equal-optimizer-update arms "
+        "Strict held-out success and continuation train time for equal-update arms "
         f"over {len(result.seeds)} prespecified seeds."
     )
     if diagnostic_count:
         desc += (
-            f" {diagnostic_count} protocol-incompatible negative controls are "
-            "shown separately from the supported comparison."
+            f" {diagnostic_count} completed negative-control arms without a protocol "
+            "qualification gate are shown separately."
         )
     if cold_start_seconds is not None:
-        desc += " The cold-start baseline is labeled no training."
+        desc += " The cold-start baseline has zero continuation updates."
     svg += line(f'<desc id="benchmark-desc">{desc}</desc>')
     svg += line(
         "<style>"
@@ -164,8 +193,9 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
         "fill:#e6edf7}.title{font-size:25px;font-weight:760;letter-spacing:-.35px}"
         ".sub{font-size:13px;fill:#91a0b8}.head{font-size:14px;font-weight:700;fill:#dce7f7}"
         ".label{font-size:14px;font-weight:580}.value{font-size:13px;font-weight:730}"
-        ".axis{font-size:11.5px;fill:#9aabc3}.note{font-size:11.5px;fill:#7f90aa}"
+        ".axis{font-size:11.5px;fill:#9aabc3}.note{font-size:13px;fill:#8fa0b9}"
         ".section{font-size:10.5px;font-weight:760;letter-spacing:1.15px;fill:#fda4af}"
+        ".badge{font-size:9px;font-weight:760;letter-spacing:.55px;fill:#fecdd3}"
         ".panel{fill:url(#panel);stroke:#263752}.track{fill:#19263c}"
         ".grid{stroke:#2b3c58;stroke-width:1}.row{fill:#ffffff;fill-opacity:.018}"
         ".dot{fill:#08101f;stroke-width:2}.pill{fill:#0b1425;stroke-width:1.4}"
@@ -194,13 +224,11 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
         f'<rect x=".75" y=".75" width="{width - 1.5}" height="{height - 1.5}" rx="17.25" '
         'fill="none" stroke="#334663" stroke-width="1.5"/>'
     )
+    svg += line(f'<text class="title" x="36" y="42">{html.escape(title)}</text>')
     svg += line(
-        '<text class="title" x="36" y="42">Protocol-aligned OPD matches continued SFT</text>'
-    )
-    svg += line(
-        f'<text class="sub" x="36" y="68">schema v{result.schema_version}  ·  '
-        f"{len(result.seeds)} prespecified seeds  ·  budget axis: "
-        f"{html.escape(result.budget_axis or 'unreported')}</text>"
+        f'<text class="sub" x="36" y="68">Schema v{result.schema_version}  ·  '
+        f"{len(result.seeds)} prespecified seeds  ·  "
+        f"{html.escape(budget_description)}</text>"
     )
     panel_y = 96
     panel_h = height - 158
@@ -211,7 +239,7 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
         f'<rect class="panel" x="694" y="{panel_y}" width="390" height="{panel_h}" rx="14"/>'
     )
     svg += line(f'<text class="head" x="{success_x}" y="123">Strict held-out success</text>')
-    svg += line(f'<text class="head" x="{time_x}" y="123">Training time</text>')
+    svg += line(f'<text class="head" x="{time_x}" y="123">Continuation train time</text>')
     for fraction in (0.0, 0.5, 1.0):
         x = success_x + success_w * fraction
         svg += line(
@@ -239,57 +267,56 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
                 'fill="#fb7185" fill-opacity=".075" stroke="#fb7185" stroke-opacity=".16"/>'
             )
             svg += line(
-                f'<text class="section" x="38" y="{y - 39}">DIAGNOSTIC CONTROLS · '
-                "INTENTIONALLY PROTOCOL-INCOMPATIBLE TEACHERS</text>"
+                f'<text class="section" x="38" y="{y - 39}">'
+                "DIAGNOSTIC NEGATIVE CONTROLS · TEACHERS NOT PROTOCOL-QUALIFIED</text>"
             )
-        svg += line(f'<rect class="row" x="24" y="{y - 27}" width="1072" height="54" rx="10"/>')
+        svg += line(f'<rect class="row" x="24" y="{y - 30}" width="1072" height="60" rx="10"/>')
         svg += line(
             f'<g data-arm="{escaped_name}" '
             f'data-success-mean="{row["success_mean"]:.6f}" '
             f'data-train-seconds-mean="{row["seconds_mean"]:.6f}">'
         )
-        svg += line(f'<text class="label" x="{label_x}" y="{y + 5}">{display_name}</text>')
+        label_y = y - 5 if is_diagnostic else y + 5
+        svg += line(f'<text class="label" x="{label_x}" y="{label_y}">{display_name}</text>')
+        if is_diagnostic:
+            svg += line(
+                f'<rect class="pill" x="{label_x}" y="{y + 3}" width="232" '
+                f'height="18" rx="9" stroke="{color}" stroke-opacity=".65"/>'
+            )
+            svg += line(
+                f'<text class="badge" x="{label_x + 116}" y="{y + 15.5}" '
+                'text-anchor="middle">NEGATIVE CONTROL · NO PROTOCOL GATE</text>'
+            )
 
-        if row["success_mean"] == 0.0:
-            status = "PROTOCOL MISMATCH" if is_diagnostic else "NO SOLVES"
-            pill_width = 154 if is_diagnostic else 92
-            svg += line(
-                f'<rect class="pill" x="{success_x + 12}" y="{y - 13}" width="{pill_width}" '
-                f'height="26" rx="13" stroke="{color}"/>'
-            )
-            svg += line(
-                f'<text class="value" x="{success_x + 12 + pill_width / 2:.1f}" y="{y + 4}" '
-                f'text-anchor="middle" fill="{color}">{status}</text>'
-            )
-        else:
-            success_end = success_x + success_w * row["success_mean"]
-            svg += line(
-                f'<rect class="track" x="{success_x}" y="{y - 10}" '
-                f'width="{success_w}" height="20" rx="5"/>'
-            )
+        success_end = success_x + success_w * row["success_mean"]
+        svg += line(
+            f'<rect class="track" x="{success_x}" y="{y - 10}" '
+            f'width="{success_w}" height="20" rx="5"/>'
+        )
+        if row["success_mean"] > 0.0:
             svg += line(
                 f'<rect x="{success_x}" y="{y - 10}" width="{success_end - success_x:.1f}" '
                 f'height="20" rx="5" fill="{color}" opacity=".84"/>'
             )
-            for seed_index, value in enumerate(row["success"]):
-                dot_x = success_x + success_w * value
-                dot_y = y - 5 + seed_index * 10
-                svg += line(
-                    f'<circle class="dot" cx="{dot_x:.1f}" cy="{dot_y}" r="3.5" stroke="{color}"/>'
-                )
+        for seed_index, value in enumerate(row["success"]):
+            dot_x = success_x + success_w * value
+            dot_y = y - 5 + seed_index * 10
             svg += line(
-                f'<text class="value" x="{success_x + success_w + 12}" y="{y + 5}">'
-                f"{row['success_mean'] * 100:.0f}%</text>"
+                f'<circle class="dot" cx="{dot_x:.1f}" cy="{dot_y}" r="3.5" stroke="{color}"/>'
             )
+        svg += line(
+            f'<text class="value" x="{success_x + success_w + 12}" y="{y + 5}">'
+            f"{row['success_mean'] * 100:.0f}%</text>"
+        )
 
         if row["name"] == "cold-start-only":
             svg += line(
-                f'<rect class="pill" x="{time_x + 12}" y="{y - 13}" width="104" '
+                f'<rect class="pill" x="{time_x + 12}" y="{y - 13}" width="190" '
                 'height="26" rx="13" stroke="#64748b"/>'
             )
             svg += line(
-                f'<text class="value" x="{time_x + 64}" y="{y + 4}" '
-                'text-anchor="middle" fill="#94a3b8">NO TRAINING</text>'
+                f'<text class="value" x="{time_x + 107}" y="{y + 4}" '
+                'text-anchor="middle" fill="#94a3b8">0 CONTINUATION UPDATES</text>'
             )
         else:
             time_end = time_x + time_w * row["seconds_mean"] / time_ceiling
@@ -313,22 +340,13 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
             )
         svg += line("</g>")
 
-    notes = []
-    if diagnostic_count:
-        notes.append(
-            "Diagnostic controls intentionally use protocol-incompatible teachers; "
-            "strict success was 0% in every seed"
-        )
-    if cold_start_seconds is not None:
-        notes.append(
-            f"cold start records setup only ({cold_start_seconds:.2f}s), not a training phase"
-        )
     svg += line(
-        f'<text class="note" x="36" y="{height - 35}">{html.escape("; ".join(notes))}.</text>'
+        f'<text class="note" x="36" y="{height - 37}">Protocol-teacher preparation: '
+        "~555 s once, excluded from continuation bars.</text>"
     )
     svg += line(
-        f'<text class="note" x="36" y="{height - 17}">Bars are seed means; hollow '
-        f"dots are individual seeds {html.escape(str(result.seeds))}. "
+        f'<text class="note" x="36" y="{height - 17}">Bars = seed means · dots = seeds '
+        f"{html.escape(str(result.seeds))} · "
         f"Source JSON SHA-256 {source_sha256[:16]}</text>"
     )
     svg += "</svg>\n"

--- a/scripts/publish_benchmark_artifacts.py
+++ b/scripts/publish_benchmark_artifacts.py
@@ -124,11 +124,11 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
     ):
         continuation_ratio = protocol_opd_row["seconds_mean"] / sft_row["seconds_mean"]
         title = (
-            "Same strict success; protocol OPD uses "
-            f"{continuation_ratio:.1f}× more continuation time"
+            "Saturated calculator task · same success, "
+            f"{continuation_ratio:.1f}× OPD continuation time"
         )
     else:
-        title = "Strict held-out success and continuation train time"
+        title = "Calculator task · strict success and continuation train time"
     trained_step_counts = {
         int(step)
         for row in rows
@@ -176,8 +176,8 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
     )
     svg += line('<title id="benchmark-title">miniVERL protocol-teacher benchmark</title>')
     desc = (
-        "Strict held-out success and continuation train time for equal-update arms "
-        f"over {len(result.seeds)} prespecified seeds."
+        "Strict success on the v0.2 calculator test set and continuation train time "
+        f"for equal-update arms over {len(result.seeds)} prespecified seeds."
     )
     if diagnostic_count:
         desc += (
@@ -238,7 +238,9 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
     svg += line(
         f'<rect class="panel" x="694" y="{panel_y}" width="390" height="{panel_h}" rx="14"/>'
     )
-    svg += line(f'<text class="head" x="{success_x}" y="123">Strict held-out success</text>')
+    svg += line(
+        f'<text class="head" x="{success_x}" y="123">Strict success on v0.2 test set</text>'
+    )
     svg += line(f'<text class="head" x="{time_x}" y="123">Continuation train time</text>')
     for fraction in (0.0, 0.5, 1.0):
         x = success_x + success_w * fraction
@@ -280,12 +282,12 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
         svg += line(f'<text class="label" x="{label_x}" y="{label_y}">{display_name}</text>')
         if is_diagnostic:
             svg += line(
-                f'<rect class="pill" x="{label_x}" y="{y + 3}" width="232" '
+                f'<rect class="pill" x="{label_x}" y="{y + 3}" width="176" '
                 f'height="18" rx="9" stroke="{color}" stroke-opacity=".65"/>'
             )
             svg += line(
-                f'<text class="badge" x="{label_x + 116}" y="{y + 15.5}" '
-                'text-anchor="middle">NEGATIVE CONTROL · NO PROTOCOL GATE</text>'
+                f'<text class="badge" x="{label_x + 88}" y="{y + 15.5}" '
+                'text-anchor="middle">NEGATIVE CONTROL · UNGATED</text>'
             )
 
         success_end = success_x + success_w * row["success_mean"]
@@ -341,8 +343,8 @@ def render_svg(result: BenchmarkResult, source_sha256: str) -> str:
         svg += line("</g>")
 
     svg += line(
-        f'<text class="note" x="36" y="{height - 37}">Protocol-teacher preparation: '
-        "~555 s once, excluded from continuation bars.</text>"
+        f'<text class="note" x="36" y="{height - 37}">'
+        "Teacher preparation is not included in continuation bars.</text>"
     )
     svg += line(
         f'<text class="note" x="36" y="{height - 17}">Bars = seed means · dots = seeds '

--- a/src/miniverl/cache/store.py
+++ b/src/miniverl/cache/store.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import hashlib
 import json
 import struct
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -43,7 +44,7 @@ from miniverl.schemas.cache import (
     CacheShardMeta,
     TeacherTargetBatch,
 )
-from miniverl.utils.runs import canonical_json, write_text
+from miniverl.utils.runs import write_json_atomic
 
 __all__ = ["TeacherCache", "read_safetensors_header", "sha256_file"]
 
@@ -56,6 +57,10 @@ _TENSOR_FIELDS = (
     "target_token_ids",
     "weights",
 )
+
+
+def _replace_shard_file(source: Path, target: Path) -> None:
+    source.replace(target)
 
 
 def sha256_file(path: Path) -> tuple[str, int]:
@@ -229,6 +234,18 @@ class TeacherCache:
         dtype: str,
     ) -> None:
         """Reject reuse when any objective or teacher identity component changed."""
+        if self.index.schema_version < 2:
+            unverified: list[str] = []
+            if (tokenizer_identity or {}).get("structural_digest_v2"):
+                unverified.append("structural tokenizer identity")
+            if teacher_adapter_provenance is not None:
+                unverified.append("teacher adapter provenance")
+            if unverified:
+                raise StaleCacheError(
+                    "schema-v1 teacher cache cannot verify " + " or ".join(unverified),
+                    hint="re-score the legacy cache so its index records the current "
+                    "tokenizer and adapter provenance",
+                )
         expected: dict[str, Any] = {
             "teacher_model_id": teacher_model_id,
             "teacher_model_revision": teacher_model_revision,
@@ -344,21 +361,32 @@ class TeacherCache:
         return f"shard-{self._shard_counter:05d}.safetensors"
 
     def flush(self) -> None:
-        """Write staged entries into a new shard and update the index."""
+        """Publish a staged shard, then atomically replace the matching index."""
         if not self._pending_order:
             return
         from safetensors.torch import save_file
 
         shard_name = self._next_shard_name()
         shard_path = self.path / shard_name
+        temporary_path = self.path / f".{shard_name}.tmp-{uuid.uuid4().hex}"
         payload: dict[str, Any] = {}
         for traj_id in self._pending_order:
             for key, tensor in self._pending[traj_id]["tensors"].items():
                 payload[f"{traj_id}|{key}"] = tensor
-        save_file(payload, str(shard_path), metadata={"miniverl_cache_shard": shard_name})
-        digest, size = sha256_file(shard_path)
+        try:
+            save_file(
+                payload,
+                str(temporary_path),
+                metadata={"miniverl_cache_shard": shard_name},
+            )
+            digest, size = sha256_file(temporary_path)
+            _replace_shard_file(temporary_path, shard_path)
+        finally:
+            if temporary_path.exists():
+                temporary_path.unlink()
         self._bytes_written_total += size
-        self.index.shards[shard_name] = CacheShardMeta(
+        next_index = self.index.model_copy(deep=True)
+        next_index.shards[shard_name] = CacheShardMeta(
             filename=shard_name,
             sha256=digest,
             size_bytes=size,
@@ -367,32 +395,33 @@ class TeacherCache:
         created = _utc_now()
         for traj_id in self._pending_order:
             meta = self._pending[traj_id]["meta"]
-            self.index.entries[traj_id] = CacheEntryMeta(
+            next_index.entries[traj_id] = CacheEntryMeta(
                 trajectory_id=traj_id,
                 policy_version=meta["policy_version"],
                 shard=shard_name,
                 num_positions=meta["num_positions"],
-                top_k=self.index.top_k,
+                top_k=next_index.top_k,
                 tail_is_exact_zero=meta["tail_is_exact_zero"],
                 selector=meta["selector"],
-                loss_mode=self.index.loss_mode,
-                temperature=self.index.temperature,
+                loss_mode=next_index.loss_mode,
+                temperature=next_index.temperature,
                 created_at=created,
                 tensor_keys=list(_TENSOR_FIELDS),
                 checksum=meta["checksum"],
                 selected_span_types=meta["selected_span_types"],
                 ordered_span_types=meta["ordered_span_types"],
             )
+        self._write_index(next_index)
+        self.index = next_index
         self._pending.clear()
         self._pending_order.clear()
         self._shard_counter += 1
-        self._write_index()
 
-    def _write_index(self) -> None:
+    def _write_index(self, index: CacheIndex | None = None) -> None:
         self.path.mkdir(parents=True, exist_ok=True)
-        index_path = write_text(
+        index_path = write_json_atomic(
             self.path / _INDEX_NAME,
-            canonical_json(self.index.model_dump(mode="json")),
+            (index or self.index).model_dump(mode="json"),
         )
         self._bytes_written_total += index_path.stat().st_size
 

--- a/src/miniverl/cache/store.py
+++ b/src/miniverl/cache/store.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import struct
 import uuid
 from datetime import datetime, timezone
@@ -44,11 +45,13 @@ from miniverl.schemas.cache import (
     CacheShardMeta,
     TeacherTargetBatch,
 )
+from miniverl.utils.logging import get_logger
 from miniverl.utils.runs import write_json_atomic
 
 __all__ = ["TeacherCache", "read_safetensors_header", "sha256_file"]
 
 _INDEX_NAME = "index.json"
+_SHARD_NAME = re.compile(r"^shard-(\d+)\.safetensors$")
 _TENSOR_FIELDS = (
     "positions",
     "topk_indices",
@@ -57,10 +60,26 @@ _TENSOR_FIELDS = (
     "target_token_ids",
     "weights",
 )
+logger = get_logger("cache")
 
 
 def _replace_shard_file(source: Path, target: Path) -> None:
     source.replace(target)
+
+
+def _delete_shard_file(path: Path) -> None:
+    path.unlink()
+
+
+def _next_shard_id(path: Path, index: CacheIndex) -> int:
+    names = set(index.shards)
+    names.update(shard.filename for shard in index.shards.values())
+    if path.is_dir():
+        names.update(child.name for child in path.iterdir() if child.is_file())
+    suffixes = [
+        int(match.group(1)) for name in names if (match := _SHARD_NAME.fullmatch(name)) is not None
+    ]
+    return max(suffixes, default=-1) + 1
 
 
 def sha256_file(path: Path) -> tuple[str, int]:
@@ -108,13 +127,13 @@ def read_safetensors_header(path: Path) -> dict[str, Any]:
 class TeacherCache:
     """Append-only, shard-based store for compressed teacher targets."""
 
-    def __init__(self, path: str | Path, index: CacheIndex, *, entries_per_shard: int = 32) -> None:
+    def __init__(self, path: str | Path, index: CacheIndex) -> None:
         self.path = Path(path)
         self.index = index
-        self.entries_per_shard = entries_per_shard
+        self.entries_per_shard = index.entries_per_shard
         self._pending: dict[str, dict[str, Any]] = {}
         self._pending_order: list[str] = []
-        self._shard_counter = len(index.shards)
+        self._shard_counter = _next_shard_id(self.path, index)
         # Cumulative I/O accounting is intentionally independent of the current
         # footprint: pruning may shrink ``total_bytes()`` but cannot un-write the
         # shards that consumed bandwidth earlier in the run.
@@ -182,8 +201,9 @@ class TeacherCache:
             temperature=temperature,
             loss_mode=loss_mode,
             dtype=dtype,
+            entries_per_shard=entries_per_shard,
         )
-        cache = cls(target, index, entries_per_shard=entries_per_shard)
+        cache = cls(target, index)
         cache._write_index()
         return cache
 
@@ -567,25 +587,42 @@ class TeacherCache:
     def prune_before(self, policy_version: int) -> int:
         """Drop entries older than ``policy_version``; returns the number removed.
 
-        Whole shards are deleted only when every entry they hold is dropped, so
-        the index and the files stay consistent.
+        The next index is published before its now-unreferenced shards are
+        deleted.  An interrupted cleanup can therefore leave an inert orphan
+        shard, but never an index that points at a shard already removed.
         """
         stale = [
             traj_id
             for traj_id, entry in self.index.entries.items()
             if entry.policy_version < policy_version
         ]
+        if not stale:
+            return 0
+
+        next_index = self.index.model_copy(deep=True)
         for traj_id in stale:
-            del self.index.entries[traj_id]
-        live_shards = {e.shard for e in self.index.entries.values()}
-        for name in list(self.index.shards):
+            del next_index.entries[traj_id]
+        live_shards = {entry.shard for entry in next_index.entries.values()}
+        unreferenced_shards = []
+        for name in list(next_index.shards):
             if name not in live_shards:
-                shard_path = self.path / name
-                if shard_path.is_file():
-                    shard_path.unlink()
-                del self.index.shards[name]
-        if stale:
-            self._write_index()
+                unreferenced_shards.append(name)
+                del next_index.shards[name]
+
+        self._write_index(next_index)
+        self.index = next_index
+        for name in unreferenced_shards:
+            shard_path = self.path / name
+            if not shard_path.is_file():
+                continue
+            try:
+                _delete_shard_file(shard_path)
+            except OSError as exc:
+                logger.warning(
+                    "teacher-cache prune left unreferenced shard %s: %s",
+                    shard_path,
+                    exc,
+                )
         return len(stale)
 
 

--- a/src/miniverl/environments/base.py
+++ b/src/miniverl/environments/base.py
@@ -228,12 +228,14 @@ class ToolEnvironment(ABC):
                 f"- {spec.name}({', '.join(spec.parameters)})" for spec in self.tool_specs()
             )
             if self.protocol_version == "v2":
+                tool_example, final_example = self._protocol_v2_examples()
                 return (
                     "Use tools to solve the task.\n"
                     f"{tools}\n"
-                    "Reply with one block:\n<tool_call>\n"
-                    '{"name":"calculator","arguments":{"expression":"2+2"}}\n'
-                    "</tool_call>\nor\n<final>\n4\n</final>"
+                    "Reply with one block:\n"
+                    f"{tool_example}\n"
+                    "or\n"
+                    f"{final_example}"
                 )
             return (
                 "Use tools to solve the task.\n"
@@ -243,6 +245,7 @@ class ToolEnvironment(ABC):
             )
         tools = "\n".join(spec.render() for spec in self.tool_specs())
         if self.protocol_version == "v2":
+            tool_example, final_example = self._protocol_v2_examples()
             return (
                 "You are a tool-using assistant. Solve the task with the tools below.\n"
                 "\n"
@@ -251,10 +254,9 @@ class ToolEnvironment(ABC):
                 "\n"
                 "Reply with exactly one block per turn.\n"
                 "To call a tool:\n"
-                '<tool_call>\n{"name":"calculator","arguments":{"expression":"2+2"}}\n'
-                "</tool_call>\n"
+                f"{tool_example}\n"
                 "To answer:\n"
-                "<final>\n4\n</final>"
+                f"{final_example}"
             )
         return (
             "You are a tool-using assistant. Solve the task with the tools below.\n"
@@ -268,6 +270,16 @@ class ToolEnvironment(ABC):
             "To answer:\n"
             "<final>\n<answer>\n</final>"
         )
+
+    def _protocol_v2_examples(self) -> tuple[str, str]:
+        """Render parseable examples from this environment's active tool contract."""
+        from miniverl.agent.protocol import render_final, render_tool_call
+
+        specs = self.tool_specs()
+        if not specs:
+            raise ValueError(f"environment {self.name!r} does not declare any tools")
+        spec = specs[0]
+        return render_tool_call(spec.name, spec.example), render_final("answer")
 
     def user_prompt(self, task: Task) -> str:
         """Compatibility helper for built-ins constructing ``reset()`` output.

--- a/src/miniverl/models/tokenizers.py
+++ b/src/miniverl/models/tokenizers.py
@@ -10,10 +10,10 @@ Two implementations satisfy :class:`~miniverl.agent.transcript.TokenizerLike`:
 :class:`HFTokenizerAdapter`
     A thin wrapper over a Hugging Face fast tokenizer.
 
-Both expose a ``fingerprint``: a behavioural hash that changes if and only if
-the tokenizer would tokenize differently.  Trajectories, caches and alignment
-maps all carry it, so a mismatched pair is rejected instead of quietly
-producing garbage targets.
+Both expose a structural identity and a legacy behavioural fingerprint.  The
+fingerprint hashes one fixed probe and can detect many, but not all, behavioural
+differences.  Trajectories, caches and alignment maps carry tokenizer identity,
+so a known mismatch is rejected instead of quietly producing garbage targets.
 """
 
 from __future__ import annotations
@@ -174,12 +174,49 @@ def tokenizer_structural_digest(tokenizer: Any) -> str:
     update("tokenizer_class", type(tokenizer).__name__)
     backend = getattr(tokenizer, "backend_tokenizer", None)
     backend_to_str = getattr(backend, "to_str", None)
+    backend_description = backend_to_str() if callable(backend_to_str) else None
+    if isinstance(backend_description, str):
+        try:
+            parsed_backend = json.loads(backend_description)
+        except json.JSONDecodeError:
+            parsed_backend = backend_description
+        backend_description = parsed_backend
+    update("backend_tokenizer", _canonicalize_tokenizer_structure(backend_description))
     update(
-        "backend_tokenizer",
-        backend_to_str() if callable(backend_to_str) else None,
+        "tokenizer_config",
+        _canonicalize_tokenizer_structure(getattr(tokenizer, "init_kwargs", {})),
     )
-    update("tokenizer_config", getattr(tokenizer, "init_kwargs", {}))
     return digest.hexdigest()
+
+
+_NON_STRUCTURAL_TOKENIZER_KEYS = frozenset(
+    {
+        "added_tokens_file",
+        "cache_dir",
+        "chat_template_file",
+        "merges_file",
+        "name_or_path",
+        "special_tokens_map_file",
+        "tokenizer_config_file",
+        "tokenizer_file",
+        "vocab_file",
+    }
+)
+
+
+def _canonicalize_tokenizer_structure(value: Any) -> Any:
+    """Remove source-location metadata while preserving tokenizer behaviour."""
+    if isinstance(value, dict):
+        return {
+            str(key): _canonicalize_tokenizer_structure(item)
+            for key, item in value.items()
+            if str(key) not in _NON_STRUCTURAL_TOKENIZER_KEYS
+        }
+    if isinstance(value, (list, tuple)):
+        return [_canonicalize_tokenizer_structure(item) for item in value]
+    if isinstance(value, set):
+        return sorted(_canonicalize_tokenizer_structure(item) for item in value)
+    return value
 
 
 class ToyTokenizer:
@@ -388,7 +425,7 @@ class HFTokenizerAdapter:
 
 
 def assert_same_tokenizer(student: Any, teacher: Any) -> None:
-    """Raise unless the two adapters have identical fingerprints."""
+    """Raise unless structural identity, or the legacy fallback, matches."""
     student_identity = getattr(student, "identity", {})
     teacher_identity = getattr(teacher, "identity", {})
     student_structural = student_identity.get("structural_digest_v2")

--- a/src/miniverl/schemas/cache.py
+++ b/src/miniverl/schemas/cache.py
@@ -75,6 +75,7 @@ class CacheIndex(BaseModel):
     temperature: float = Field(gt=0.0)
     loss_mode: str
     dtype: str = "float32"
+    entries_per_shard: int = Field(default=32, ge=1, le=4096)
     entries: dict[str, CacheEntryMeta] = Field(default_factory=dict)
     shards: dict[str, CacheShardMeta] = Field(default_factory=dict)
 

--- a/src/miniverl/training/trainer.py
+++ b/src/miniverl/training/trainer.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import gc
 import hashlib
 import random
+import shutil
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -461,7 +462,7 @@ class OPDTrainer:
                     next_cycle=trainer._start_cycle,
                 )
             return trainer
-        except BaseException:
+        except BaseException as construction_error:
             # Construction owns every resource it has allocated. Teardown errors
             # are logged because the construction failure is the actionable root
             # cause and must retain its original traceback.
@@ -509,6 +510,35 @@ class OPDTrainer:
                         "allocator cleanup after trainer construction failure: %s",
                         cleanup_error,
                     )
+            if write_artifacts and resume_options == 0 and paths.root.exists():
+                try:
+                    shutil.rmtree(paths.root)
+                except BaseException as cleanup_error:
+                    logger.warning(
+                        "run-directory cleanup after trainer construction failure: %s",
+                        cleanup_error,
+                    )
+                    failed_manifest = {
+                        "manifest_schema_version": 2,
+                        "status": "failed_construction",
+                        "run_id": resolved_id,
+                        "failed_at": utc_now(),
+                        "failure": {
+                            "type": type(construction_error).__name__,
+                            "message": str(construction_error),
+                        },
+                        "cleanup_failure": {
+                            "type": type(cleanup_error).__name__,
+                            "message": str(cleanup_error),
+                        },
+                    }
+                    try:
+                        write_json_atomic(paths.manifest, failed_manifest)
+                    except BaseException as manifest_error:
+                        logger.warning(
+                            "failed-construction manifest cleanup fallback failed: %s",
+                            manifest_error,
+                        )
             raise
 
     def _write_startup_artifacts(self) -> None:

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -345,6 +345,55 @@ def test_sharding_is_deterministic_and_index_stays_consistent(tmp_path: Path):
     assert cache.validate() == []
 
 
+def test_reopen_after_pruning_allocates_after_the_highest_surviving_shard(
+    tmp_path: Path,
+) -> None:
+    cache_path = tmp_path / "tc"
+    cache = _cache(cache_path, entries_per_shard=1)
+    for policy_version in range(4):
+        cache.write(
+            _batch(f"t{policy_version}", policy_version=policy_version),
+            selector="hybrid",
+        )
+
+    surviving_bytes = {
+        name: (cache_path / name).read_bytes()
+        for name in ("shard-00002.safetensors", "shard-00003.safetensors")
+    }
+    assert cache.prune_before(2) == 2
+
+    reopened = TeacherCache.open(cache_path)
+    assert reopened.entries_per_shard == 1
+    assert reopened.read("t2", expect_policy_version=2).trajectory_id == "t2"
+    assert reopened.read("t3", expect_policy_version=3).trajectory_id == "t3"
+
+    reopened.write(_batch("t4", policy_version=4), selector="hybrid")
+
+    assert sorted(reopened.index.shards) == [
+        "shard-00002.safetensors",
+        "shard-00003.safetensors",
+        "shard-00004.safetensors",
+    ]
+    assert reopened.read("t4", expect_policy_version=4).trajectory_id == "t4"
+    for name, original in surviving_bytes.items():
+        assert (cache_path / name).read_bytes() == original
+
+
+def test_reopen_allocates_after_the_highest_on_disk_orphan_shard(tmp_path: Path) -> None:
+    cache_path = tmp_path / "tc"
+    cache = _cache(cache_path, entries_per_shard=1)
+    cache.write(_batch("t0"), selector="hybrid")
+    (cache_path / "shard-00007.safetensors").write_bytes(
+        (cache_path / "shard-00000.safetensors").read_bytes()
+    )
+
+    reopened = TeacherCache.open(cache_path)
+    reopened.write(_batch("t1"), selector="hybrid")
+
+    assert reopened.index.entries["t1"].shard == "shard-00008.safetensors"
+    assert (cache_path / "shard-00007.safetensors").is_file()
+
+
 def test_shard_is_written_to_a_temporary_name_before_publication(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -476,6 +525,68 @@ def test_prune_before_removes_old_policy_versions_and_their_shards(tmp_path: Pat
     assert removed == 1
     assert "old" not in cache
     assert "new" in cache
+
+
+def test_failed_prune_index_publication_preserves_old_index_and_shards(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import miniverl.cache.store as store_module
+
+    cache_path = tmp_path / "tc"
+    cache = _cache(cache_path, entries_per_shard=1)
+    cache.write(_batch("old", policy_version=1), selector="hybrid")
+    cache.write(_batch("new", policy_version=5), selector="hybrid")
+    index_path = cache_path / "index.json"
+    original_index_bytes = index_path.read_bytes()
+    original_index = cache.index.model_dump(mode="json")
+    original_shards = {
+        path.name: path.read_bytes() for path in cache_path.glob("shard-*.safetensors")
+    }
+
+    def fail_index_publication(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        raise OSError("injected prune index replacement failure")
+
+    monkeypatch.setattr(store_module, "write_json_atomic", fail_index_publication)
+    with pytest.raises(OSError, match="injected prune index"):
+        cache.prune_before(5)
+
+    assert cache.index.model_dump(mode="json") == original_index
+    assert index_path.read_bytes() == original_index_bytes
+    assert {
+        path.name: path.read_bytes() for path in cache_path.glob("shard-*.safetensors")
+    } == original_shards
+    assert cache.read("old", expect_policy_version=1).trajectory_id == "old"
+    assert cache.read("new", expect_policy_version=5).trajectory_id == "new"
+
+
+def test_prune_deletion_failure_leaves_a_harmless_orphan_after_index_publication(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import miniverl.cache.store as store_module
+
+    cache_path = tmp_path / "tc"
+    cache = _cache(cache_path, entries_per_shard=1)
+    cache.write(_batch("old", policy_version=1), selector="hybrid")
+    cache.write(_batch("new", policy_version=5), selector="hybrid")
+    old_shard = cache.index.entries["old"].shard
+    deletion_attempts: list[Path] = []
+
+    def fail_deletion(path: Path) -> None:
+        published = json.loads((cache_path / "index.json").read_text(encoding="utf-8"))
+        assert old_shard not in published["shards"]
+        deletion_attempts.append(path)
+        raise OSError("injected orphan cleanup failure")
+
+    monkeypatch.setattr(store_module, "_delete_shard_file", fail_deletion, raising=False)
+    assert cache.prune_before(5) == 1
+
+    assert deletion_attempts == [cache_path / old_shard]
+    assert old_shard not in cache.index.shards
+    assert (cache_path / old_shard).is_file()
+    reopened = TeacherCache.open(cache_path)
+    assert "old" not in reopened
+    assert reopened.read("new", expect_policy_version=5).trajectory_id == "new"
+    assert reopened.validate() == []
 
 
 def test_pruning_does_not_reduce_cumulative_bytes_written(tmp_path: Path):

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -281,6 +281,52 @@ def test_cache_identity_includes_teacher_adapter_provenance(tmp_path: Path) -> N
         )
 
 
+@pytest.mark.parametrize(
+    ("tokenizer_identity", "adapter_provenance", "unverified_component"),
+    [
+        ({"structural_digest_v2": "e" * 64}, None, "structural tokenizer identity"),
+        (
+            {},
+            {
+                "source": "hub",
+                "identity": "owner/adapter",
+                "revision": "a" * 40,
+            },
+            "teacher adapter provenance",
+        ),
+    ],
+)
+def test_schema_v1_cache_is_rejected_when_current_identity_cannot_be_verified(
+    tmp_path: Path,
+    tokenizer_identity: dict[str, object],
+    adapter_provenance: dict[str, object] | None,
+    unverified_component: str,
+) -> None:
+    cache_path = tmp_path / "tc"
+    _cache(cache_path)
+    index_path = cache_path / "index.json"
+    payload = json.loads(index_path.read_text(encoding="utf-8"))
+    payload["schema_version"] = 1
+    payload.pop("tokenizer_identity")
+    payload.pop("teacher_adapter_provenance")
+    index_path.write_text(json.dumps(payload), encoding="utf-8")
+    legacy_cache = TeacherCache.open(cache_path)
+
+    with pytest.raises(StaleCacheError, match=unverified_component):
+        legacy_cache.assert_compatible(
+            teacher_model_id="toy-teacher",
+            teacher_model_revision="rev-abc",
+            tokenizer_fingerprint="fp-1234",
+            tokenizer_identity=tokenizer_identity,
+            teacher_adapter_provenance=adapter_provenance,
+            vocab_size=VOCAB,
+            top_k=TOP_K,
+            temperature=1.0,
+            loss_mode="bucketed_topk_tail",
+            dtype="float32",
+        )
+
+
 def test_sharding_is_deterministic_and_index_stays_consistent(tmp_path: Path):
     cache = _cache(tmp_path / "tc", entries_per_shard=2)
     for i in range(5):
@@ -297,6 +343,58 @@ def test_sharding_is_deterministic_and_index_stays_consistent(tmp_path: Path):
     for entry in cache.index.entries.values():
         assert entry.shard in cache.index.shards
     assert cache.validate() == []
+
+
+def test_shard_is_written_to_a_temporary_name_before_publication(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import safetensors.torch as safetensors_torch
+
+    cache = _cache(tmp_path / "tc", entries_per_shard=8)
+    cache.write(_batch("t0"), selector="hybrid")
+    real_save_file = safetensors_torch.save_file
+    save_targets: list[Path] = []
+
+    def tracking_save_file(tensors, filename, *, metadata):  # type: ignore[no-untyped-def]
+        save_targets.append(Path(filename))
+        return real_save_file(tensors, filename, metadata=metadata)
+
+    monkeypatch.setattr(safetensors_torch, "save_file", tracking_save_file)
+    cache.flush()
+
+    assert len(save_targets) == 1
+    assert save_targets[0].name.startswith(".shard-00000.safetensors.tmp-")
+    assert (tmp_path / "tc" / "shard-00000.safetensors").is_file()
+    assert not list((tmp_path / "tc").glob(".*.tmp-*"))
+
+
+def test_failed_atomic_index_publication_keeps_the_previous_index_retriable(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import miniverl.cache.store as store_module
+
+    cache_path = tmp_path / "tc"
+    cache = _cache(cache_path, entries_per_shard=8)
+    cache.write(_batch("t0"), selector="hybrid")
+    index_path = cache_path / "index.json"
+    original_index = index_path.read_bytes()
+    real_write_json_atomic = store_module.write_json_atomic
+
+    def fail_index_publication(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        raise OSError("injected atomic index replacement failure")
+
+    monkeypatch.setattr(store_module, "write_json_atomic", fail_index_publication)
+    with pytest.raises(OSError, match="injected atomic index"):
+        cache.flush()
+
+    assert index_path.read_bytes() == original_index
+    assert cache._pending_order == ["t0"]
+    assert len(TeacherCache.open(cache_path)) == 0
+    assert not list(cache_path.glob(".*.tmp-*"))
+
+    monkeypatch.setattr(store_module, "write_json_atomic", real_write_json_atomic)
+    cache.flush()
+    assert len(TeacherCache.open(cache_path)) == 1
 
 
 def test_reopening_a_cache_validates_it(tmp_path: Path):

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -269,18 +269,20 @@ def test_published_gpu_visualization_matches_its_source_result():
     text_nodes = [text.strip() for text in root.itertext() if text.strip()]
     visible_text = " ".join(text_nodes)
     assert f"Source JSON SHA-256 {digest[:16]}" in visible_text
-    assert "Same strict success; protocol OPD uses 6.1× more continuation time" in visible_text
+    assert "Saturated calculator task · same success, 6.1× OPD continuation time" in visible_text
     assert "DIAGNOSTIC NEGATIVE CONTROLS · TEACHERS NOT PROTOCOL-QUALIFIED" in visible_text
     assert "intentionally incompatible" not in visible_text.lower()
+    assert "Strict success on v0.2 test set" in visible_text
     assert "Continuation train time" in visible_text
-    assert "Protocol-teacher preparation: ~555 s once, excluded" in visible_text
+    assert "Teacher preparation is not included in continuation bars." in visible_text
+    assert "~555" not in visible_text
     assert "optimizer_steps" not in visible_text
     cold_text = [text.strip() for text in groups["cold-start-only"].itertext() if text.strip()]
     assert "0 CONTINUATION UPDATES" in cold_text
     assert "0s" not in cold_text
     for name in ("opd-raw-teacher", "opd-privileged-context"):
         arm_text = [text.strip() for text in groups[name].itertext() if text.strip()]
-        assert "NEGATIVE CONTROL · NO PROTOCOL GATE" in arm_text
+        assert "NEGATIVE CONTROL · UNGATED" in arm_text
         assert "0%" in arm_text
         assert "PROTOCOL MISMATCH" not in arm_text
     assert "COLLAPSED" not in visible_text

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -269,19 +269,23 @@ def test_published_gpu_visualization_matches_its_source_result():
     text_nodes = [text.strip() for text in root.itertext() if text.strip()]
     visible_text = " ".join(text_nodes)
     assert f"Source JSON SHA-256 {digest[:16]}" in visible_text
-    assert "Protocol-aligned OPD matches continued SFT" in visible_text
-    assert "DIAGNOSTIC CONTROLS" in visible_text
-    assert "Diagnostic controls intentionally use protocol-incompatible teachers" in visible_text
+    assert "Same strict success; protocol OPD uses 6.1× more continuation time" in visible_text
+    assert "DIAGNOSTIC NEGATIVE CONTROLS · TEACHERS NOT PROTOCOL-QUALIFIED" in visible_text
+    assert "intentionally incompatible" not in visible_text.lower()
+    assert "Continuation train time" in visible_text
+    assert "Protocol-teacher preparation: ~555 s once, excluded" in visible_text
+    assert "optimizer_steps" not in visible_text
     cold_text = [text.strip() for text in groups["cold-start-only"].itertext() if text.strip()]
-    assert "NO TRAINING" in cold_text
+    assert "0 CONTINUATION UPDATES" in cold_text
     assert "0s" not in cold_text
     for name in ("opd-raw-teacher", "opd-privileged-context"):
         arm_text = [text.strip() for text in groups[name].itertext() if text.strip()]
-        assert "PROTOCOL MISMATCH" in arm_text
-        assert "0%" not in arm_text
+        assert "NEGATIVE CONTROL · NO PROTOCOL GATE" in arm_text
+        assert "0%" in arm_text
+        assert "PROTOCOL MISMATCH" not in arm_text
     assert "COLLAPSED" not in visible_text
     assert text_nodes.index("OPD · protocol-aligned teacher") < text_nodes.index(
-        "DIAGNOSTIC CONTROLS · INTENTIONALLY PROTOCOL-INCOMPATIBLE TEACHERS"
+        "DIAGNOSTIC NEGATIVE CONTROLS · TEACHERS NOT PROTOCOL-QUALIFIED"
     )
     assert "\ufffd" not in visible_text
     grid_lines = [
@@ -309,8 +313,13 @@ def test_published_gpu_visualization_matches_its_source_result():
 
 def test_single_gpu_visual_identity_and_pypi_link_are_prominent() -> None:
     banner = (REPO_ROOT / "docs" / "banner.svg").read_text(encoding="utf-8")
-    assert "PERSONAL SINGLE-GPU TRAINING" in banner
-    assert "GPU adaptive" in banner
+    assert "SINGLE-GPU LLM POST-TRAINING" in banner
+    assert "1× CUDA GPU" in banner
+    assert "BF16 / FP16 auto" in banner
+    assert "typed provenance" in banner
+    assert "Exact or top-k + tail teacher targets" in banner
+    assert 'pip install "miniverl[train,cuda]"' not in banner
+    assert "the GPU you have" not in banner
     assert "16 GB first" not in banner
     ET.fromstring(banner)
 

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -24,6 +24,7 @@ Pure string invariants: no torch, no I/O, no randomness.
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import json
 from typing import Any
 
@@ -827,30 +828,98 @@ def test_historical_v1_full_prompt_keeps_its_ambiguous_final_example() -> None:
     )
 
 
-@pytest.mark.parametrize("prompt_style", ["full", "compact"])
-def test_v2_prompt_examples_parse_as_the_intended_actions(prompt_style: str) -> None:
-    import re
-
-    from miniverl.agent.protocol import ActionKind, parse_assistant_text
+@pytest.mark.parametrize(
+    ("prompt_style", "expected_sha256"),
+    [
+        ("full", "cf668e51feb9f7b6dfea67683fda8e8fe93e51b6c379a244ece28a11f558641a"),
+        ("compact", "4f1a67077e93b27600892bf0a02d5b23441ab6f8b38be58846dc8af38709ba59"),
+    ],
+)
+def test_historical_v1_prompt_is_byte_frozen(prompt_style: str, expected_sha256: str) -> None:
     from miniverl.environments.registry import make_environment
 
     prompt = make_environment(
         "calculator",
         prompt_style=prompt_style,
-        protocol_version="v2",
+        protocol_version="v1",
     ).system_prompt()
+    assert hashlib.sha256(prompt.encode("utf-8")).hexdigest() == expected_sha256
+
+
+def _assert_v2_prompt_example_round_trips(environment) -> None:  # type: ignore[no-untyped-def]
+    import re
+
+    from miniverl.agent.protocol import ActionKind, parse_assistant_text
+
+    prompt = environment.system_prompt()
     tool_block = re.search(r"<tool_call>.*?</tool_call>", prompt, flags=re.DOTALL)
     final_block = re.search(r"<final>.*?</final>", prompt, flags=re.DOTALL)
     assert tool_block is not None
     assert final_block is not None
 
+    expected = environment.tool_specs()[0]
     tool = parse_assistant_text(tool_block.group(0))
     final = parse_assistant_text(final_block.group(0))
     assert tool.kind is ActionKind.TOOL_CALL
-    assert tool.tool_name == "calculator"
-    assert tool.arguments == {"expression": "2+2"}
+    assert tool.tool_name == expected.name
+    assert tool.arguments == expected.example
     assert final.kind is ActionKind.FINAL
-    assert final.final_answer == "4"
+    assert final.final_answer == "answer"
+
+
+@pytest.mark.parametrize("environment_name", ["calculator", "jsonnav", "sqlite"])
+@pytest.mark.parametrize("prompt_style", ["full", "compact"])
+def test_v2_builtin_prompt_examples_use_the_active_tool_spec(
+    environment_name: str, prompt_style: str
+) -> None:
+    from miniverl.environments.registry import make_environment
+
+    environment = make_environment(
+        environment_name,
+        prompt_style=prompt_style,
+        protocol_version="v2",
+    )
+    _assert_v2_prompt_example_round_trips(environment)
+
+
+@pytest.mark.parametrize("prompt_style", ["full", "compact"])
+def test_v2_custom_environment_prompt_example_uses_its_tool_spec(prompt_style: str) -> None:
+    from miniverl.environments.base import Task, ToolEnvironment, ToolSpec
+
+    class CustomEnvironment(ToolEnvironment):
+        name = "custom-test"
+
+        def tool_specs(self) -> list[ToolSpec]:
+            return [
+                ToolSpec(
+                    name="reverse",
+                    description="Reverse text.",
+                    parameters={"text": "string"},
+                    required=("text",),
+                    example={"text": "abc"},
+                )
+            ]
+
+        def generate_task(self, index: int, seed: int, *, difficulty: str, split: str) -> Task:
+            raise NotImplementedError
+
+        def reset(self, task: Task) -> Any:
+            raise NotImplementedError
+
+        def step(self, call: Any) -> Any:
+            raise NotImplementedError
+
+        def verify(self, answer: str) -> Any:
+            raise NotImplementedError
+
+        def oracle_actions(self, task: Task) -> list[Any]:
+            raise NotImplementedError
+
+    environment = CustomEnvironment(
+        prompt_style=prompt_style,
+        protocol_version="v2",
+    )
+    _assert_v2_prompt_example_round_trips(environment)
 
 
 def test_v2_render_parse_round_trips_unicode_and_escapes_closing_tag_injection() -> None:

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -901,19 +901,19 @@ def test_v2_custom_environment_prompt_example_uses_its_tool_spec(prompt_style: s
             ]
 
         def generate_task(self, index: int, seed: int, *, difficulty: str, split: str) -> Task:
-            raise NotImplementedError
+            raise AssertionError("not used by this prompt-only test")
 
         def reset(self, task: Task) -> Any:
-            raise NotImplementedError
+            raise AssertionError("not used by this prompt-only test")
 
         def step(self, call: Any) -> Any:
-            raise NotImplementedError
+            raise AssertionError("not used by this prompt-only test")
 
         def verify(self, answer: str) -> Any:
-            raise NotImplementedError
+            raise AssertionError("not used by this prompt-only test")
 
         def oracle_actions(self, task: Task) -> list[Any]:
-            raise NotImplementedError
+            raise AssertionError("not used by this prompt-only test")
 
     environment = CustomEnvironment(
         prompt_style=prompt_style,

--- a/tests/unit/test_tokenizer_identity.py
+++ b/tests/unit/test_tokenizer_identity.py
@@ -36,6 +36,7 @@ class _FakeTokenizer:
         vocab: dict[str, int] | None = None,
         added: dict[str, int] | None = None,
         normalizer: str = "NFC",
+        name_or_path: str = "same/repo",
     ) -> None:
         self._vocab = vocab or {
             "<pad>": 0,
@@ -46,6 +47,10 @@ class _FakeTokenizer:
         }
         self._added = added or {"<tool>": max(self._vocab.values()) + 1}
         self.backend_tokenizer = _BackendTokenizer(normalizer)
+        self.init_kwargs = {
+            "clean_up_tokenization_spaces": False,
+            "name_or_path": name_or_path,
+        }
 
     def __len__(self) -> int:
         return max([*self._vocab.values(), *self._added.values()]) + 1
@@ -91,6 +96,13 @@ def test_same_probe_but_different_structure_has_a_different_v2_digest(changed) -
 
 def test_identical_tokenizer_structure_has_identical_v2_identity() -> None:
     assert _adapter().identity == _adapter().identity
+
+
+def test_local_source_paths_do_not_change_structural_identity(tmp_path) -> None:
+    first = _adapter(name_or_path=str(tmp_path / "checkout-a" / "tokenizer"))
+    second = _adapter(name_or_path=str(tmp_path / "checkout-b" / "tokenizer"))
+
+    assert first.identity == second.identity
 
 
 def test_same_repo_with_different_revisions_is_loaded_and_compared(monkeypatch) -> None:

--- a/tests/unit/test_trainer_lifecycle.py
+++ b/tests/unit/test_trainer_lifecycle.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import gc
+import json
 import weakref
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -52,6 +54,32 @@ def test_close_releases_owned_resources_once_and_is_idempotent(tmp_path) -> None
     assert trainer.optimizer is None
     assert trainer._cache is None
     assert trainer._offline_samples is None
+
+
+def test_model_construction_failure_never_leaves_an_orphan_run_directory(
+    tmp_path, monkeypatch
+) -> None:
+    import miniverl.training.trainer as trainer_module
+    from miniverl.trainer import OPDTrainer
+
+    config = _config(tmp_path)
+    run_id = "model-construction-failure"
+    run_directory = Path(config.run.output_dir) / run_id
+    monkeypatch.setattr(
+        trainer_module,
+        "build_student",
+        Mock(side_effect=RuntimeError("injected model construction failure")),
+    )
+
+    with pytest.raises(RuntimeError, match="injected model construction failure"):
+        OPDTrainer.from_config(config, run_id=run_id)
+
+    if run_directory.exists():
+        manifest_path = run_directory / "manifest.json"
+        assert manifest_path.is_file()
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert manifest["status"] == "failed_construction"
+        assert manifest["failure"]["type"] == "RuntimeError"
 
 
 def test_close_drops_model_optimizer_runner_scorer_and_target_provider_references(


### PR DESCRIPTION
## Changes

- redraw the generated benchmark SVG around measured 0% negative controls and continuation-only timing; scope the title and strict-success label to the saturated v0.2 calculator task, shorten the diagnostic badges, and remove the unsourced `~555 s` figure
- generate protocol-v2 examples from each environment's active `ToolSpec`, with built-in/custom round trips and byte-frozen protocol-v1 fixtures
- persist `entries_per_shard` in the cache index and allocate new shards after the highest numeric suffix found in either the index or cache directory
- make pruning transactional: atomically publish a copied next index before best-effort deletion, preserving every old shard if publication fails and tolerating harmless orphan shards if cleanup fails
- reject unverifiable schema-v1 caches, atomically publish cache shards/indexes, canonicalize tokenizer identity inputs, and clean up failed model construction reservations
- tighten the dark banner and bilingual onboarding, and correct tokenizer and CUDA-install documentation without expanding either README

## Why

The published figure needed task scope and had an unsourced teacher-preparation duration. Cache reopen could also reuse a surviving shard suffix after pruning, lose its configured shard size, and delete old shards before the replacement index was safely published.

The new regression writes shards 0-3, prunes 0-1, reopens, writes shard 4, and proves shards 2/3 remain byte-identical and readable. Separate fault injections prove failed index publication leaves the old index and all old shards intact, while post-publication deletion failure only leaves an unreferenced file.

## Impact

No algorithm, environment, benchmark, model family, or GPU experiment was added. The v0.2.0/v0.2.1/v0.2.2 tags, public adapter revision, and frozen benchmark JSON remain unchanged. Version remains `0.2.3.dev0`; this PR does not publish v0.2.3.

## Validation

- `ruff check .` passed
- `ruff format --check .` passed
- `mypy src/miniverl` passed
- `pytest -q -m "not gpu and not network" --cov=miniverl --cov-report=term-missing --cov-fail-under=80`: 1085 passed, 87.30% coverage
- `pytest -q -m gpu`: 5 passed
- `pytest -q -m network`: 3 passed
- package build and `twine check`: wheel and sdist passed
- 92 relative Markdown targets across 40 tracked files passed; changed English docs/changelog passed external link checking
- generated SVG byte comparison passed; rendered and inspected at 1120 px and 820 px
- frozen JSON SHA-256: `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`