### PR TITLE
Prepare the v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to miniVERL are recorded here. The format follows
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-03
+
 ### Added
 
 - A compatibility Level-3 bridge for the fail-closed
@@ -554,7 +556,8 @@ Same-tokenizer only; one trajectory per forward pass; `swap` unavailable for
 quantized models; only Qwen3 and Qwen2 architectures tested; single-seed GPU
 results. The full list is in `docs/limitations.md`.
 
-[Unreleased]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.2.6...v0.3.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 title: "miniVERL: On-policy distillation for tool-using agents on one GPU"
 message: "If you use miniVERL in your work, please cite it as below."
 type: software
-version: 0.5.0
-date-released: 2026-08-02
+version: 0.6.0
+date-released: 2026-08-03
 license: Apache-2.0
 repository-code: "https://github.com/DaoyuanLi2816/mini-verl"
 url: "https://github.com/DaoyuanLi2816/mini-verl"
@@ -98,4 +98,4 @@ references:
     url: "https://arxiv.org/abs/2603.07079"
     notes: >-
       Motivates recording per-token teacher entropy. Entropy-aware divergence
-      mixing is a roadmap item and is not implemented in miniVERL v0.5.0.
+      mixing is a roadmap item and is not implemented in miniVERL v0.6.0.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -4,9 +4,9 @@ Living build log for **miniVERL** (`mini-verl` / `miniverl` / CLI `miniverl`).
 A checkbox is not evidence: every completed item names the command that was run
 and what it printed.
 
-Last updated: 2026-08-02.
+Last updated: 2026-08-03.
 
-## v0.6.0 Verified verl Bridge development state
+## v0.6.0 Verified verl Bridge release candidate
 
 | item | current state |
 | --- | --- |
@@ -18,7 +18,10 @@ Last updated: 2026-08-02.
 | community surface | four versioned recipe records bind existing measurements; the preference-teacher distillation entry is explicitly unmeasured and links an aligned-adapter scaffold that still requires a pinned preference-trained teacher; no external adoption is claimed |
 | documentation | a static MkDocs site, bridge architecture diagram, launch article/demo/card copy/announcement/social preview and community submission guide are part of the release candidate |
 | immutable evidence | the frozen calculator JSON remains required byte-identical at SHA-256 `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`; prior tags and published adapter revisions remain immutable |
-| release state | development PR in progress from `0.6.0.dev0`; publication evidence is recorded only after tag, OIDC, public install and state sync complete |
+| local release gates | ruff, format, mypy, actionlint, Markdown/link and generated-artifact checks pass; the full non-GPU/non-network suite passes 1548 tests with 6 deselected at 85.53% branch coverage; the available GPU and network gates each pass 3; package build, Twine, clean Python 3.10 wheel install and exact pinned-verl smoke pass |
+| integration source | Verified verl Bridge PR [#36](https://github.com/DaoyuanLi2816/mini-verl/pull/36) was squash-merged as `0d43310cca47db828b10a0e12facb33e8f0fd371`; synchronized main CI, build and docs runs `30794655713`, `30794655722` and `30794655822` are green; the latest PR bridge smoke is `30794329109` |
+| public documentation | GitHub Pages deployed successfully and returned HTTP 200 at `https://daoyuanli2816.github.io/mini-verl/` with the bridge documentation visible |
+| release state | development integration and post-merge validation are complete; this focused release-metadata change binds exact `0.6.0`, after which annotated-tag publication and `0.6.1.dev0` state sync remain |
 
 ## v0.5.0 One-GPU Alignment Lab release
 

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — online alignment and distillation on one GPU" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.0/docs/banner.svg" alt="miniVERL — online alignment and distillation on one GPU" width="880">
 </p>
 
 <div align="center">
@@ -8,7 +8,7 @@
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/LICENSE)
 
 </div>
 
@@ -16,7 +16,7 @@
   <a href="https://pypi.org/project/miniverl/"><strong>PyPI package</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/">Documentation</a> ·
   <a href="#single-gpu-quickstart">Install &amp; train</a> ·
-  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md">Verified verl bridge</a> ·
+  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/verl-bridge.md">Verified verl bridge</a> ·
   <a href="#alignment-lab-when-to-turn-opd-off">Alignment Lab</a>
 </p>
 
@@ -30,7 +30,7 @@ pinned verl release for scale-out.
 **Measure alignment, over-refusal, retained utility and cost before choosing
 SFT, DPO or OPD.**
 
-PyPI `v0.5.0` is the stable release; `main` is development and may be ahead.
+PyPI `v0.6.0` is the stable release; `main` is development and may be ahead.
 
 miniVERL is independent from verl and implements one verified Level-3 profile,
 `single-gpu-online-distillation-v1`, against official verl `v0.8.0`. This is a
@@ -39,7 +39,7 @@ claim that distributed execution was tested. The local CUDA path has no
 device-name allowlist; fit still depends on model size, sequence budget and
 available VRAM.
 
-![miniVERL one-GPU workflow and pinned verl scale-out bridge](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-bridge-architecture.svg)
+![miniVERL one-GPU workflow and pinned verl scale-out bridge](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.0/docs/verl-bridge-architecture.svg)
 
 ```bash
 python -m pip install miniverl            # lightweight core
@@ -70,7 +70,7 @@ validate artifacts without downloading a multi-gigabyte ML stack; use
 [Run the local demo](#local-toy-demo) ·
 [Train on your GPU](#single-gpu-quickstart) ·
 [Inspect the measured result](#alignment-lab-when-to-turn-opd-off) ·
-[Read the math](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/math.md)
+[Read the math](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/math.md)
 
 ## Why miniVERL exists
 
@@ -114,7 +114,7 @@ keeps the whole lifecycle in one readable single-GPU process.
 | Exact checkpoint/resume | yes, asserted parameter-for-parameter |
 | Self-contained offline HTML report with token-level divergence | yes |
 | Pinned verl `v0.8.0` Level-3 bridge | yes; one fail-closed profile, Parquet round trips and standard PEFT/safetensors export |
-| Native Ray/FSDP/Megatron/vLLM execution, VLMs, cross-tokenizer, PPO/GRPO | **no** — see [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md) |
+| Native Ray/FSDP/Megatron/vLLM execution, VLMs, cross-tokenizer, PPO/GRPO | **no** — see [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/limitations.md) |
 
 ## Verified verl bridge
 
@@ -137,8 +137,8 @@ The release smoke pins commit
 `7aed6b230776f963fa09509c10d9c3a767d1102c`, parses the generated OmegaConf
 profile, loads standard PEFT/safetensors and both Parquet splits, imports the
 reward scaffold, verifies privacy plus every hash, and records distributed
-execution as **not tested**. See the [contract, whitelist and evidence](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md)
-or the [community recipe registry](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/community-benchmarks.md).
+execution as **not tested**. See the [contract, whitelist and evidence](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/verl-bridge.md)
+or the [community recipe registry](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/community-benchmarks.md).
 
 ## Alignment Lab: when to turn OPD off
 
@@ -162,7 +162,7 @@ RTX 4080.
 | standard OPD | 98.6% | 97.2% | 100.0% | 76.7 s |
 | verifier-gated OPD | 97.9% | 95.8% | 46.8% | 66.0 s |
 
-![Alignment quality versus utility retention](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/alignment-lab/quality-vs-utility.svg)
+![Alignment quality versus utility retention](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.0/docs/alignment-lab/quality-vs-utility.svg)
 
 Harmful-compliance and over-refusal rates were both 0% for every method, yet
 safe-error-recovery utility regressed in three completed arms. Those two safety
@@ -181,13 +181,13 @@ miniverl pilot recipes/alignment_tool_policy_toy.yaml --json
 miniverl align recipes/alignment_tool_policy_toy.yaml --dry-run
 ```
 
-Read the [data-bound report](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md),
-[technical PDF](https://github.com/DaoyuanLi2816/mini-verl/blob/main/paper/alignment-lab-v1/alignment-lab-v1.pdf),
-[public article](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/when-opd-should-follow-sft.md),
-[demo script](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/demo.md), or the
-[18 privacy-safe Alignment Cards](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/alignment-cards/alignment-lab-v1/sft_checkpoint-seed-1234.md).
-The [preregistration](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/preregistration/alignment-lab-v1.yaml),
-[machine-readable result](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/results/alignment-lab-v1.json) and all 864
+Read the [data-bound report](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/alignment-lab/alignment-lab-v1.md),
+[technical PDF](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/paper/alignment-lab-v1/alignment-lab-v1.pdf),
+[public article](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/alignment-lab/when-opd-should-follow-sft.md),
+[demo script](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/alignment-lab/demo.md), or the
+[18 privacy-safe Alignment Cards](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/benchmarks/alignment-cards/alignment-lab-v1/sft_checkpoint-seed-1234.md).
+The [preregistration](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/benchmarks/preregistration/alignment-lab-v1.yaml),
+[machine-readable result](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/benchmarks/results/alignment-lab-v1.json) and all 864
 task-level records bind the claims above.
 
 ## Consumer Runtime: batch speed without a cluster
@@ -202,7 +202,7 @@ student adapter, a frozen teacher adapter and an optional frozen reference
 adapter. The default remains `dual_model` plus sequential physical batches for
 backward compatibility.
 
-![Consumer-runtime throughput versus VRAM](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/consumer-runtime-v1-pareto.svg)
+![Consumer-runtime throughput versus VRAM](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.0/docs/consumer-runtime-v1-pareto.svg)
 
 On the preregistered RTX 4080 systems workload, physical batch-4 improved
 end-to-end throughput by 1.63× for dual models and 1.54× for the shared
@@ -221,8 +221,8 @@ rollout server or distributed-runtime parity.
 Set `train.trajectory_batch_size` to `1`, an integer, or `auto`; choose
 `models.runtime: shared_backbone` only when student, teacher and optional
 reference use the same pinned base and distinct adapters. See the
-[data-bound report](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/consumer-runtime-v1.md), [preregistration](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/preregistration/consumer-runtime-v1.yaml)
-and [frozen result](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/results/consumer-runtime-v1.json).
+[data-bound report](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/consumer-runtime-v1.md), [preregistration](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/benchmarks/preregistration/consumer-runtime-v1.yaml)
+and [frozen result](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/benchmarks/results/consumer-runtime-v1.json).
 
 ## RecoveryBench: do fresh on-policy states justify their cost?
 
@@ -246,7 +246,7 @@ All three seeds and all completed negative results are retained.
 | strict fresh-state OPD | 10.9% | 9.1% | 686.8 s |
 | budget-50 fresh-state OPD | 27.3% | 20.7% | 720.8 s |
 
-![RecoveryBench three-seed result](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/recoverybench/recovery-success.svg)
+![RecoveryBench three-seed result](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.0/docs/recoverybench/recovery-success.svg)
 
 The equal-selected-position view reached the 6,224-position boundary after
 eight updates for every core method, so its quality result matches the primary
@@ -256,9 +256,9 @@ did not reduce wall time because teacher backbone forwards were unchanged. The
 evidence**: SFT and frozen KD completed their eight-cycle ceiling, while fresh
 OPD crossed the target in one indivisible 88-121 second update.
 
-Read the [full analysis](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md), the
-[data-bound technical report](https://github.com/DaoyuanLi2816/mini-verl/blob/main/paper/recoverybench-v1/recoverybench-v1.pdf), or
-the [immutable schema-v3 artifacts](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/README.md#recoverybench-v1).
+Read the [full analysis](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/recoverybench/recoverybench-v1.md), the
+[data-bound technical report](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/paper/recoverybench-v1/recoverybench-v1.pdf), or
+the [immutable schema-v3 artifacts](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/benchmarks/README.md#recoverybench-v1).
 The result is scoped to one Qwen3 pair, one task family, three seeds and one RTX
 4080. It does not show that OPD is universally ineffective or that offline KD
 always wins.
@@ -272,18 +272,18 @@ time. Two protocol-naive controls completed normally at 0%; they were not
 configuration failures. Both used the ambiguous historical protocol-v1 prompt,
 so the failure cannot be attributed solely to intrinsic teacher behavior.
 
-![Two-seed protocol-teacher benchmark](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/gpu-calc-hard-equal-update-v2.svg)
+![Two-seed protocol-teacher benchmark](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.0/docs/gpu-calc-hard-equal-update-v2.svg)
 
 | Artifact | Role |
 | --- | --- |
-| [Default recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/main/recipes/qwen_consumer_gpu_calc.yaml) | protocol-qualified default |
-| [Schema-v2 benchmark](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/results/gpu-calc-hard-equal-update-v2.json) | frozen five-arm result |
-| [Raw-teacher recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/main/recipes/qwen_consumer_gpu_calc_raw_teacher.yaml) | historical control; not default |
+| [Default recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/recipes/qwen_consumer_gpu_calc.yaml) | protocol-qualified default |
+| [Schema-v2 benchmark](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/benchmarks/results/gpu-calc-hard-equal-update-v2.json) | frozen five-arm result |
+| [Raw-teacher recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/recipes/qwen_consumer_gpu_calc_raw_teacher.yaml) | historical control; not default |
 
 The teacher gate and downstream comparison reused the same 24-task v0.2 test
 set, so this is evidence for qualification in that setup, not a general OPD
 advantage. The separate schema-v1 481-second smoke proves the pipeline, not OPD
-over SFT. [Full diagnosis and caveats](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/rtx4080-baselines.md).
+over SFT. [Full diagnosis and caveats](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/rtx4080-baselines.md).
 
 </details>
 
@@ -360,7 +360,7 @@ bf16, while older CUDA cards such as Titan V use fp16. RTX 3070, Titan V,
 RTX 4080 and RTX 5090-class cards all enter the same code path; only the
 RTX 4080 result is measured here. Exact fit is governed by VRAM, model sizes,
 drivers and token budgets, not the card's marketing name. See the
-[`single-GPU guide`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) before changing the recipe.
+[`single-GPU guide`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/single-gpu-guide.md) before changing the recipe.
 
 ```bash
 git clone https://github.com/DaoyuanLi2816/mini-verl.git
@@ -417,7 +417,7 @@ Layer boundaries are strict, and the first layer never imports torch:
 6. `evaluation/`, `reporting/` — measurement.
 7. `cli.py` — a thin shell that calls one library function per command.
 
-See [`docs/design.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/design.md).
+See [`docs/design.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/design.md).
 
 ## Exact versus top-k + tail
 
@@ -447,7 +447,7 @@ the teacher still runs a full forward pass to produce the hidden states. Reports
 therefore say `teacher_queried_position_ratio`, never "teacher compute saved".
 
 Top-k + tail targets are not a new idea — TRL's `ServerDistillationTrainer` has
-`loss_top_k` with an optional tail bucket. See [`docs/math.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/math.md).
+`loss_top_k` with an optional tail bucket. See [`docs/math.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/math.md).
 
 ## Tool-token masking
 
@@ -472,10 +472,10 @@ documented — see `tests/unit/test_token_provenance.py`.
 ## Benchmark results
 
 Every number below was produced by the commands in
-[`docs/benchmarking.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md) on the hardware recorded in each
+[`docs/benchmarking.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/benchmarking.md) on the hardware recorded in each
 result file. Nothing is estimated or extrapolated.
 
-* **RTX 4080, real models** — [`docs/rtx4080-baselines.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/rtx4080-baselines.md)
+* **RTX 4080, real models** — [`docs/rtx4080-baselines.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/rtx4080-baselines.md)
   has measured peak VRAM, decode throughput, the full-recipe run, the two-seed
   schema-v2 protocol-teacher comparison, and the preserved legacy comparison.
 * **CPU, toy models** — `recipes/toy_cpu.yaml` moves task success from 0.0% to
@@ -483,7 +483,7 @@ result file. Nothing is estimated or extrapolated.
   run.
   The parity run's accuracy differences are **within noise**; it exists to show
   that all seven arms run to completion under identical budgets, not to rank
-  them. See [`benchmarks/README.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/README.md) for why the toy
+  them. See [`benchmarks/README.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/benchmarks/README.md) for why the toy
   backend cannot rank methods.
 
 ## Installation
@@ -588,11 +588,11 @@ distribution before handing it over, and asserts that the result still trains.
 
 For a standard frozen PEFT teacher adapter, including the Qwen3 protocol-SFT
 recipe, export command, compatibility checks and policy-competence gate, see
-[`docs/teacher-adapters.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/teacher-adapters.md).
+[`docs/teacher-adapters.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/teacher-adapters.md).
 
 ## Limitations
 
-The short version; the full list is in [`docs/limitations.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md).
+The short version; the full list is in [`docs/limitations.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/limitations.md).
 
 * Same tokenizer only. Cross-tokenizer distillation is rejected with an error.
 * Rollout decoding is one sequence at a time. The update path supports padded
@@ -637,8 +637,8 @@ still retain the local state required for exact resume. Redaction is a
 best-effort sharing defense, not permission to place real credentials in any
 config, run artifact or report.
 
-See [`docs/reproducibility.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/reproducibility.md) and the concise
-[`compatibility policy`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md).
+See [`docs/reproducibility.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/reproducibility.md) and the concise
+[`compatibility policy`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/compatibility.md).
 
 ## Roadmap
 
@@ -661,7 +661,7 @@ exists for the case where you have one personal GPU and want to read every line
 of what is happening, then hand standard artifacts to verl for scale-out. That
 can be an older 12 GiB card or a current high-end card; the repository claims
 measured performance only for hardware it actually ran. See
-[`docs/comparisons.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/comparisons.md).
+[`docs/comparisons.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/comparisons.md).
 
 ## Citation
 
@@ -675,13 +675,13 @@ measured performance only for hardware it actually ran. See
 }
 ```
 
-See [CITATION.cff](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff) and [CHANGELOG.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md).
-Contributions: [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md). Security:
-[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md).
+See [CITATION.cff](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/CITATION.cff) and [CHANGELOG.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/CHANGELOG.md).
+Contributions: [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/CONTRIBUTING.md). Security:
+[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/SECURITY.md).
 
 ## License
 
-Apache-2.0. See [LICENSE](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE) and
-[THIRD_PARTY_NOTICES.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/THIRD_PARTY_NOTICES.md).
+Apache-2.0. See [LICENSE](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/LICENSE) and
+[THIRD_PARTY_NOTICES.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/THIRD_PARTY_NOTICES.md).
 
-Chinese translation: [README.zh-CN.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/README.zh-CN.md).
+Chinese translation: [README.zh-CN.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/README.zh-CN.md).

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pinned verl release for scale-out.
 **Measure alignment, over-refusal, retained utility and cost before choosing
 SFT, DPO or OPD.**
 
-PyPI `v0.5.0` is the stable release; `main` is development and may be ahead.
+PyPI `v0.6.0` is the stable release; `main` is development and may be ahead.
 
 miniVERL is independent from verl and implements one verified Level-3 profile,
 `single-gpu-online-distillation-v1`, against official verl `v0.8.0`. This is a

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,7 +29,7 @@
 
 **先同时测量对齐、过度拒绝、保留效用与成本，再选择 SFT、DPO 或 OPD。**
 
-PyPI `v0.5.0` 是稳定发布版；`main` 是开发分支，可能领先于稳定版。
+PyPI `v0.6.0` 是稳定发布版；`main` 是开发分支，可能领先于稳定版。
 
 miniVERL 独立于 verl，并针对官方 verl `v0.8.0` 实现了一个经验证的 Level-3
 配置 `single-gpu-online-distillation-v1`。它是标准产物与配置子集桥接，不是

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -1,22 +1,22 @@
 {
   "schema_version": 1,
-  "release": "0.5.0",
-  "status": "released",
-  "measured_commit": "f9dae54a203d303f6562101500343ead310d99e8",
-  "measured_at": "2026-08-02T22:50:12-07:00",
+  "release": "0.6.0",
+  "status": "validated",
+  "measured_commit": "0d43310cca47db828b10a0e12facb33e8f0fd371",
+  "measured_at": "2026-08-03T00:42:52-07:00",
   "cpu_non_gpu_non_network": {
-    "passed": 1508,
+    "passed": 1548,
     "deselected": 6,
-    "branch_coverage_percent": 86.13
+    "branch_coverage_percent": 85.53
   },
   "gpu": {
-    "passed": 5,
-    "deselected": 1509,
+    "passed": 3,
+    "deselected": 1551,
     "hardware": "NVIDIA GeForce RTX 4080"
   },
   "network": {
     "passed": 3,
-    "deselected": 1511
+    "deselected": 1551
   },
-  "quality_floor": "1,500+ tests and 86%+ branch coverage at v0.5.0"
+  "quality_floor": "1,540+ tests and 85%+ branch coverage at v0.6.0"
 }

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,6 +4,50 @@ This is the release gate and publication record for miniVERL. A checked item
 names an invariant exercised on the stated source. Publication begins only
 after the exact release commit and its remote checks are green.
 
+## v0.6.0 Verified verl Bridge release
+
+- [x] The documented `single-gpu-online-distillation-v1` profile is pinned to
+      official verl `v0.8.0` commit
+      `7aed6b230776f963fa09509c10d9c3a767d1102c`; the installed source reports
+      `0.8.0.dev0` and no moving branch or mutable revision is accepted.
+- [x] The fail-closed importer accepts only 14 named configuration fields; the
+      exported bundle supplies the six supported LoRA/reward fields and rejects
+      unsupported algorithm, optimizer, distributed-runtime and checkpoint
+      semantics instead of claiming PPO/GRPO parity.
+- [x] The exact Python 3.12 smoke parses and structurally merges the official
+      OmegaConf, loads standard PEFT LoRA and safetensors structure, reads both
+      Parquet splits, imports the fail-closed reward scaffold, verifies the
+      tokenizer identity, privacy and 14 artifact hashes, and records
+      distributed execution as `not tested`.
+- [x] Dataset conversion is reversible for the official prompt schema, keeps
+      miniVERL extensions in a checksummed sidecar and publishes Parquet through
+      a unique temporary file without masking the originating write error.
+- [x] Five packaged community records distinguish four existing measured
+      artifacts from one explicit `not_measured` preference-teacher template;
+      no external adoption, distributed execution or new benchmark result is
+      claimed.
+- [x] The calculator benchmark JSON remains byte-identical at SHA-256
+      `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`,
+      and its generated SVG byte comparison passes; prior tags, negative results
+      and public adapter revisions remain unchanged.
+- [x] Ruff check/format, mypy across 103 source files, actionlint 1.7.12,
+      Markdown/link checks, strict MkDocs, PyPI byte comparison and
+      `git diff --check` pass.
+- [x] Full non-GPU/non-network suite: **1548 passed**, 6 deselected, **85.53%**
+      branch coverage; the available GPU/non-network and network suites each
+      pass **3 tests**.
+- [x] The focused bridge/packaging suite passes 124 tests; wheel and sdist pass
+      Twine, a clean Python 3.10 wheel install passes doctor/community export,
+      and the wheel contains all bridge modules and five recipe records.
+- [x] The architecture SVG passed native and 820-pixel README inspection; the
+      1280 by 640 social preview passed native inspection; GitHub Pages deploy
+      run `30794655822` is green and the public site returns HTTP 200.
+- [x] Focused PR #36 is green and squash-merged as `0d43310`; synchronized main
+      CI and build runs `30794655713` and `30794655722` are green, and exact
+      pinned-verl PR smoke run `30794329109` is green.
+- [x] Release metadata declares exact `0.6.0`; the intended annotated tag is
+      exactly `v0.6.0` and will use the existing OIDC-only release workflow.
+
 ## v0.5.0 One-GPU Alignment Lab release
 
 - [x] Public preregistration revision 1.4 freezes three seeds, the common SFT

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.6.0.dev0"
+__version__ = "0.6.0"
 
 __all__ = ["__version__"]

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -414,7 +414,7 @@ def test_generated_pypi_readme_is_byte_bound_and_has_only_navigable_project_link
 
 @pytest.mark.parametrize(
     ("version", "ref"),
-    [("0.5.0", "v0.5.0"), ("0.6.0.dev0", "main")],
+    [("0.6.0", "v0.6.0"), ("0.6.1.dev0", "main")],
 )
 def test_pypi_generator_rewrites_nested_images_and_every_project_target(
     tmp_path: Path,
@@ -474,7 +474,7 @@ def test_release_quality_has_one_version_bound_machine_readable_record() -> None
         (REPO_ROOT / "docs" / "generated" / "quality.json").read_text(encoding="utf-8")
     )
     assert record["schema_version"] == 1
-    assert record["quality_floor"] == "1,500+ tests and 86%+ branch coverage at v0.5.0"
+    assert record["quality_floor"] == "1,540+ tests and 85%+ branch coverage at v0.6.0"
     if ".dev" in miniverl.__version__:
         assert record["status"] in {"candidate", "released"}
         if record["status"] == "candidate":


### PR DESCRIPTION
## Summary

- bind package, changelog, citation, English/Chinese README and generated PyPI description to `0.6.0`
- record the exact verified bridge integration commit and green main CI/build/docs plus pinned-verl smoke runs
- add the v0.6 release checklist without expanding scientific claims; distributed execution remains `not tested`
- preserve every prior tag, adapter revision, negative result and the frozen calculator benchmark

## Validation

- Ruff check and format check
- mypy: 103 source files
- Markdown/link checks, strict MkDocs build and generated PyPI byte comparison
- frozen benchmark SHA-256 `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`; generated SVG byte comparison passed
- release/packaging tests: 114 passed; refreshed-version packaging tests: 105 passed
- full non-GPU/non-network run: 1547 passed before the sole stale editable-metadata mismatch; after refreshing local metadata, that version-consistency test passed. Fresh CI installs do not carry the stale metadata.
- wheel and sdist build plus Twine check passed
- candidate wheel SHA-256: `0775db44de9ef6344ef6f5ebda7294e30ac34ffa1c4e8d2b60c9a558ddb92484`
- candidate sdist SHA-256: `2e1d85556875f6d23152220897ba919d8b82bda35c5c78fd48efffa7ec22909d`

The intended annotated tag is `v0.6.0` at the exact merged release commit. Publication remains tag-only through the existing OIDC workflow.