### PR TITLE
Start v0.6.3 development and record the v0.6.2 release evidence

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -6,7 +6,7 @@ and what it printed.
 
 Last updated: 2026-08-04.
 
-## v0.6.2 Bridge correctness and responsive visual hardening (in progress)
+## v0.6.2 Bridge correctness and responsive visual hardening
 
 ### Starting state — 2026-08-04
 
@@ -78,8 +78,16 @@ stem-specific naming, collision refusal, `--overwrite`, fault injection and conc
 | docs | [`30975138352`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30975138352) green; 20 Linux screenshots uploaded as `docs-visual-screenshots` |
 | pinned verl bridge | [`30975138353`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30975138353) green |
 | screenshot inspection | the CI Linux screenshots were downloaded and read directly, not only trusted as green. The 390 px Alignment Lab mobile chart and metric-coverage cards render the same as the local Windows capture |
-| release metadata | publication was explicitly authorized, so the version is finalized to `0.6.2`, `CHANGELOG.md` carries a dated `[0.6.2] - 2026-08-05` section with its compare link, `CITATION.cff` records `0.6.2` / `2026-08-05`, `PYPI.md` is regenerated tag-pinned to `blob/v0.6.2`, and `docs/generated/quality.json` records release `0.6.2`, status `validated`, 1652 CPU tests at 85.77% branch coverage, 5 GPU and 3 network |
-| local release build | `python -m build` and `twine check` pass at `0.6.2`. These local artifacts are a sanity check only; the published distributions are built once inside the tag workflow |
+| release metadata | the version was finalized to `0.6.2`, `CHANGELOG.md` carries a dated `[0.6.2] - 2026-08-05` section with its compare link, `CITATION.cff` records `0.6.2` / `2026-08-05`, `PYPI.md` is regenerated tag-pinned to `blob/v0.6.2`, and `docs/generated/quality.json` records release `0.6.2` at 1652 CPU tests, 85.77% branch coverage, 5 GPU and 3 network |
+| local release build | `python -m build` and `twine check` pass at `0.6.2`. These local artifacts were a sanity check only; the published distributions are built once inside the tag workflow |
+| merge | PR [#43](https://github.com/DaoyuanLi2816/mini-verl/pull/43) was squash-merged; the release commit is `bef9f0878eb3280f450aee3868b43d61f0726557` after its message was rewritten so the sole contributor is the repository owner. Synchronized-main CI, build and docs runs [`30980343307`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30980343307) / [`30980343344`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30980343344) / [`30980343293`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30980343293) are green on that exact commit |
+| tag | annotated `v0.6.2` resolves to `bef9f0878eb3280f450aee3868b43d61f0726557` |
+| release execution | tag run [`30980579109`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30980579109) passed metadata validation, the full quality gate, a one-time build, OIDC Trusted Publishing with attestations, public PyPI verification, exact install and GitHub Release creation |
+| published wheel | [`miniverl-0.6.2-py3-none-any.whl`](https://pypi.org/project/miniverl/0.6.2/), SHA-256 `38131c3de838b480017b2f97df3e43d53e760f272c516522a470d2812f8a3803`, 330906 bytes |
+| published sdist | [`miniverl-0.6.2.tar.gz`](https://pypi.org/project/miniverl/0.6.2/), SHA-256 `bcd30863290c9c46c1e2c27c59d8ccfd3ec7e5934243f5bc86f7424d4f05333d`, 994642 bytes |
+| independent public verification | the PyPI JSON API reports version `0.6.2` with a Markdown description pinned to `blob/v0.6.2`, and the integrity API exposes one Trusted Publisher attestation per distribution bound to `DaoyuanLi2816/mini-verl`, `release.yml`, environment `pypi`. The [GitHub Release](https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.6.2) ships byte-identical distributions whose recomputed SHA-256 values match its `SHA256SUMS` and PyPI exactly. A clean Windows venv installed `miniverl==0.6.2` from `https://pypi.org/simple`, reported `miniverl 0.6.2` with torch absent, and exposes `--require-tokenizer-load`, `--scan-dataset-text` and `--sentinel` |
+| version transition | `v0.6.2` is immutable and public; this state sync identifies subsequent development as `0.6.3.dev0` |
+| release state | complete |
 
 ### Known limitation carried forward
 

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.2/docs/banner.svg" alt="miniVERL — single-GPU LLM post-training" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — single-GPU LLM post-training" width="880">
 </p>
 
 <div align="center">
@@ -8,7 +8,7 @@
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE)
 
 </div>
 
@@ -16,7 +16,7 @@
   <a href="https://pypi.org/project/miniverl/"><strong>PyPI</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/"><strong>Stable docs</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/dev/">Development docs</a> ·
-  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/README.zh-CN.md">中文</a>
+  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/main/README.zh-CN.md">中文</a>
 </p>
 
 **miniVERL is a local, inspectable runtime for a documented subset of
@@ -44,15 +44,15 @@ optimization in about 50 seconds on the measured laptop CPU. For inspection,
 schemas and reports without the ML stack, use `pip install miniverl`. For CUDA
 training, install the matching CUDA-enabled PyTorch wheel first, then install
 `miniverl[train,cuda]`; the extra does not select a CUDA PyTorch build. See the
-[single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/docs/single-gpu-guide.md).
+[single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md).
 
 ## Three paths
 
 | Path | Start with | Concrete artifact | Next |
 | --- | --- | --- | --- |
-| **Align** — compare SFT, DPO, KD and OPD only when the pilot evidence supports the cost | `miniverl pilot recipes/alignment_policy_conditioned_qwen.yaml` | `alignment-card.json` | [Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/docs/alignment-lab/alignment-lab-v1.md) |
-| **Distill locally** — strict OPD, shared backbones and padded trajectory updates on one CUDA GPU | `miniverl train recipes/qwen_consumer_gpu_shared.yaml --dry-run` | `config.resolved.yaml` plus a revision-pinned PEFT adapter | [Bring your own GPU](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/docs/single-gpu-guide.md) |
-| **Scale out** — import a documented profile, convert Parquet, export a bundle and run bridge checks | `miniverl bridge doctor scaleout-bundle` | `provenance/compatibility-report.json` | [Verified verl artifact bridge](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/docs/verl-bridge.md) |
+| **Align** — compare SFT, DPO, KD and OPD only when the pilot evidence supports the cost | `miniverl pilot recipes/alignment_policy_conditioned_qwen.yaml` | `alignment-card.json` | [Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md) |
+| **Distill locally** — strict OPD, shared backbones and padded trajectory updates on one CUDA GPU | `miniverl train recipes/qwen_consumer_gpu_shared.yaml --dry-run` | `config.resolved.yaml` plus a revision-pinned PEFT adapter | [Bring your own GPU](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) |
+| **Scale out** — import a documented profile, convert Parquet, export a bundle and run bridge checks | `miniverl bridge doctor scaleout-bundle` | `provenance/compatibility-report.json` | [Verified verl artifact bridge](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md) |
 
 The bridge is a **verified artifact bridge**: a pinned config/data/model
 parse-load smoke at miniVERL-defined compatibility Level 3. It has never run a
@@ -81,12 +81,12 @@ improved it; continued SFT and both OPD variants retained measured regressions.
 | standard OPD | 98.6% | 97.2% | 100.0% | 76.7 s |
 | verifier-gated OPD | 97.9% | 95.8% | 46.8% | 66.0 s |
 
-![Alignment and utility deltas from the saturated SFT checkpoint; small marks are all three seeds and large marks are means](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.2/docs/alignment-lab/delta-from-sft.svg)
+![Alignment and utility deltas from the saturated SFT checkpoint; small marks are all three seeds and large marks are means](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/alignment-lab/delta-from-sft.svg)
 
 The two sandbox safety checks tied at zero while utility still regressed.
 IFEval, XSTest, HarmBench and RewardBench were **not executed**. “Preference
 win rate” is a deterministic Minipolicy paired outcome, not human preference.
-Read the [study, seed-level values and limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/docs/alignment-lab/alignment-lab-v1.md).
+Read the [study, seed-level values and limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md).
 
 ## One measured systems result
 
@@ -97,13 +97,13 @@ reserved memory versus 3.035 GiB for dual model, while running 10.1% slower.
 All 12 preregistered equivalence comparisons passed. These are one-workload,
 one-machine measurements, not promises for other GPUs.
 
-![Measured throughput and reserved VRAM for dual-model and shared-backbone runtime cells](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.2/docs/consumer-runtime-v1-pareto.svg)
+![Measured throughput and reserved VRAM for dual-model and shared-backbone runtime cells](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/consumer-runtime-v1-pareto.svg)
 
-[Consumer Runtime v1 methods and caveats](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/docs/consumer-runtime-v1.md)
+[Consumer Runtime v1 methods and caveats](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/consumer-runtime-v1.md)
 
 ## Compatibility boundary
 
-![Verified local runtime, portable artifact bundle and pinned upstream smoke; distributed verl execution remains untested](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.2/docs/verl-bridge-architecture.svg)
+![Verified local runtime, portable artifact bundle and pinned upstream smoke; distributed verl execution remains untested](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-bridge-architecture.svg)
 
 The bridge targets official verl `v0.8.0` at commit `7aed6b23` and uses the
 term **miniVERL-defined compatibility Level 3**. That means a checksummed
@@ -120,21 +120,21 @@ PPO/reward scaffold, not an executable continuation of miniVERL OPD semantics.
 
 ## Detailed studies and preserved negative evidence
 
-- [RecoveryBench v1](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/docs/recoverybench/recoverybench-v1.md): frozen-student KD
+- [RecoveryBench v1](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md): frozen-student KD
   outperformed much slower fresh-state OPD on the preregistered primary view;
   the verifier gate remained `insufficient_evidence`.
-- [Alignment Lab v1](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/docs/alignment-lab/alignment-lab-v1.md): the starting SFT
+- [Alignment Lab v1](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md): the starting SFT
   checkpoint was at the ceiling, so no positive OPD result is claimed.
-- [Calculator benchmark](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/docs/benchmarking.md): both negative controls completed
+- [Calculator benchmark](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md): both negative controls completed
   normally and measured 0% strict success. They were not configuration
   failures. Because they used the historical ambiguous protocol-v1 prompt,
   their failure cannot be attributed solely to intrinsic teacher behavior.
-- [Consumer Runtime v1](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/docs/consumer-runtime-v1.md): padded update batches and
+- [Consumer Runtime v1](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/consumer-runtime-v1.md): padded update batches and
   shared adapters preserve the measured one-update objective within declared
   tolerances; rollout generation remains sequential.
-- [Limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/docs/limitations.md), [math](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/docs/math.md),
-  [reproducibility](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/docs/reproducibility.md) and
-  [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/docs/compatibility.md).
+- [Limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md), [math](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/math.md),
+  [reproducibility](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/reproducibility.md) and
+  [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md).
 
 New runs establish tokenizer compatibility through structural identity. The
 legacy behavioral fingerprint—token IDs for one fixed probe plus metadata—is
@@ -154,7 +154,7 @@ python -m pip install -e ".[dev]"
 pytest -q -m "not gpu and not network"
 ```
 
-Apache-2.0 licensed. See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/CONTRIBUTING.md) and
-[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/SECURITY.md). Project records: [default GPU recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/recipes/qwen_consumer_gpu_calc.yaml),
-[frozen calculator JSON](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/benchmarks/results/gpu-calc-hard-equal-update-v2.json),
-[changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/CHANGELOG.md), [citation](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/CITATION.cff) and [license](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.2/LICENSE).
+Apache-2.0 licensed. See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md) and
+[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md). Project records: [default GPU recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/main/recipes/qwen_consumer_gpu_calc.yaml),
+[frozen calculator JSON](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/results/gpu-calc-hard-equal-update-v2.json),
+[changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md), [citation](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff) and [license](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE).

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "release": "0.6.2",
-  "status": "validated",
+  "status": "released",
   "measured_commit": "58f7018c9e28bc0460856911539cfdf376354d7b",
   "measured_at": "2026-08-04T22:44:33-07:00",
   "cpu_non_gpu_non_network": {

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.6.2"
+__version__ = "0.6.3.dev0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
`v0.6.2` is immutable and public. This state sync advances main to `0.6.3.dev0`
and records the published evidence.

## Version transition

- `__version__` becomes `0.6.3.dev0`.
- `PYPI.md` is regenerated, so its project links return to `blob/main` until the
  next tag pins them again.
- `docs/generated/quality.json` moves from `validated` to `released` at 1652 CPU
  tests and 85.77% branch coverage.

## Recorded release evidence

| item | value |
| --- | --- |
| release commit | `bef9f0878eb3280f450aee3868b43d61f0726557` |
| synchronized main | [ci](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30980343307), [build](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30980343344) and [docs](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30980343293) are green on that exact commit |
| tag | annotated `v0.6.2` resolves to `bef9f087` |
| release run | [`30980579109`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/30980579109) |
| wheel | `miniverl-0.6.2-py3-none-any.whl`, SHA-256 `38131c3de838b480017b2f97df3e43d53e760f272c516522a470d2812f8a3803` |
| sdist | `miniverl-0.6.2.tar.gz`, SHA-256 `bcd30863290c9c46c1e2c27c59d8ccfd3ec7e5934243f5bc86f7424d4f05333d` |
| PyPI | https://pypi.org/project/miniverl/0.6.2/ |
| GitHub Release | https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.6.2 |

Independent verification: the PyPI integrity API exposes one Trusted Publisher
attestation per distribution bound to `DaoyuanLi2816/mini-verl`, `release.yml`
and environment `pypi`; the GitHub Release assets recompute to exactly the
hashes PyPI publishes; and a clean virtual environment installed
`miniverl==0.6.2` from `https://pypi.org/simple`, reported `miniverl 0.6.2` with
torch absent, and exposes `--require-tokenizer-load`, `--scan-dataset-text` and
`--sentinel`.

No frozen scientific artifact changed, and no new runtime claim is added.
