### PR TITLE
Serialize the Pages deploy job across refs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -88,6 +88,12 @@ jobs:
   deploy:
     name: deploy versioned documentation
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    # The workflow-level group keys on `github.ref`, so a release tag push and the `main` push that accompanies it
+    # land in different groups and run at the same time. Both then claim the single `github-pages` environment and
+    # one of them fails. Serialize just the deploy job across every ref so the builds still run in parallel.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
The `deploy versioned documentation` job failed on the `v0.6.1` tag push ([run 30857762945](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30857762945)), while the `main` build for the same release succeeded.

Cause: the workflow-level concurrency group is `docs-${{ github.ref }}`. A release produces two pushes with different refs — `refs/heads/main` and `refs/tags/v0.6.1` — so they land in separate groups and run at the same time. Both then try to claim the single `github-pages` environment, and one deployment loses. The deployment record confirms it: `github-pages` for ref `v0.6.1` is `failure`, and the later `main` deployment is `success`, which is why the site itself is fine.

This adds a job-level `concurrency: pages` to the deploy job only, so deployments serialize across every ref while the build and visual-gate jobs keep running in parallel per ref. Without it the race repeats on every tagged release.

Verified `.github/workflows/docs.yml` still parses as YAML. The real check is the workflow run on this PR.
