### PR TITLE
Accept HTML banner markup in PyPI verification

### DIFF
--- a/scripts/verify_pypi_release.py
+++ b/scripts/verify_pypi_release.py
@@ -12,10 +12,40 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any
 
 _INTEGRITY_MEDIA_TYPE = "application/vnd.pypi.integrity.v1+json"
+
+
+class _PinnedImageParser(HTMLParser):
+    def __init__(self, target: str) -> None:
+        super().__init__()
+        self.target = target
+        self.alts: list[str] = []
+
+    def handle_starttag(
+        self,
+        tag: str,
+        attrs: list[tuple[str, str | None]],
+    ) -> None:
+        if tag != "img":
+            return
+        attributes = dict(attrs)
+        alt = attributes.get("alt")
+        if attributes.get("src") == self.target and alt:
+            self.alts.append(alt)
+
+
+def _pinned_image_alts(description: str, target: str) -> list[str]:
+    markdown_alts = re.findall(
+        rf"!\[([^\]]+)\]\({re.escape(target)}\)",
+        description,
+    )
+    parser = _PinnedImageParser(target)
+    parser.feed(description)
+    return [*markdown_alts, *parser.alts]
 
 
 def _request_json(url: str, *, accept: str = "application/json") -> dict[str, Any]:
@@ -135,10 +165,7 @@ def _verify_long_description_links(
     if f"{github}/blob/main/" in description or f"{raw}/main/" in description:
         raise RuntimeError("stable PyPI long description still links repository files through main")
 
-    image_matches = re.findall(
-        rf"!\[([^\]]+)\]\({re.escape(required_image_url)}\)",
-        description,
-    )
+    image_matches = _pinned_image_alts(description, required_image_url)
     if not image_matches:
         raise RuntimeError(
             "PyPI long description does not use the release-pinned banner as an image"

--- a/tests/unit/test_pypi_release_verifier.py
+++ b/tests/unit/test_pypi_release_verifier.py
@@ -227,7 +227,7 @@ def test_long_description_can_defer_a_client_challenge_to_browser_inspection(
     )
     banner = f"https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/{tag}/docs/banner.svg"
     links = [f"{repository}/blob/{tag}/{path}" for path in paths]
-    description = "\n".join([*links, f"![release banner]({banner})"])
+    description = "\n".join([*links, f'<img src="{banner}" alt="release banner" width="880">'])
     monkeypatch.setattr(
         verifier,
         "_request_json",


### PR DESCRIPTION
## Summary

- parse release-pinned HTML `<img>` banner markup in addition to Markdown images
- retain exact source URL and non-empty alt-text requirements
- cover the actual PyPI long-description format in the client-challenge regression

## Validation

- public PyPI 0.2.4 description recognized with its exact tag-pinned banner URL
- `pytest tests/unit/test_pypi_release_verifier.py -q`
- `ruff check .`
- `ruff format --check .`
- `mypy src/miniverl scripts/verify_pypi_release.py`
- actionlint
- frozen benchmark SHA-256 unchanged