### PR TITLE
Start v0.6.1 development

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -6,7 +6,7 @@ and what it printed.
 
 Last updated: 2026-08-03.
 
-## v0.6.0 Verified verl Bridge release candidate
+## v0.6.0 Verified verl Bridge release
 
 | item | current state |
 | --- | --- |
@@ -21,7 +21,13 @@ Last updated: 2026-08-03.
 | local release gates | ruff, format, mypy, actionlint, Markdown/link and generated-artifact checks pass; the full non-GPU/non-network suite passes 1548 tests with 6 deselected at 85.53% branch coverage; the available GPU and network gates each pass 3; package build, Twine, clean Python 3.10 wheel install and exact pinned-verl smoke pass |
 | integration source | Verified verl Bridge PR [#36](https://github.com/DaoyuanLi2816/mini-verl/pull/36) was squash-merged as `0d43310cca47db828b10a0e12facb33e8f0fd371`; synchronized main CI, build and docs runs `30794655713`, `30794655722` and `30794655822` are green; the latest PR bridge smoke is `30794329109` |
 | public documentation | GitHub Pages deployed successfully and returned HTTP 200 at `https://daoyuanli2816.github.io/mini-verl/` with the bridge documentation visible |
-| release state | development integration and post-merge validation are complete; this focused release-metadata change binds exact `0.6.0`, after which annotated-tag publication and `0.6.1.dev0` state sync remain |
+| release metadata | PR [#37](https://github.com/DaoyuanLi2816/mini-verl/pull/37) was squash-merged as exact commit `6cfbdbb7bbf5c6042def4cf154bfe3c3b6530eea`; annotated tag `v0.6.0` resolves to that commit |
+| release execution | tag run [`30796058250`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30796058250) passed metadata, the full quality gate, one-time build, OIDC Trusted Publishing with attestations, public PyPI verification, exact install and GitHub Release creation |
+| published wheel | [`miniverl-0.6.0-py3-none-any.whl`](https://pypi.org/project/miniverl/0.6.0/), SHA-256 `e5fbb99bf410c27d22d6959f9599dfa4fbac2e940dac63f55c9676f68264abd1` |
+| published sdist | [`miniverl-0.6.0.tar.gz`](https://pypi.org/project/miniverl/0.6.0/), SHA-256 `2e1d85556875f6d23152220897ba919d8b82bda35c5c78fd48efffa7ec22909d` |
+| independent public verification | PyPI and GitHub Release expose the same files and hashes; PyPI exposes one Trusted Publisher attestation bundle per distribution, bound to `release.yml`, environment `pypi` and commit `6cfbdbb7`; a clean Windows Python 3.10 install from `https://pypi.org/simple` reported `miniverl 0.6.0` and passed JSON `doctor` with the core path healthy and torch absent |
+| version transition | `v0.6.0` is immutable and public; this state-sync change identifies subsequent development as `0.6.1.dev0` |
+| release state | complete; PyPI, [`miniVERL v0.6.0`](https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.6.0) and the public documentation site expose the verified release |
 
 ## v0.5.0 One-GPU Alignment Lab release
 

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.0/docs/banner.svg" alt="miniVERL — online alignment and distillation on one GPU" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — online alignment and distillation on one GPU" width="880">
 </p>
 
 <div align="center">
@@ -8,7 +8,7 @@
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE)
 
 </div>
 
@@ -16,7 +16,7 @@
   <a href="https://pypi.org/project/miniverl/"><strong>PyPI package</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/">Documentation</a> ·
   <a href="#single-gpu-quickstart">Install &amp; train</a> ·
-  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/verl-bridge.md">Verified verl bridge</a> ·
+  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md">Verified verl bridge</a> ·
   <a href="#alignment-lab-when-to-turn-opd-off">Alignment Lab</a>
 </p>
 
@@ -39,7 +39,7 @@ claim that distributed execution was tested. The local CUDA path has no
 device-name allowlist; fit still depends on model size, sequence budget and
 available VRAM.
 
-![miniVERL one-GPU workflow and pinned verl scale-out bridge](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.0/docs/verl-bridge-architecture.svg)
+![miniVERL one-GPU workflow and pinned verl scale-out bridge](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-bridge-architecture.svg)
 
 ```bash
 python -m pip install miniverl            # lightweight core
@@ -70,7 +70,7 @@ validate artifacts without downloading a multi-gigabyte ML stack; use
 [Run the local demo](#local-toy-demo) ·
 [Train on your GPU](#single-gpu-quickstart) ·
 [Inspect the measured result](#alignment-lab-when-to-turn-opd-off) ·
-[Read the math](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/math.md)
+[Read the math](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/math.md)
 
 ## Why miniVERL exists
 
@@ -114,7 +114,7 @@ keeps the whole lifecycle in one readable single-GPU process.
 | Exact checkpoint/resume | yes, asserted parameter-for-parameter |
 | Self-contained offline HTML report with token-level divergence | yes |
 | Pinned verl `v0.8.0` Level-3 bridge | yes; one fail-closed profile, Parquet round trips and standard PEFT/safetensors export |
-| Native Ray/FSDP/Megatron/vLLM execution, VLMs, cross-tokenizer, PPO/GRPO | **no** — see [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/limitations.md) |
+| Native Ray/FSDP/Megatron/vLLM execution, VLMs, cross-tokenizer, PPO/GRPO | **no** — see [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md) |
 
 ## Verified verl bridge
 
@@ -137,8 +137,8 @@ The release smoke pins commit
 `7aed6b230776f963fa09509c10d9c3a767d1102c`, parses the generated OmegaConf
 profile, loads standard PEFT/safetensors and both Parquet splits, imports the
 reward scaffold, verifies privacy plus every hash, and records distributed
-execution as **not tested**. See the [contract, whitelist and evidence](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/verl-bridge.md)
-or the [community recipe registry](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/community-benchmarks.md).
+execution as **not tested**. See the [contract, whitelist and evidence](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md)
+or the [community recipe registry](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/community-benchmarks.md).
 
 ## Alignment Lab: when to turn OPD off
 
@@ -162,7 +162,7 @@ RTX 4080.
 | standard OPD | 98.6% | 97.2% | 100.0% | 76.7 s |
 | verifier-gated OPD | 97.9% | 95.8% | 46.8% | 66.0 s |
 
-![Alignment quality versus utility retention](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.0/docs/alignment-lab/quality-vs-utility.svg)
+![Alignment quality versus utility retention](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/alignment-lab/quality-vs-utility.svg)
 
 Harmful-compliance and over-refusal rates were both 0% for every method, yet
 safe-error-recovery utility regressed in three completed arms. Those two safety
@@ -181,13 +181,13 @@ miniverl pilot recipes/alignment_tool_policy_toy.yaml --json
 miniverl align recipes/alignment_tool_policy_toy.yaml --dry-run
 ```
 
-Read the [data-bound report](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/alignment-lab/alignment-lab-v1.md),
-[technical PDF](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/paper/alignment-lab-v1/alignment-lab-v1.pdf),
-[public article](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/alignment-lab/when-opd-should-follow-sft.md),
-[demo script](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/alignment-lab/demo.md), or the
-[18 privacy-safe Alignment Cards](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/benchmarks/alignment-cards/alignment-lab-v1/sft_checkpoint-seed-1234.md).
-The [preregistration](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/benchmarks/preregistration/alignment-lab-v1.yaml),
-[machine-readable result](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/benchmarks/results/alignment-lab-v1.json) and all 864
+Read the [data-bound report](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md),
+[technical PDF](https://github.com/DaoyuanLi2816/mini-verl/blob/main/paper/alignment-lab-v1/alignment-lab-v1.pdf),
+[public article](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/when-opd-should-follow-sft.md),
+[demo script](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/demo.md), or the
+[18 privacy-safe Alignment Cards](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/alignment-cards/alignment-lab-v1/sft_checkpoint-seed-1234.md).
+The [preregistration](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/preregistration/alignment-lab-v1.yaml),
+[machine-readable result](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/results/alignment-lab-v1.json) and all 864
 task-level records bind the claims above.
 
 ## Consumer Runtime: batch speed without a cluster
@@ -202,7 +202,7 @@ student adapter, a frozen teacher adapter and an optional frozen reference
 adapter. The default remains `dual_model` plus sequential physical batches for
 backward compatibility.
 
-![Consumer-runtime throughput versus VRAM](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.0/docs/consumer-runtime-v1-pareto.svg)
+![Consumer-runtime throughput versus VRAM](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/consumer-runtime-v1-pareto.svg)
 
 On the preregistered RTX 4080 systems workload, physical batch-4 improved
 end-to-end throughput by 1.63× for dual models and 1.54× for the shared
@@ -221,8 +221,8 @@ rollout server or distributed-runtime parity.
 Set `train.trajectory_batch_size` to `1`, an integer, or `auto`; choose
 `models.runtime: shared_backbone` only when student, teacher and optional
 reference use the same pinned base and distinct adapters. See the
-[data-bound report](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/consumer-runtime-v1.md), [preregistration](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/benchmarks/preregistration/consumer-runtime-v1.yaml)
-and [frozen result](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/benchmarks/results/consumer-runtime-v1.json).
+[data-bound report](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/consumer-runtime-v1.md), [preregistration](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/preregistration/consumer-runtime-v1.yaml)
+and [frozen result](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/results/consumer-runtime-v1.json).
 
 ## RecoveryBench: do fresh on-policy states justify their cost?
 
@@ -246,7 +246,7 @@ All three seeds and all completed negative results are retained.
 | strict fresh-state OPD | 10.9% | 9.1% | 686.8 s |
 | budget-50 fresh-state OPD | 27.3% | 20.7% | 720.8 s |
 
-![RecoveryBench three-seed result](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.0/docs/recoverybench/recovery-success.svg)
+![RecoveryBench three-seed result](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/recoverybench/recovery-success.svg)
 
 The equal-selected-position view reached the 6,224-position boundary after
 eight updates for every core method, so its quality result matches the primary
@@ -256,9 +256,9 @@ did not reduce wall time because teacher backbone forwards were unchanged. The
 evidence**: SFT and frozen KD completed their eight-cycle ceiling, while fresh
 OPD crossed the target in one indivisible 88-121 second update.
 
-Read the [full analysis](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/recoverybench/recoverybench-v1.md), the
-[data-bound technical report](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/paper/recoverybench-v1/recoverybench-v1.pdf), or
-the [immutable schema-v3 artifacts](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/benchmarks/README.md#recoverybench-v1).
+Read the [full analysis](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md), the
+[data-bound technical report](https://github.com/DaoyuanLi2816/mini-verl/blob/main/paper/recoverybench-v1/recoverybench-v1.pdf), or
+the [immutable schema-v3 artifacts](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/README.md#recoverybench-v1).
 The result is scoped to one Qwen3 pair, one task family, three seeds and one RTX
 4080. It does not show that OPD is universally ineffective or that offline KD
 always wins.
@@ -272,18 +272,18 @@ time. Two protocol-naive controls completed normally at 0%; they were not
 configuration failures. Both used the ambiguous historical protocol-v1 prompt,
 so the failure cannot be attributed solely to intrinsic teacher behavior.
 
-![Two-seed protocol-teacher benchmark](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.0/docs/gpu-calc-hard-equal-update-v2.svg)
+![Two-seed protocol-teacher benchmark](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/gpu-calc-hard-equal-update-v2.svg)
 
 | Artifact | Role |
 | --- | --- |
-| [Default recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/recipes/qwen_consumer_gpu_calc.yaml) | protocol-qualified default |
-| [Schema-v2 benchmark](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/benchmarks/results/gpu-calc-hard-equal-update-v2.json) | frozen five-arm result |
-| [Raw-teacher recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/recipes/qwen_consumer_gpu_calc_raw_teacher.yaml) | historical control; not default |
+| [Default recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/main/recipes/qwen_consumer_gpu_calc.yaml) | protocol-qualified default |
+| [Schema-v2 benchmark](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/results/gpu-calc-hard-equal-update-v2.json) | frozen five-arm result |
+| [Raw-teacher recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/main/recipes/qwen_consumer_gpu_calc_raw_teacher.yaml) | historical control; not default |
 
 The teacher gate and downstream comparison reused the same 24-task v0.2 test
 set, so this is evidence for qualification in that setup, not a general OPD
 advantage. The separate schema-v1 481-second smoke proves the pipeline, not OPD
-over SFT. [Full diagnosis and caveats](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/rtx4080-baselines.md).
+over SFT. [Full diagnosis and caveats](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/rtx4080-baselines.md).
 
 </details>
 
@@ -360,7 +360,7 @@ bf16, while older CUDA cards such as Titan V use fp16. RTX 3070, Titan V,
 RTX 4080 and RTX 5090-class cards all enter the same code path; only the
 RTX 4080 result is measured here. Exact fit is governed by VRAM, model sizes,
 drivers and token budgets, not the card's marketing name. See the
-[`single-GPU guide`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/single-gpu-guide.md) before changing the recipe.
+[`single-GPU guide`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) before changing the recipe.
 
 ```bash
 git clone https://github.com/DaoyuanLi2816/mini-verl.git
@@ -417,7 +417,7 @@ Layer boundaries are strict, and the first layer never imports torch:
 6. `evaluation/`, `reporting/` — measurement.
 7. `cli.py` — a thin shell that calls one library function per command.
 
-See [`docs/design.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/design.md).
+See [`docs/design.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/design.md).
 
 ## Exact versus top-k + tail
 
@@ -447,7 +447,7 @@ the teacher still runs a full forward pass to produce the hidden states. Reports
 therefore say `teacher_queried_position_ratio`, never "teacher compute saved".
 
 Top-k + tail targets are not a new idea — TRL's `ServerDistillationTrainer` has
-`loss_top_k` with an optional tail bucket. See [`docs/math.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/math.md).
+`loss_top_k` with an optional tail bucket. See [`docs/math.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/math.md).
 
 ## Tool-token masking
 
@@ -472,10 +472,10 @@ documented — see `tests/unit/test_token_provenance.py`.
 ## Benchmark results
 
 Every number below was produced by the commands in
-[`docs/benchmarking.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/benchmarking.md) on the hardware recorded in each
+[`docs/benchmarking.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md) on the hardware recorded in each
 result file. Nothing is estimated or extrapolated.
 
-* **RTX 4080, real models** — [`docs/rtx4080-baselines.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/rtx4080-baselines.md)
+* **RTX 4080, real models** — [`docs/rtx4080-baselines.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/rtx4080-baselines.md)
   has measured peak VRAM, decode throughput, the full-recipe run, the two-seed
   schema-v2 protocol-teacher comparison, and the preserved legacy comparison.
 * **CPU, toy models** — `recipes/toy_cpu.yaml` moves task success from 0.0% to
@@ -483,7 +483,7 @@ result file. Nothing is estimated or extrapolated.
   run.
   The parity run's accuracy differences are **within noise**; it exists to show
   that all seven arms run to completion under identical budgets, not to rank
-  them. See [`benchmarks/README.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/benchmarks/README.md) for why the toy
+  them. See [`benchmarks/README.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/README.md) for why the toy
   backend cannot rank methods.
 
 ## Installation
@@ -588,11 +588,11 @@ distribution before handing it over, and asserts that the result still trains.
 
 For a standard frozen PEFT teacher adapter, including the Qwen3 protocol-SFT
 recipe, export command, compatibility checks and policy-competence gate, see
-[`docs/teacher-adapters.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/teacher-adapters.md).
+[`docs/teacher-adapters.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/teacher-adapters.md).
 
 ## Limitations
 
-The short version; the full list is in [`docs/limitations.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/limitations.md).
+The short version; the full list is in [`docs/limitations.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md).
 
 * Same tokenizer only. Cross-tokenizer distillation is rejected with an error.
 * Rollout decoding is one sequence at a time. The update path supports padded
@@ -637,8 +637,8 @@ still retain the local state required for exact resume. Redaction is a
 best-effort sharing defense, not permission to place real credentials in any
 config, run artifact or report.
 
-See [`docs/reproducibility.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/reproducibility.md) and the concise
-[`compatibility policy`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/compatibility.md).
+See [`docs/reproducibility.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/reproducibility.md) and the concise
+[`compatibility policy`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md).
 
 ## Roadmap
 
@@ -661,7 +661,7 @@ exists for the case where you have one personal GPU and want to read every line
 of what is happening, then hand standard artifacts to verl for scale-out. That
 can be an older 12 GiB card or a current high-end card; the repository claims
 measured performance only for hardware it actually ran. See
-[`docs/comparisons.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/docs/comparisons.md).
+[`docs/comparisons.md`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/comparisons.md).
 
 ## Citation
 
@@ -675,13 +675,13 @@ measured performance only for hardware it actually ran. See
 }
 ```
 
-See [CITATION.cff](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/CITATION.cff) and [CHANGELOG.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/CHANGELOG.md).
-Contributions: [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/CONTRIBUTING.md). Security:
-[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/SECURITY.md).
+See [CITATION.cff](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff) and [CHANGELOG.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md).
+Contributions: [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md). Security:
+[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md).
 
 ## License
 
-Apache-2.0. See [LICENSE](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/LICENSE) and
-[THIRD_PARTY_NOTICES.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/THIRD_PARTY_NOTICES.md).
+Apache-2.0. See [LICENSE](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE) and
+[THIRD_PARTY_NOTICES.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/THIRD_PARTY_NOTICES.md).
 
-Chinese translation: [README.zh-CN.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.0/README.zh-CN.md).
+Chinese translation: [README.zh-CN.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/README.zh-CN.md).

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "release": "0.6.0",
-  "status": "validated",
+  "status": "released",
   "measured_commit": "0d43310cca47db828b10a0e12facb33e8f0fd371",
   "measured_at": "2026-08-03T00:42:52-07:00",
   "cpu_non_gpu_non_network": {

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -48,6 +48,22 @@ after the exact release commit and its remote checks are green.
 - [x] Release metadata declares exact `0.6.0`; the intended annotated tag is
       exactly `v0.6.0` and will use the existing OIDC-only release workflow.
 
+## After the tag
+
+- [x] Annotated tag `v0.6.0` resolves to exact release commit
+      `6cfbdbb7bbf5c6042def4cf154bfe3c3b6530eea`; OIDC publication, public
+      hashes/attestations, clean install and one GitHub Release were verified by
+      tag run [`30796058250`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30796058250).
+- [x] This post-release state-sync change advances development to
+      `0.6.1.dev0`; it merges only after remote checks are green.
+
+Published artifact identity:
+
+- `miniverl-0.6.0-py3-none-any.whl`: SHA-256
+  `e5fbb99bf410c27d22d6959f9599dfa4fbac2e940dac63f55c9676f68264abd1`
+- `miniverl-0.6.0.tar.gz`: SHA-256
+  `2e1d85556875f6d23152220897ba919d8b82bda35c5c78fd48efffa7ec22909d`
+
 ## v0.5.0 One-GPU Alignment Lab release
 
 - [x] Public preregistration revision 1.4 freezes three seeds, the common SFT

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.6.0"
+__version__ = "0.6.1.dev0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

- record the completed v0.6.0 annotated-tag/OIDC/PyPI/GitHub Release evidence
- advance development to `0.6.1.dev0`
- mark the v0.6 quality record released and regenerate `PYPI.md` against `main`

## Public release verification

- tag `v0.6.0` -> `6cfbdbb7bbf5c6042def4cf154bfe3c3b6530eea`
- release workflow: https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30796058250
- wheel SHA-256: `e5fbb99bf410c27d22d6959f9599dfa4fbac2e940dac63f55c9676f68264abd1`
- sdist SHA-256: `2e1d85556875f6d23152220897ba919d8b82bda35c5c78fd48efffa7ec22909d`
- PyPI provenance exposes one Trusted Publisher attestation bundle per distribution
- a clean Windows Python 3.10 install from `https://pypi.org/simple` reports `miniverl 0.6.0`; core `doctor --json` passes with torch absent

## Validation

- Ruff check and format check
- mypy: 103 source files
- Markdown/link and generated PyPI checks
- full non-GPU/non-network suite: 1548 passed, 6 deselected, 85.53% branch coverage
- packaging/release focused suite: 111 passed
- wheel and sdist build; Twine check
- frozen calculator JSON remains SHA-256 `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`