### PR TITLE
Start v0.4.0 development

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -6,7 +6,7 @@ and what it printed.
 
 Last updated: 2026-08-01.
 
-## v0.3.0 RecoveryBench development
+## v0.3.0 RecoveryBench release
 
 | item | current state |
 | --- | --- |
@@ -14,7 +14,7 @@ Last updated: 2026-08-01.
 | available execution environment | Windows checkout with Python 3.12, Torch 2.13.0+cu130 and an NVIDIA GeForce RTX 4080 (16376 MiB); GitHub and Hugging Face access are available and publication remains restricted to exact validated tags |
 | immutable baseline | calculator benchmark SHA-256 is `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`; calculator protocol-teacher HEAD is `23323751318135484c06c043b1f9b9e7016dd89f`; existing tags remain untouched |
 | phase boundary | RecoveryBench must be preregistered, fully measured with the sequential engine, frozen, merged, released as `v0.3.0`, publicly verified and state-synced to `0.4.0.dev0` before padded batching begins |
-| current highest-risk work | final experiment, artifact audit and data-bound publication are complete; remaining work is release validation, integration, Trusted Publishing verification and the required `0.4.0.dev0` state sync |
+| current highest-risk work | RecoveryBench, release validation, integration and Trusted Publishing verification are complete; the next phase is the separately gated v0.4 consumer batched runtime |
 | RecoveryBench environment | `sqlite_recovery` has 12 structurally disjoint versioned templates, deterministic controlled/natural/no-intervention subsets, structured tool-error provenance, executable recovery oracles, and exact recovery metrics; focused environment and backward-read tests pass |
 | preregistration | public commit `7087b3a333463b88a62ffed73daee2c85d039145` and revision-1.3 digest `9c4c2ec19a56cebb2b2c1c0f3c7e504a9285467c99ae1590488251fbf2ff3934` bind the final procedure; the later public wall-budget amendment was reverted, its partial replacement stopped, and the already-complete frozen experiment was retained without rerun |
 | teacher selection so far | the historical calculator teacher completed 96 eval tasks and failed the gate at 25.0% strict, 10.7% recovery, 95.8% parse validity and 14.4% tool execution; candidate A trained for 64 QLoRA SFT updates and its in-process NF4 eval measured 86.5%, 78.1%, 100% and 87.5%; a separately loaded full-precision reapplication failed at 65.6%, 65.6%, 100% and 62.7% and is retained as a noncanonical diagnostic |
@@ -32,6 +32,13 @@ Last updated: 2026-08-01.
 | secondary budgets | all equal-selected-position arms crossed the 6,224 target after eight steps with recorded overshoot; the nominal 50-second artifact is explicitly a cycle-capped wall diagnostic because SFT and frozen KD completed eight cycles while fresh OPD crossed the target in one indivisible step |
 | immutable RecoveryBench results | equal-updates `6ce2e6837e12b99ebc4fad6d27ce3e69c92e295ff3b9b60e0f68c2d308022384`; equal-selected-positions `fe4c9afc799724dfe7a32e631676a1e5177c44559a7374d2ea31da135354f137`; wall diagnostic `425b0fa568f37b09e61af731d3da5009bd3833bddde6efaf2c66e9dba8355cbe`; task JSONL `aff96bffc6da27240a852410ac041bd4d95badf34cad030e6f437be1491a55ad`; paired analysis `8a6891f74aed80f07ec00d5ea1909895c579346e1abbb1d5d95a354bb46c6b81` |
 | technical publication | the generated Markdown analysis, three SVGs and deterministic six-page PDF report are data-bound to the frozen JSON; native/README-width SVG inspection and every-page PDF inspection found no clipping or overlap |
+| integration source | RecoveryBench PR [#27](https://github.com/DaoyuanLi2816/mini-verl/pull/27) was squash-merged as `bee82d3a6e2c8a5c3f4c62c0d3827a07483a1977`; release-metadata PR [#28](https://github.com/DaoyuanLi2816/mini-verl/pull/28) was squash-merged as `624c6a352db53e0bd2038c4aeb0669a16a402239`; annotated tag `v0.3.0` resolves to the latter exact commit |
+| version transition | `v0.3.0` is immutable and public; this state-sync change identifies subsequent development as `0.4.0.dev0` |
+| release execution | tag run [`30772772078`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30772772078) passed metadata, full tests, one-time build, OIDC publication with attestations, public verification, exact clean install and GitHub Release creation |
+| published wheel | [`miniverl-0.3.0-py3-none-any.whl`](https://pypi.org/project/miniverl/0.3.0/), SHA-256 `e42404ced88b75ba4ff31541cb3df697da0eee09a68f603e4eadbf69a11d2032` |
+| published sdist | [`miniverl-0.3.0.tar.gz`](https://pypi.org/project/miniverl/0.3.0/), SHA-256 `006ce418243286dd27e0731090bf9fa1711a1abc962ecfcc4d39807257539cb2` |
+| independent public verification | GitHub Release downloads reproduce both public hashes; a no-cache Windows Python 3.10 install from `https://pypi.org/simple` reported `miniverl 0.3.0`, passed JSON `doctor`, and kept torch, Transformers, PEFT and bitsandbytes absent |
+| release state | complete; PyPI and [`miniVERL v0.3.0`](https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.3.0) expose the same verified wheel and sdist |
 
 ## v0.2.6 concurrency, lifecycle and privacy correctness release
 

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.3.0/docs/banner.svg" alt="miniVERL — auditable online post-training on one GPU" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — auditable online post-training on one GPU" width="880">
 </p>
 
 <div align="center">
@@ -8,14 +8,14 @@
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE)
 
 </div>
 
 <p align="center">
   <a href="https://pypi.org/project/miniverl/"><strong>PyPI package</strong></a> ·
   <a href="#single-gpu-quickstart">Install &amp; train</a> ·
-  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/docs/single-gpu-guide.md">Bring your own GPU</a> ·
+  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md">Bring your own GPU</a> ·
   <a href="#recoverybench-do-fresh-on-policy-states-justify-their-cost">Measured result</a>
 </p>
 
@@ -59,7 +59,7 @@ validate artifacts without downloading a multi-gigabyte ML stack; use
 [Run the local demo](#local-toy-demo) ·
 [Train on your GPU](#single-gpu-quickstart) ·
 [Inspect the measured result](#recoverybench-do-fresh-on-policy-states-justify-their-cost) ·
-[Read the math](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/docs/math.md)
+[Read the math](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/math.md)
 
 ## Why miniVERL exists
 
@@ -98,7 +98,7 @@ keeps the whole lifecycle in one readable single-GPU process.
 | Calculator, JSON-navigation and SQLite environments | yes, deterministic with exact verifiers |
 | Exact checkpoint/resume | yes, asserted parameter-for-parameter |
 | Self-contained offline HTML report with token-level divergence | yes |
-| Ray, FSDP, DeepSpeed, vLLM, VLMs, cross-tokenizer, PPO/GRPO | **no** — see [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/docs/limitations.md) |
+| Ray, FSDP, DeepSpeed, vLLM, VLMs, cross-tokenizer, PPO/GRPO | **no** — see [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md) |
 
 ## RecoveryBench: do fresh on-policy states justify their cost?
 
@@ -122,7 +122,7 @@ All three seeds and all completed negative results are retained.
 | strict fresh-state OPD | 10.9% | 9.1% | 686.8 s |
 | budget-50 fresh-state OPD | 27.3% | 20.7% | 720.8 s |
 
-![RecoveryBench three-seed result](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.3.0/docs/recoverybench/recovery-success.svg)
+![RecoveryBench three-seed result](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/recoverybench/recovery-success.svg)
 
 The equal-selected-position view reached the 6,224-position boundary after
 eight updates for every core method, so its quality result matches the primary
@@ -132,9 +132,9 @@ did not reduce wall time because teacher backbone forwards were unchanged. The
 evidence**: SFT and frozen KD completed their eight-cycle ceiling, while fresh
 OPD crossed the target in one indivisible 88-121 second update.
 
-Read the [full analysis](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/docs/recoverybench/recoverybench-v1.md), the
-[data-bound technical report](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/paper/recoverybench-v1/recoverybench-v1.pdf), or
-the [immutable schema-v3 artifacts](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/benchmarks/README.md#recoverybench-v1).
+Read the [full analysis](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md), the
+[data-bound technical report](https://github.com/DaoyuanLi2816/mini-verl/blob/main/paper/recoverybench-v1/recoverybench-v1.pdf), or
+the [immutable schema-v3 artifacts](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/README.md#recoverybench-v1).
 The result is scoped to one Qwen3 pair, one task family, three seeds and one RTX
 4080. It does not show that OPD is universally ineffective or that offline KD
 always wins.
@@ -148,18 +148,18 @@ time. Two protocol-naive controls completed normally at 0%; they were not
 configuration failures. Both used the ambiguous historical protocol-v1 prompt,
 so the failure cannot be attributed solely to intrinsic teacher behavior.
 
-![Two-seed protocol-teacher benchmark](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.3.0/docs/gpu-calc-hard-equal-update-v2.svg)
+![Two-seed protocol-teacher benchmark](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/gpu-calc-hard-equal-update-v2.svg)
 
 | Artifact | Role |
 | --- | --- |
-| [Default recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/recipes/qwen_consumer_gpu_calc.yaml) | protocol-qualified default |
-| [Schema-v2 benchmark](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/benchmarks/results/gpu-calc-hard-equal-update-v2.json) | frozen five-arm result |
-| [Raw-teacher recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/recipes/qwen_consumer_gpu_calc_raw_teacher.yaml) | historical control; not default |
+| [Default recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/main/recipes/qwen_consumer_gpu_calc.yaml) | protocol-qualified default |
+| [Schema-v2 benchmark](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/results/gpu-calc-hard-equal-update-v2.json) | frozen five-arm result |
+| [Raw-teacher recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/main/recipes/qwen_consumer_gpu_calc_raw_teacher.yaml) | historical control; not default |
 
 The teacher gate and downstream comparison reused the same 24-task v0.2 test
 set, so this is evidence for qualification in that setup, not a general OPD
 advantage. The separate schema-v1 481-second smoke proves the pipeline, not OPD
-over SFT. [Full diagnosis and caveats](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/docs/rtx4080-baselines.md).
+over SFT. [Full diagnosis and caveats](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/rtx4080-baselines.md).
 
 </details>
 
@@ -236,7 +236,7 @@ bf16, while older CUDA cards such as Titan V use fp16. RTX 3070, Titan V,
 RTX 4080 and RTX 5090-class cards all enter the same code path; only the
 RTX 4080 result is measured here. Exact fit is governed by VRAM, model sizes,
 drivers and token budgets, not the card's marketing name. See the
-[`single-GPU guide`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/docs/single-gpu-guide.md) before changing the recipe.
+[`single-GPU guide`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) before changing the recipe.
 
 ```bash
 git clone https://github.com/DaoyuanLi2816/mini-verl.git
@@ -293,7 +293,7 @@ Layer boundaries are strict, and the first layer never imports torch:
 6. `evaluation/`, `reporting/` — measurement.
 7. `cli.py` — a thin shell that calls one library function per command.
 
-See [`docs/design.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/docs/design.md).
+See [`docs/design.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/design.md).
 
 ## Exact versus top-k + tail
 
@@ -323,7 +323,7 @@ the teacher still runs a full forward pass to produce the hidden states. Reports
 therefore say `teacher_queried_position_ratio`, never "teacher compute saved".
 
 Top-k + tail targets are not a new idea — TRL's `ServerDistillationTrainer` has
-`loss_top_k` with an optional tail bucket. See [`docs/math.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/docs/math.md).
+`loss_top_k` with an optional tail bucket. See [`docs/math.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/math.md).
 
 ## Tool-token masking
 
@@ -348,10 +348,10 @@ documented — see `tests/unit/test_token_provenance.py`.
 ## Benchmark results
 
 Every number below was produced by the commands in
-[`docs/benchmarking.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/docs/benchmarking.md) on the hardware recorded in each
+[`docs/benchmarking.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md) on the hardware recorded in each
 result file. Nothing is estimated or extrapolated.
 
-* **RTX 4080, real models** — [`docs/rtx4080-baselines.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/docs/rtx4080-baselines.md)
+* **RTX 4080, real models** — [`docs/rtx4080-baselines.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/rtx4080-baselines.md)
   has measured peak VRAM, decode throughput, the full-recipe run, the two-seed
   schema-v2 protocol-teacher comparison, and the preserved legacy comparison.
 * **CPU, toy models** — `recipes/toy_cpu.yaml` moves task success from 0.0% to
@@ -359,7 +359,7 @@ result file. Nothing is estimated or extrapolated.
   run.
   The parity run's accuracy differences are **within noise**; it exists to show
   that all seven arms run to completion under identical budgets, not to rank
-  them. See [`benchmarks/README.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/benchmarks/README.md) for why the toy
+  them. See [`benchmarks/README.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/README.md) for why the toy
   backend cannot rank methods.
 
 ## Installation
@@ -464,11 +464,11 @@ distribution before handing it over, and asserts that the result still trains.
 
 For a standard frozen PEFT teacher adapter, including the Qwen3 protocol-SFT
 recipe, export command, compatibility checks and policy-competence gate, see
-[`docs/teacher-adapters.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/docs/teacher-adapters.md).
+[`docs/teacher-adapters.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/teacher-adapters.md).
 
 ## Limitations
 
-The short version; the full list is in [`docs/limitations.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/docs/limitations.md).
+The short version; the full list is in [`docs/limitations.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md).
 
 * Same tokenizer only. Cross-tokenizer distillation is rejected with an error.
 * One trajectory per forward pass — `gradient_accumulation_steps` *is* the batch
@@ -512,8 +512,8 @@ still retain the local state required for exact resume. Redaction is a
 best-effort sharing defense, not permission to place real credentials in any
 config, run artifact or report.
 
-See [`docs/reproducibility.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/docs/reproducibility.md) and the concise
-[`compatibility policy`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/docs/compatibility.md).
+See [`docs/reproducibility.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/reproducibility.md) and the concise
+[`compatibility policy`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md).
 
 ## Roadmap
 
@@ -534,7 +534,7 @@ multi-turn tool use — at cluster scale, with Ray. If you have a cluster, use i
 miniVERL exists for the case where you have one personal GPU and want to read
 every line of what is happening. That can be an older 12 GiB card or a current
 high-end card; the repository claims measured performance only for hardware it
-actually ran. See [`docs/comparisons.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/docs/comparisons.md).
+actually ran. See [`docs/comparisons.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/comparisons.md).
 
 ## Citation
 
@@ -548,13 +548,13 @@ actually ran. See [`docs/comparisons.md`](https://github.com/DaoyuanLi2816/mini-
 }
 ```
 
-See [CITATION.cff](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/CITATION.cff) and [CHANGELOG.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/CHANGELOG.md).
-Contributions: [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/CONTRIBUTING.md). Security:
-[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/SECURITY.md).
+See [CITATION.cff](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff) and [CHANGELOG.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md).
+Contributions: [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md). Security:
+[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md).
 
 ## License
 
-Apache-2.0. See [LICENSE](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/LICENSE) and
-[THIRD_PARTY_NOTICES.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/THIRD_PARTY_NOTICES.md).
+Apache-2.0. See [LICENSE](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE) and
+[THIRD_PARTY_NOTICES.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/THIRD_PARTY_NOTICES.md).
 
-Chinese translation: [README.zh-CN.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.3.0/README.zh-CN.md).
+Chinese translation: [README.zh-CN.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/README.zh-CN.md).

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "release": "0.3.0",
-  "status": "validated",
+  "status": "released",
   "measured_commit": "9175bbe88e19e96834766a34dc7c9513c46513c7",
   "measured_at": "2026-08-02T15:55:58-07:00",
   "cpu_non_gpu_non_network": {

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -48,9 +48,18 @@ after the exact release commit and its remote checks are green.
 
 ## After the tag
 
-- [ ] OIDC publication, public hashes/attestations, clean install and one
-      GitHub Release are verified from the same distributions.
-- [ ] Post-release state-sync PR advances clean `main` to `0.4.0.dev0`.
+- [x] OIDC publication, public hashes/attestations, clean install and one
+      GitHub Release were verified from the same distributions by tag run
+      [`30772772078`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30772772078).
+- [x] This post-release state-sync change advances development to
+      `0.4.0.dev0`; it merges only after remote checks are green.
+
+Published artifact identity:
+
+- `miniverl-0.3.0-py3-none-any.whl`: SHA-256
+  `e42404ced88b75ba4ff31541cb3df697da0eee09a68f603e4eadbf69a11d2032`
+- `miniverl-0.3.0.tar.gz`: SHA-256
+  `006ce418243286dd27e0731090bf9fa1711a1abc962ecfcc4d39807257539cb2`
 
 ## Historical v0.2.6 release record
 

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.3.0"
+__version__ = "0.4.0.dev0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

- advance development from the immutable v0.3.0 release to 0.4.0.dev0
- restore main-pinned links in the generated PyPI description
- record the verified OIDC run, public hashes, attestations, GitHub Release and independent clean install
- preserve all frozen RecoveryBench and calculator artifacts

## Public v0.3.0 evidence

- release workflow: https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30772772078
- wheel: `e42404ced88b75ba4ff31541cb3df697da0eee09a68f603e4eadbf69a11d2032`
- sdist: `006ce418243286dd27e0731090bf9fa1711a1abc962ecfcc4d39807257539cb2`
- no-cache Python 3.10 public install reported 0.3.0, passed JSON doctor, and kept the optional ML stack absent

## Validation

- PyPI description byte check and Markdown links
- Ruff check/format and `mypy src/miniverl`
- 86 focused packaging/version tests
- legacy calculator and primary RecoveryBench hashes unchanged

No runtime or scientific result changes.