### PR TITLE
Close the v0.6.3 reward-verifier, trust-boundary, sidecar and streaming gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
           python scripts/build_pypi_readme.py --check
           python scripts/release_state.py --check
           python scripts/check_markdown_links.py
+          python scripts/check_text_integrity.py
           miniverl --help
           miniverl --version
           miniverl doctor --json > doctor.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,47 @@ All notable changes to miniVERL are recorded here. The format follows
   they asked for a diagnosis, while the report described the result as a
   "side-effect-free import". The scaffold is now parsed with `ast.parse` and
   verified statically, reporting `not_present`, `syntax_valid`,
-  `interface_shape_verified` or `trusted_dynamic_import_verified`. Top-level
-  calls, non-literal assignments, decorators, class-body statements and
-  call-valued default arguments are rejected because each runs at import time.
+  `interface_shape_verified` or `trusted_dynamic_import_verified`. Every
+  definition-time position is audited, not only top-level statements: class
+  bases, `metaclass=` and other class keywords, parameter and return
+  annotations, annotated-assignment annotations, type-parameter bounds,
+  decorators and call-valued defaults all run when a module is imported, so
+  `class Hidden(exploit())` is rejected rather than reported as verified.
+  Keyword-only parameters are checked too, so a required keyword-only
+  `extra_info` — which raises `TypeError` on verl's three-argument call — no
+  longer passes. Source bytes, AST nodes, AST depth and finding count are
+  bounded, imports are listed with `import_runtime_safety: not_verified`, and
+  relative bundle-local imports are refused.
+- `bridge doctor` separates what a bundle *says* from what this process
+  *recomputed*. `SHA256SUMS` ships inside the bundle it describes, so anyone who
+  edits a claim can reseal it; matching hashes prove internal consistency only.
+  Bundle testimony now appears under `bundle_declared_claims` with a
+  `provenance_trust` level of `unsigned_self_consistent`, the top-level flags
+  reflect only locally recomputed results, and `--require-verl` performs the
+  upstream OmegaConf parse and structured merge locally instead of comparing an
+  installed commit id.
+- Portable metadata privacy ran one absolute-path regex, so a manifest holding
+  an API key, a bearer token or a database URL with inline credentials passed.
+  Structured JSON/YAML is now walked so a finding can name a JSON path,
+  unstructured text reports a line number, the scan is bounded by file size,
+  total bytes and finding count, and matched text is still never reported. The
+  status is named `heuristic_passed`/`heuristic_failed` because it is a
+  detector, not de-identification proof.
+- An extension sidecar that exists but does not validate now fails the
+  conversion instead of being treated as absent. Schema version, exact
+  namespace, a `rows` mapping, canonical integer keys within the source row
+  count, JSON-compatible values, unknown top-level fields and optional
+  `source_sha256`/`source_rows` binding are all checked; sidecars published by
+  0.6.0–0.6.2 still read.
+- `convert-dataset` streams record batches through a `ParquetWriter` instead of
+  calling `read_table(...).to_pylist()`, which materialized the entire dataset
+  before converting a row. The output schema is derived once from the source
+  schema, so an optional nested field that appears only in a later row group
+  cannot produce a second incompatible schema. Strict conversion remains
+  complete-or-nothing and now stops before reading the next row group.
+- `scripts/check_text_integrity.py` fails CI on GBK-mangled UTF-8 punctuation,
+  U+FFFD and unintended byte-order marks. The release checklist's `— not
+  applicable` and the changelog's `base → SFT` arrows are repaired.
 - Added `miniverl bridge doctor --trust-and-import-reward-code` for bundles you
   produced yourself. It warns before executing anything, reports
   `untrusted_code_executed: true`, and does not claim to be a sandbox.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Changelog
+# Changelog
 
 All notable changes to miniVERL are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses
@@ -203,7 +203,8 @@ All notable changes to miniVERL are recorded here. The format follows
 
 ### Added
 
-- `miniverl align` for explicit base 鈫?SFT checkpoint 鈫?teacher/reference 鈫?  alignment 鈫?evaluation 鈫?Alignment Card workflows, plus an
+- `miniverl align` for explicit base → SFT checkpoint → teacher/reference →
+  alignment → evaluation → Alignment Card workflows, plus an
   uncertainty-aware, versioned `miniverl pilot` decision aid.
 - Policy-conditioned and frozen aligned-adapter teachers, pinned TRL DPO
   provenance, a versioned verifier-gated selector, deterministic tool-policy
@@ -442,7 +443,7 @@ Single-GPU portability and presentation release.
 ### Added
 
 - A hardware-portability guide for personal NVIDIA GPUs, including honest
-  starting points for 8鈥?2 GiB, 16鈥?4 GiB and 24鈥?2+ GiB cards, OOM controls,
+  starting points for 8–12 GiB, 16–24 GiB and 24–32+ GiB cards, OOM controls,
   and a reproducible hardware-result contribution path.
 - A prominent PyPI destination in both READMEs and package metadata.
 - Visual regression assertions that keep benchmark grid lines below axis labels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+﻿# Changelog
 
 All notable changes to miniVERL are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses
@@ -16,7 +16,7 @@ All notable changes to miniVERL are recorded here. The format follows
   they asked for a diagnosis, while the report described the result as a
   "side-effect-free import". The scaffold is now parsed with `ast.parse` and
   verified statically, reporting `not_present`, `syntax_valid`,
-  `interface_statically_verified` or `trusted_dynamic_import_verified`. Top-level
+  `interface_shape_verified` or `trusted_dynamic_import_verified`. Top-level
   calls, non-literal assignments, decorators, class-body statements and
   call-valued default arguments are rejected because each runs at import time.
 - Added `miniverl bridge doctor --trust-and-import-reward-code` for bundles you
@@ -203,14 +203,13 @@ All notable changes to miniVERL are recorded here. The format follows
 
 ### Added
 
-- `miniverl align` for explicit base → SFT checkpoint → teacher/reference →
-  alignment → evaluation → Alignment Card workflows, plus an
+- `miniverl align` for explicit base 鈫?SFT checkpoint 鈫?teacher/reference 鈫?  alignment 鈫?evaluation 鈫?Alignment Card workflows, plus an
   uncertainty-aware, versioned `miniverl pilot` decision aid.
 - Policy-conditioned and frozen aligned-adapter teachers, pinned TRL DPO
   provenance, a versioned verifier-gated selector, deterministic tool-policy
   evaluation and privacy-safe JSON/Markdown Alignment Cards.
 - A preregistered three-seed Alignment Lab result, 864 task-level records, a
-  matched State × Supervision diagnostic, four data-bound figures, technical
+  matched State 脳 Supervision diagnostic, four data-bound figures, technical
   report, article and reproducible short demo.
 
 ### Changed
@@ -256,7 +255,7 @@ All notable changes to miniVERL are recorded here. The format follows
 
 ### Results
 
-- Batch-4 improved end-to-end throughput by 1.63× for dual ownership and 1.54×
+- Batch-4 improved end-to-end throughput by 1.63脳 for dual ownership and 1.54脳
   for shared ownership on the declared Qwen3-0.6B workload. Shared batch-4 used
   2.227 GiB peak reserved memory versus 3.035 GiB for dual, but was 10.1% slower.
 - Identical trajectory and teacher-target digests held across all eight cells;
@@ -443,7 +442,7 @@ Single-GPU portability and presentation release.
 ### Added
 
 - A hardware-portability guide for personal NVIDIA GPUs, including honest
-  starting points for 8–12 GiB, 16–24 GiB and 24–32+ GiB cards, OOM controls,
+  starting points for 8鈥?2 GiB, 16鈥?4 GiB and 24鈥?2+ GiB cards, OOM controls,
   and a reproducible hardware-result contribution path.
 - A prominent PyPI destination in both READMEs and package metadata.
 - Visual regression assertions that keep benchmark grid lines below axis labels

--- a/PYPI.md
+++ b/PYPI.md
@@ -70,9 +70,14 @@ with in-process rollback, not multi-file crash atomicity.
 
 An exported bundle is untrusted input. `bridge doctor` inspects its reward
 scaffold statically with `ast.parse` and **never executes it** unless you pass
-`--trust-and-import-reward-code`; adapter weights are validated past the
-header; and tokenizer, safetensors and privacy results each report how far
-verification actually got rather than a single pass or fail.
+`--trust-and-import-reward-code` — class bases, `metaclass=`, annotations and
+type-parameter bounds are audited too, because all of them run at import.
+Adapter weights are validated past the header, a malformed extension sidecar
+fails the conversion instead of being read as empty, and dataset conversion
+streams row groups rather than materializing the table. What a bundle *claims*
+is reported separately from what was *recomputed* locally: its own `SHA256SUMS`
+can only prove internal consistency. Tokenizer, safetensors and privacy results
+each report how far verification actually got rather than a single pass or fail.
 
 ## One measured alignment result
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,14 @@ with in-process rollback, not multi-file crash atomicity.
 
 An exported bundle is untrusted input. `bridge doctor` inspects its reward
 scaffold statically with `ast.parse` and **never executes it** unless you pass
-`--trust-and-import-reward-code`; adapter weights are validated past the
-header; and tokenizer, safetensors and privacy results each report how far
-verification actually got rather than a single pass or fail.
+`--trust-and-import-reward-code` — class bases, `metaclass=`, annotations and
+type-parameter bounds are audited too, because all of them run at import.
+Adapter weights are validated past the header, a malformed extension sidecar
+fails the conversion instead of being read as empty, and dataset conversion
+streams row groups rather than materializing the table. What a bundle *claims*
+is reported separately from what was *recomputed* locally: its own `SHA256SUMS`
+can only prove internal consistency. Tokenizer, safetensors and privacy results
+each report how far verification actually got rather than a single pass or fail.
 
 ## One measured alignment result
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -65,9 +65,13 @@ calculator 环境，也不会创建身份不明确的同基座教师。未解析
 
 导出的 bundle 属于不可信输入。`bridge doctor` 用 `ast.parse` 静态检查其
 reward scaffold，**默认绝不执行它**，除非显式传入
-`--trust-and-import-reward-code`；adapter 权重的校验会越过文件头验证实际
-载荷；tokenizer、safetensors 与隐私三项各自报告验证真正到达的层级，而不是
-笼统的通过或失败。
+`--trust-and-import-reward-code`；基类、`metaclass=`、类型注解与类型参数
+边界同样会被审查，因为它们都在 import 时求值。adapter 权重的校验会越过
+文件头验证实际载荷；格式非法的 extension sidecar 会让转换失败，而不是被
+当成空文件读过去；数据集转换按 row group 流式处理，不再整表物化。bundle
+自己**声称**的内容与本地**实际重算**的结果分开报告：它自带的 `SHA256SUMS`
+只能证明内部一致性。tokenizer、safetensors 与隐私三项各自报告验证真正
+到达的层级，而不是笼统的通过或失败。
 
 ## 一项对齐实测结果
 

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -2,14 +2,14 @@
   "schema_version": 1,
   "release": "0.6.3",
   "status": "validated",
-  "measured_commit": "1d2b43fbb93deac5d64b4f40b8ea6121f2f67ed0",
-  "measured_at": "2026-08-05T15:40:00-07:00",
+  "measured_commit": "e8a36db60b2146b684204df8a8bea3e20c11d8e4",
+  "measured_at": "2026-08-05T18:20:00-07:00",
   "platform": "Windows 11 Pro 10.0.22631, CPython 3.12, coverage branch mode",
   "cpu_non_gpu_non_network": {
-    "passed": 1763,
+    "passed": 1830,
     "skipped": 2,
     "deselected": 6,
-    "branch_coverage_percent": 86.02,
+    "branch_coverage_percent": 86.10,
     "skip_reason": "symlink creation requires privileges on Windows; hard-link and case aliases cover the same guard"
   },
   "gpu": {

--- a/docs/recoverybench/recoverybench-v1.md
+++ b/docs/recoverybench/recoverybench-v1.md
@@ -1,4 +1,4 @@
-﻿# RecoveryBench v1
+# RecoveryBench v1
 
 RecoveryBench asks a narrow mechanism question: when the starting checkpoint,
 teacher, task schedule, optimizer and update count are controlled, does scoring

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,4 +1,4 @@
-﻿# Release checklist
+# Release checklist
 
 This is the release gate and publication record for miniVERL. A checked item
 names an invariant exercised on the stated source. Publication begins only
@@ -43,7 +43,7 @@ after the exact release commit and its remote checks are green.
 - [x] Alignment Lab publication is generated as one diverging forest chart and
       two row matrices: every arm exposes all three frozen seeds and its mean,
       quantitative marks remain in-domain, and non-teacher query ratios remain
-      `鈥?not applicable` rather than being coerced to zero.
+      `— not applicable` rather than being coerced to zero.
 - [x] The scoped safety figure states that both sandbox checks tied at zero
       while utility regressed, records the external endpoints as not run, and
       does not imply a broad safety benchmark.

--- a/docs/verl-bridge.md
+++ b/docs/verl-bridge.md
@@ -224,15 +224,44 @@ merely by being diagnosed:
 | --- | --- |
 | `not_present` | No scaffold file, or it is unreadable. |
 | `syntax_valid` | It parses as Python, but the interface check failed. |
-| `interface_statically_verified` | A top-level `compute_score(data_source, solution_str, ground_truth, extra_info=None)` exists, is synchronous, is undecorated, is not bound by assignment, and the module contains no top-level executable statement. |
+| `interface_shape_verified` | A top-level `compute_score(data_source, solution_str, ground_truth, extra_info=None)` exists, is synchronous, is not bound by assignment, and no definition-time expression forbidden by this policy was found. |
 | `trusted_dynamic_import_verified` | The module was actually imported. Reached only through an explicit opt-in. |
 
-The default path stops at `interface_statically_verified`. Top-level calls,
-non-literal assignments, decorators, class-body statements and call-valued
-default arguments are all rejected, because each of them runs at import time.
-Static verification proves the interface is present and that importing would
-not obviously run code; it proves nothing about whether the reward logic is
-correct or safe to run later.
+The default path stops at `interface_shape_verified`. The level is named for
+what it proves: the interface has the expected *shape*. It is not a statement
+that the file is safe to import.
+
+Importing a module runs more than its top-level statements, so the check covers
+every definition-time position:
+
+| Position | Example |
+| --- | --- |
+| Top-level statements | `exploit()`, non-literal assignments, loops |
+| Class bases | `class Hidden(exploit())` |
+| Class keywords | `class Hidden(object, metaclass=exploit())` |
+| Annotations | `def compute_score(data_source: exploit())`, `-> exploit()`, `VALUE: exploit() = 1` |
+| Type parameters | Python 3.12 bounds and defaults |
+| Decorators and defaults | `@exploit()`, `extra_info=exploit()` |
+
+Ordinary type annotations and base classes are unaffected: only expressions
+that would actually evaluate — calls, lambdas, comprehensions, `await`, walrus
+— are rejected.
+
+The signature contract is enforced including keyword-only parameters, so a
+required keyword-only `extra_info` is refused: verl calls `compute_score` with
+three positional arguments and that signature would raise `TypeError`.
+
+Inspection is bounded — source bytes, AST node count, AST depth and the number
+of reported findings — so a hostile scaffold produces a bounded diagnostic
+rather than exhausting the process that asked for a diagnosis. Imports are
+listed under `imports_present` with `import_runtime_safety: not_verified`,
+because this check never runs them and an imported third-party module can do
+anything; a relative, bundle-local import is refused outright.
+
+What this proves is narrow: the interface is present and no forbidden
+definition-time expression exists. It proves nothing about whether the reward
+logic is correct, whether imported modules are side-effect free, or whether the
+file is safe to run later.
 
 If you produced the bundle yourself and want the historical behaviour:
 
@@ -243,6 +272,34 @@ miniverl bridge doctor exports/<bundle> --trust-and-import-reward-code
 This executes the bundle's Python in your process with your privileges. It
 prints a warning first and reports `untrusted_code_executed: true`. A
 subprocess would not be a security sandbox either, so none is claimed.
+
+### What the bundle claims versus what was recomputed
+
+`provenance/SHA256SUMS` lives inside the bundle it describes. Anyone who edits
+`compatibility-report.json` can regenerate it, so agreement between them proves
+internal consistency and nothing else. miniVERL implements no signature or
+transparency-log verification, and does not pretend otherwise.
+
+The diagnosis therefore reports three separate things:
+
+| Field | Meaning |
+| --- | --- |
+| `bundle_declared_claims` | Copied from the bundle. Events this run did not observe. |
+| `locally_recomputed_checks` | Performed in this process against the bytes on disk. |
+| `provenance_trust` | `unsigned_self_consistent` at best; `signature_verification: not_available`. |
+
+Historical smoke results, distributed execution and algorithm parity can only
+ever be *declared*: no doctor run launches a job or compares algorithms, so the
+top-level `distributed_execution_tested` and `algorithm_semantic_parity` flags
+are always `false` regardless of what a bundle asserts. Checksum consistency,
+config structure, the pinned requirement file, tokenizer load, adapter
+structure, Parquet schema, the reward interface and the metadata privacy
+heuristic are recomputed every time.
+
+`--require-verl` recomputes the upstream check rather than trusting a record of
+it: it loads the installed pinned verl's generated PPO config, parses the
+bundle's `verl-overrides.yaml` and performs the structured merge in this
+process. It still launches nothing.
 
 ### Adapter weights are validated past the header
 

--- a/scripts/check_text_integrity.py
+++ b/scripts/check_text_integrity.py
@@ -34,6 +34,16 @@ from pathlib import Path
 #: Chinese README, so this needs no per-file allowlist.
 MOJIBAKE_LEADERS = ("鈥", "鈫", "锛", "銆", "鎴", "鑰", "娴", "鏂")
 
+#: The only files allowed to contain the damaged sequences: the detector itself
+#: and its regression tests, which must spell them out to recognise them. Keep
+#: this list at exactly these two entries -- anything else is real damage.
+FIXTURE_ALLOWLIST = frozenset(
+    {
+        "scripts/check_text_integrity.py",
+        "tests/unit/test_text_integrity.py",
+    }
+)
+
 #: Suffixes worth reading as text. Frozen scientific results are included on
 #: purpose: mojibake in a published result would be a real defect. Nothing here
 #: rewrites them -- the check only reports.
@@ -92,6 +102,8 @@ def check_text_integrity(root: Path) -> list[str]:
         if path.suffix.lower() not in TEXT_SUFFIXES or not path.is_file():
             continue
         relative = path.relative_to(root).as_posix()
+        if relative in FIXTURE_ALLOWLIST:
+            continue
         try:
             raw = path.read_bytes()
         except OSError:

--- a/scripts/check_text_integrity.py
+++ b/scripts/check_text_integrity.py
@@ -1,0 +1,139 @@
+"""Fail on mojibake and unintended byte-order marks in tracked text files.
+
+`docs/release-checklist.md` shipped `鈥?not applicable` -- a UTF-8 en dash that
+was decoded as GBK and re-encoded, which is what happens when a file is written
+through a non-UTF-8 console. The bytes are valid UTF-8 afterwards, so no
+encoding error is ever raised and the damage survives review.
+
+The check is deliberately targeted rather than exhaustive. A blanket "no CJK
+outside the Chinese README" rule would fire on the Unicode fixtures in the test
+suite and on the `中文` README link, so it would be switched off within a week.
+Instead it looks for three unambiguous signals:
+
+* the leading characters this specific mis-decoding produces -- UTF-8 `—`, `→`
+  and curly quotes read as GBK all begin `鈥`, `鈫`, `锛`, `銆`;
+* U+FFFD REPLACEMENT CHARACTER, which is always damage;
+* a UTF-8 byte-order mark. Nothing here reads UTF-8-with-BOM deliberately, and
+  it breaks shebangs, YAML front matter and strict JSON parsers.
+
+This will not catch every possible encoding accident, only the class that has
+actually occurred. Widen `MOJIBAKE_LEADERS` when a new one appears.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import unicodedata
+from pathlib import Path
+
+#: Leading characters produced when UTF-8 punctuation is decoded as GBK.
+#: `鈥` is a mangled em dash, `鈫` a mangled arrow, `锛`/`銆` mangled CJK
+#: punctuation. None of these is ever written on purpose here, including in the
+#: Chinese README, so this needs no per-file allowlist.
+MOJIBAKE_LEADERS = ("鈥", "鈫", "锛", "銆", "鎴", "鑰", "娴", "鏂")
+
+#: Suffixes worth reading as text. Frozen scientific results are included on
+#: purpose: mojibake in a published result would be a real defect. Nothing here
+#: rewrites them -- the check only reports.
+TEXT_SUFFIXES = frozenset(
+    {
+        ".py",
+        ".md",
+        ".txt",
+        ".json",
+        ".yaml",
+        ".yml",
+        ".toml",
+        ".cfg",
+        ".ini",
+        ".sh",
+        ".ps1",
+        ".html",
+        ".css",
+        ".js",
+        ".svg",
+        ".cff",
+        ".jsonl",
+    }
+)
+
+_BOM = "﻿"
+_REPLACEMENT = "�"
+
+
+def _tracked_files(root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=root,
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    return [root / name for name in result.stdout.split("\0") if name]
+
+
+def _describe(text: str, index: int) -> str:
+    """Locate a suspicious character without echoing the surrounding content."""
+    line = text.count("\n", 0, index) + 1
+    character = text[index]
+    try:
+        name = unicodedata.name(character)
+    except ValueError:
+        name = "unnamed"
+    return f"line {line}: U+{ord(character):04X} {name}"
+
+
+def check_text_integrity(root: Path) -> list[str]:
+    """Return one problem string per damaged file."""
+    problems: list[str] = []
+    for path in _tracked_files(root):
+        if path.suffix.lower() not in TEXT_SUFFIXES or not path.is_file():
+            continue
+        relative = path.relative_to(root).as_posix()
+        try:
+            raw = path.read_bytes()
+        except OSError:
+            continue
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            problems.append(f"{relative}: not valid UTF-8 ({exc.reason})")
+            continue
+
+        if text.startswith(_BOM):
+            problems.append(f"{relative}: starts with a UTF-8 byte-order mark")
+
+        replacement = text.find(_REPLACEMENT)
+        if replacement != -1:
+            problems.append(f"{relative}: {_describe(text, replacement)} (replacement character)")
+
+        for leader in MOJIBAKE_LEADERS:
+            index = text.find(leader)
+            if index != -1:
+                problems.append(
+                    f"{relative}: {_describe(text, index)} "
+                    "(mis-decoded UTF-8 punctuation; rewrite the file as UTF-8)"
+                )
+                break
+    return problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    args = parser.parse_args()
+
+    problems = check_text_integrity(args.root)
+    if problems:
+        print("text integrity check failed:")
+        for problem in problems:
+            print(f"  - {problem}")
+        return 1
+    print("text integrity check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/miniverl/bridge/dataset.py
+++ b/src/miniverl/bridge/dataset.py
@@ -9,6 +9,7 @@ labels as incomplete instead of lossless.
 from __future__ import annotations
 
 import hashlib
+import json
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Literal
@@ -80,9 +81,168 @@ def _sidecar_path(parquet: Path) -> Path:
     return parquet.with_suffix(parquet.suffix + ".miniverl.json")
 
 
-def _write_parquet(pa: Any, pq: Any, rows: list[dict[str, Any]], path: Path) -> None:
-    """Materialize the accepted rows. Seam kept module-level for fault injection."""
-    pq.write_table(pa.Table.from_pylist(rows), path)
+def _write_parquet(pa: Any, writer: Any, rows: list[dict[str, Any]], schema: Any) -> None:
+    """Write one buffered batch. Seam kept module-level for fault injection."""
+    writer.write_table(pa.Table.from_pylist(rows, schema=schema))
+
+
+#: Rows decoded from Parquet at a time, and the write buffer size. Small enough
+#: that a huge dataset never becomes a single Python list.
+CONVERSION_BATCH_ROWS = 512
+
+#: A partial conversion can reject an unbounded number of rows. Counts stay
+#: exact; the per-row detail array is sampled so the report cannot grow without
+#: limit. Provenance for accepted rows is never sampled.
+MAX_REPORTED_REJECTIONS = 100
+
+_SIDECAR_SCHEMA_VERSIONS = frozenset({1})
+_SIDECAR_NAMESPACE = "extra_info.miniverl"
+
+#: Any other top-level key is treated as an unknown critical field. A sidecar
+#: this version does not fully understand must not be half-applied.
+_SIDECAR_KNOWN_FIELDS = frozenset(
+    {
+        "schema_version",
+        "namespace",
+        "semantics",
+        "rows",
+        # Optional binding a sidecar may carry to name the dataset it belongs to.
+        "source_sha256",
+        "source_rows",
+        "generator",
+    }
+)
+
+
+def _sidecar_error(path: Path, detail: str) -> ConfigError:
+    """Sidecar diagnostics name the location, never the extension payload."""
+    return ConfigError(
+        f"extension sidecar {path.name} is invalid: {detail}",
+        hint=(
+            "a sidecar that exists but cannot be validated is never treated as absent, "
+            "because that would silently drop miniVERL extension provenance. Fix or "
+            "remove the sidecar. Extension values are not shown here because they may "
+            "contain teacher targets."
+        ),
+    )
+
+
+def _load_input_sidecar(path: Path, *, source_rows: int) -> dict[str, Any]:
+    """Validate an existing sidecar strictly, or fail closed.
+
+    Up to the v0.6.3 release candidate any JSON object was accepted, so ``{}``
+    and ``{"rows": []}`` both read as "no extensions" and quietly discarded the
+    provenance the sidecar existed to carry.
+    """
+    if not path.is_file():
+        return {}
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise _sidecar_error(path, f"it cannot be read as JSON ({type(exc).__name__})") from exc
+    if not isinstance(loaded, Mapping):
+        raise _sidecar_error(path, "the top level must be a JSON object")
+
+    unknown = sorted(set(loaded) - _SIDECAR_KNOWN_FIELDS)
+    if unknown:
+        raise _sidecar_error(path, f"unknown field(s) {', '.join(unknown)}")
+    version = loaded.get("schema_version")
+    if version not in _SIDECAR_SCHEMA_VERSIONS:
+        supported = ", ".join(str(item) for item in sorted(_SIDECAR_SCHEMA_VERSIONS))
+        raise _sidecar_error(path, f"schema_version {version!r} is not one of {supported}")
+    namespace = loaded.get("namespace")
+    if namespace != _SIDECAR_NAMESPACE:
+        raise _sidecar_error(path, f"namespace must be {_SIDECAR_NAMESPACE!r}, got {namespace!r}")
+    rows = loaded.get("rows")
+    if not isinstance(rows, Mapping):
+        raise _sidecar_error(path, "rows must be a JSON object keyed by source row index")
+
+    declared_rows = loaded.get("source_rows")
+    if declared_rows is not None and declared_rows != source_rows:
+        raise _sidecar_error(
+            path, f"source_rows {declared_rows!r} does not match the dataset's {source_rows}"
+        )
+
+    for key in rows:
+        text = str(key)
+        if not text.isdigit() or str(int(text)) != text:
+            raise _sidecar_error(
+                path, f"row key {text!r} is not a canonical non-negative integer string"
+            )
+        if int(text) >= source_rows:
+            raise _sidecar_error(
+                path, f"row key {text!r} is outside the source dataset's {source_rows} row(s)"
+            )
+    try:
+        canonical_json(dict(rows))
+    except (TypeError, ValueError) as exc:
+        raise _sidecar_error(path, "row values are not JSON-compatible") from exc
+    return dict(loaded)
+
+
+def _verify_sidecar_binding(sidecar: Mapping[str, Any], path: Path, *, source: Path) -> None:
+    """Check the optional digest binding after the cheap structural checks."""
+    declared = sidecar.get("source_sha256")
+    if declared is not None and declared != _sha256(source):
+        raise _sidecar_error(path, "source_sha256 does not match the dataset being converted")
+
+
+def _extra_info_type(pa: Any, source_type: Any, *, direction: str, extension_type: Any) -> Any:
+    """Output type for ``extra_info`` after the miniVERL field moves."""
+    fields = []
+    if source_type is not None and pa.types.is_struct(source_type):
+        fields = [field for field in source_type if field.name != "miniverl"]
+    if direction == "to-verl-parquet" and extension_type is not None:
+        fields.append(pa.field("miniverl", extension_type))
+    if not fields:
+        # Parquet cannot encode an empty struct; an all-null column is the exact
+        # canonical intermediate.
+        return pa.null()
+    return pa.struct(fields)
+
+
+def _output_schema(pa: Any, source_schema: Any, *, direction: str, extension_type: Any) -> Any:
+    """Derive one output schema up front so every batch writes the same shape.
+
+    Inferring a schema per batch would let an optional nested field that only
+    appears in a later row group produce an incompatible second schema.
+    """
+    fields = []
+    has_extra_info = False
+    for field in source_schema:
+        if field.name == "miniverl_extensions":
+            # Never an output column: it is reconciled into the sidecar or into
+            # ``extra_info.miniverl``.
+            continue
+        if field.name == "extra_info":
+            has_extra_info = True
+            fields.append(
+                pa.field(
+                    "extra_info",
+                    _extra_info_type(
+                        pa, field.type, direction=direction, extension_type=extension_type
+                    ),
+                )
+            )
+        else:
+            fields.append(field)
+    if not has_extra_info and direction == "to-verl-parquet" and extension_type is not None:
+        fields.append(pa.field("extra_info", pa.struct([pa.field("miniverl", extension_type)])))
+    return pa.schema(fields)
+
+
+def _extension_type(pa: Any, source_schema: Any, sidecar: Mapping[str, Any]) -> Any:
+    """Arrow type for the miniVERL extension payload, or ``None`` if there is none."""
+    for field in source_schema:
+        if field.name == "miniverl_extensions":
+            return field.type
+    rows = sidecar.get("rows") or {}
+    if not rows:
+        return None
+    try:
+        return pa.array(list(rows.values())).type
+    except (pa.ArrowInvalid, pa.ArrowTypeError, TypeError):  # pragma: no cover - exotic payloads
+        return None
 
 
 def _collect_extension_sources(
@@ -207,84 +367,115 @@ def _convert_locked(
     max_prompt_characters: int | None,
     allow_rejected_rows: bool = False,
 ) -> dict[str, Any]:
-    """Build and publish one coherent Parquet/sidecar/report family."""
+    """Build and publish one coherent Parquet/sidecar/report family.
+
+    The source is streamed a record batch at a time and accepted rows are
+    written straight into the staging file, so neither the whole table nor the
+    whole converted dataset is ever held in memory. Publication still happens
+    only in ``transaction.commit()``, which keeps strict conversion
+    complete-or-nothing.
+    """
     try:
-        rows = pq.read_table(source_path).to_pylist()
+        parquet_file = pq.ParquetFile(source_path)
+        source_schema = parquet_file.schema_arrow
+        source_rows = parquet_file.metadata.num_rows
     except Exception as exc:
         raise ConfigError(f"cannot read Parquet dataset {source_path}: {exc}") from exc
 
-    input_sidecar: dict[str, Any] = {}
     candidate_sidecar = _sidecar_path(source_path)
-    if candidate_sidecar.is_file():
-        import json
+    input_sidecar = _load_input_sidecar(candidate_sidecar, source_rows=source_rows)
+    if input_sidecar:
+        _verify_sidecar_binding(input_sidecar, candidate_sidecar, source=source_path)
 
-        try:
-            loaded = json.loads(candidate_sidecar.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as exc:
-            raise ConfigError(f"cannot read extension sidecar {candidate_sidecar}: {exc}") from exc
-        if isinstance(loaded, dict):
-            input_sidecar = loaded
+    extension_type = _extension_type(pa, source_schema, input_sidecar)
+    schema = _output_schema(pa, source_schema, direction=direction, extension_type=extension_type)
 
-    accepted: list[dict[str, Any]] = []
     rejected: list[dict[str, Any]] = []
+    rejected_total = 0
     extensions: dict[str, Any] = {}
     source_row_indices: dict[str, int] = {}
     deduplicated: list[dict[str, Any]] = []
     over_bound = 0
-    for source_index, raw in enumerate(rows):
-        if not isinstance(raw, Mapping):
-            rejected.append({"row": source_index, "reason": "row must be an object"})
-            continue
-        row = dict(raw)
-        reason = _validate_row(row)
-        if reason:
-            rejected.append({"row": source_index, "reason": reason})
-            continue
-        prompt = row["prompt"]
-        assert isinstance(prompt, list)
-        if max_prompt_characters is not None and _prompt_characters(prompt) > max_prompt_characters:
-            over_bound += 1
-
-        found, extra = _collect_extension_sources(
-            row, source_index=source_index, input_sidecar=input_sidecar
-        )
-        extension, merged_sources = _resolve_extension(found, source_index=source_index)
-        if merged_sources:
-            deduplicated.append({"row": source_index, "sources": merged_sources})
-        if direction == "to-verl-parquet":
-            if extension is not None:
-                extra["miniverl"] = extension
-            row["extra_info"] = extra or None
-        else:
-            # Parquet cannot encode an empty struct. ``None`` is the exact
-            # canonical intermediate when all extension fields moved to the
-            # checksummed sidecar; the reverse conversion restores the object.
-            row["extra_info"] = extra or None
-        if extension is not None:
-            # Keyed on the output row so the sidecar stays consistent with the
-            # Parquet file it accompanies; the source index is kept separately.
-            extensions[str(len(accepted))] = extension
-        source_row_indices[str(len(accepted))] = source_index
-        accepted.append(row)
-
-    if rejected and not allow_rejected_rows:
-        first = rejected[0]
-        raise ConfigError(
-            f"{len(rejected)} of {len(rows)} source row(s) failed validation; "
-            f"first failure is row {first['row']}: {first['reason']}",
-            hint=(
-                "conversion is complete-or-nothing by default. Fix the source rows, or "
-                "pass --allow-rejected-rows to publish an explicitly partial dataset"
-            ),
-        )
-    if not accepted:
-        raise ConfigError("dataset conversion accepted zero rows", hint="inspect the rejected rows")
+    accepted_total = 0
+    buffer: list[dict[str, Any]] = []
 
     staged_parquet = transaction.path("parquet")
+    writer = pq.ParquetWriter(staged_parquet, schema)
+
+    def _flush() -> None:
+        if not buffer:
+            return
+        _write_parquet(pa, writer, buffer, schema)
+        buffer.clear()
+
     try:
-        _write_parquet(pa, pq, accepted, staged_parquet)
+        source_index = -1
+        for batch in parquet_file.iter_batches(batch_size=CONVERSION_BATCH_ROWS):
+            for raw in batch.to_pylist():
+                source_index += 1
+                if not isinstance(raw, Mapping):
+                    reason = "row must be an object"
+                elif (validation := _validate_row(dict(raw))) is not None:
+                    reason = validation
+                else:
+                    reason = None
+                if reason is not None:
+                    # Fail before reading any further row group unless a partial
+                    # dataset was explicitly authorized.
+                    if not allow_rejected_rows:
+                        raise ConfigError(
+                            f"source row {source_index} failed validation: {reason}",
+                            hint=(
+                                "conversion is complete-or-nothing by default. Fix the source "
+                                "rows, or pass --allow-rejected-rows to publish an explicitly "
+                                "partial dataset"
+                            ),
+                        )
+                    rejected_total += 1
+                    if len(rejected) < MAX_REPORTED_REJECTIONS:
+                        rejected.append({"row": source_index, "reason": reason})
+                    continue
+
+                row = dict(raw)
+                prompt = row["prompt"]
+                assert isinstance(prompt, list)
+                if (
+                    max_prompt_characters is not None
+                    and _prompt_characters(prompt) > max_prompt_characters
+                ):
+                    over_bound += 1
+
+                found, extra = _collect_extension_sources(
+                    row, source_index=source_index, input_sidecar=input_sidecar
+                )
+                extension, merged_sources = _resolve_extension(found, source_index=source_index)
+                if merged_sources:
+                    deduplicated.append({"row": source_index, "sources": merged_sources})
+                if direction == "to-verl-parquet" and extension is not None:
+                    extra["miniverl"] = extension
+                # Parquet cannot encode an empty struct. ``None`` is the exact
+                # canonical intermediate when all extension fields moved to the
+                # checksummed sidecar; the reverse conversion restores the object.
+                row["extra_info"] = extra or None
+                if extension is not None:
+                    # Keyed on the output row so the sidecar stays consistent with
+                    # the Parquet file it accompanies.
+                    extensions[str(accepted_total)] = extension
+                source_row_indices[str(accepted_total)] = source_index
+                accepted_total += 1
+                buffer.append(row)
+                if len(buffer) >= CONVERSION_BATCH_ROWS:
+                    _flush()
+        _flush()
+    except ConfigError:
+        raise
     except Exception as exc:
         raise ConfigError(f"cannot write Parquet dataset {targets['parquet']}: {exc}") from exc
+    finally:
+        writer.close()
+
+    if not accepted_total:
+        raise ConfigError("dataset conversion accepted zero rows", hint="inspect the rejected rows")
     transaction.claim("parquet")
 
     emit_sidecar = bool(extensions) and direction == "from-verl-parquet"
@@ -314,14 +505,19 @@ def _convert_locked(
             "rows_truncated": 0,
         }
     )
-    partial = bool(rejected)
+    partial = bool(rejected_total)
     report: dict[str, Any] = {
         "schema_version": 3,
         "direction": direction,
-        "source_rows": len(rows),
-        "accepted_rows": len(accepted),
-        "rejected_rows": len(rejected),
+        "source_rows": source_rows,
+        "accepted_rows": accepted_total,
+        "rejected_rows": rejected_total,
+        # Counts stay exact; only the per-row detail is sampled so one very
+        # broken dataset cannot produce an unbounded report.
         "rejections": rejected,
+        "rejections_truncated": rejected_total > len(rejected),
+        "max_reported_rejections": MAX_REPORTED_REJECTIONS,
+        "conversion_batch_rows": CONVERSION_BATCH_ROWS,
         # A conversion that dropped rows is never described as lossless overall.
         "complete_dataset_conversion": not partial,
         "lossless_for_accepted_rows": True,

--- a/src/miniverl/bridge/doctor.py
+++ b/src/miniverl/bridge/doctor.py
@@ -6,6 +6,7 @@ import hashlib
 import importlib.metadata
 import json
 import re
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -594,6 +595,193 @@ def _scan_dataset_text(
     }
 
 
+#: Bounds for the portable-metadata scan. A bundle must not be able to stall a
+#: diagnosis by shipping an enormous "metadata" file.
+METADATA_MAX_FILE_BYTES = 1_000_000
+METADATA_MAX_TOTAL_BYTES = 32 * 1024 * 1024
+METADATA_MAX_FINDINGS = 200
+
+#: Structured keys whose *name* means the value is a credential, whatever it
+#: looks like. Matched against the final path component only.
+_SECRET_KEY_NAME = re.compile(
+    r"(?i)^(api[_-]?key|secret([_-]?key)?|password|passwd|access[_-]?token|"
+    r"auth([_-]?token)?|token|authorization|credentials?|private[_-]?key|"
+    r"client[_-]?secret|session[_-]?key)$"
+)
+
+#: Value-shaped detectors. These run against strings wherever they are found.
+_VALUE_DETECTORS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("url_userinfo", re.compile(r"[a-zA-Z][a-zA-Z0-9+.\-]*://[^/\s:@]+:[^/\s@]+@")),
+    ("private_key_block", re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")),
+    ("aws_access_key_id", re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")),
+    ("bearer_token", re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._\-]{20,}")),
+    ("absolute_local_path", _ABSOLUTE_PATH),
+)
+
+#: Text-shaped detector. Only meaningful in unstructured prose/scripts, where
+#: there is no key/value structure to inspect.
+_TEXT_CREDENTIAL = re.compile(
+    r"(?i)\b(?:api[_-]?key|secret[_-]?key|secret|password|passwd|"
+    r"access[_-]?token|auth[_-]?token|api[_-]?token|token)\b\s*[:=]\s*\S"
+)
+
+_STRUCTURED_SUFFIXES = {".json", ".yaml", ".yml"}
+_NEVER_TEXT_SUFFIXES = {".parquet", ".safetensors", ".bin", ".pt", ".onnx", ".npz"}
+
+
+def _scan_string(value: str, *, sentinels: tuple[str, ...]) -> list[str]:
+    """Detector categories matched by one string. Never returns the text."""
+    categories = [name for name, pattern in _VALUE_DETECTORS if pattern.search(value)]
+    if any(sentinel and sentinel in value for sentinel in sentinels):
+        categories.append("user_sentinel")
+    return categories
+
+
+def _walk_structured(
+    value: Any,
+    *,
+    path: str,
+    relative: str,
+    sentinels: tuple[str, ...],
+    findings: list[dict[str, Any]],
+    depth: int = 0,
+) -> None:
+    """Report credential-shaped keys and values with their JSON path only."""
+    if depth > 12 or len(findings) > METADATA_MAX_FINDINGS:
+        return
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            child = f"{path}.{key}"
+            if _SECRET_KEY_NAME.match(str(key)) and isinstance(item, str) and item.strip():
+                findings.append(
+                    {
+                        "category": "semantic_secret_key",
+                        "file": relative,
+                        "path": child,
+                        "detail": "a key whose name denotes a credential holds a non-empty value",
+                    }
+                )
+            _walk_structured(
+                item,
+                path=child,
+                relative=relative,
+                sentinels=sentinels,
+                findings=findings,
+                depth=depth + 1,
+            )
+    elif isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            _walk_structured(
+                item,
+                path=f"{path}[{index}]",
+                relative=relative,
+                sentinels=sentinels,
+                findings=findings,
+                depth=depth + 1,
+            )
+    elif isinstance(value, str):
+        for category in _scan_string(value, sentinels=sentinels):
+            findings.append(
+                {
+                    "category": category,
+                    "file": relative,
+                    "path": path,
+                    "detail": "a detector matched this value",
+                }
+            )
+
+
+def _scan_portable_metadata(root: Path, *, sentinels: tuple[str, ...]) -> dict[str, Any]:
+    """Bounded heuristic scan of the bundle's portable text metadata.
+
+    Structured files are parsed so a finding can name a JSON path; everything
+    else is scanned line by line. Matched text never leaves this function --
+    only the file, location and detector category do.
+    """
+    findings: list[dict[str, Any]] = []
+    files_inspected = 0
+    files_skipped_too_large = 0
+    bytes_scanned = 0
+    truncated = False
+
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix.lower() in _NEVER_TEXT_SUFFIXES:
+            continue
+        if bytes_scanned >= METADATA_MAX_TOTAL_BYTES or len(findings) > METADATA_MAX_FINDINGS:
+            truncated = True
+            break
+        try:
+            size = path.stat().st_size
+        except OSError:
+            continue
+        if size > METADATA_MAX_FILE_BYTES:
+            files_skipped_too_large += 1
+            truncated = True
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        relative = path.relative_to(root).as_posix()
+        files_inspected += 1
+        bytes_scanned += len(text.encode("utf-8", errors="ignore"))
+
+        parsed: Any = None
+        if path.suffix.lower() in _STRUCTURED_SUFFIXES:
+            try:
+                parsed = (
+                    json.loads(text) if path.suffix.lower() == ".json" else yaml.safe_load(text)
+                )
+            except (json.JSONDecodeError, yaml.YAMLError):
+                parsed = None
+        if parsed is not None:
+            _walk_structured(
+                parsed, path="$", relative=relative, sentinels=sentinels, findings=findings
+            )
+            continue
+
+        for number, line in enumerate(text.splitlines(), start=1):
+            categories = _scan_string(line, sentinels=sentinels)
+            if _TEXT_CREDENTIAL.search(line):
+                categories.append("credential_assignment")
+            for category in categories:
+                findings.append(
+                    {
+                        "category": category,
+                        "file": relative,
+                        "line": number,
+                        "detail": "a detector matched this line",
+                    }
+                )
+
+    unique: list[dict[str, Any]] = []
+    seen: set[tuple[Any, ...]] = set()
+    for item in findings:
+        key = (item["category"], item["file"], item.get("path"), item.get("line"))
+        if key not in seen:
+            seen.add(key)
+            unique.append(item)
+    return {
+        "status": "heuristic_failed" if unique else "heuristic_passed",
+        "method": (
+            "heuristic key-name and regular-expression detectors; not de-identification proof"
+        ),
+        "scan_scope": "sampled" if truncated else "full",
+        "files_inspected": files_inspected,
+        "files_skipped_too_large": files_skipped_too_large,
+        "bytes_scanned": bytes_scanned,
+        "max_file_bytes": METADATA_MAX_FILE_BYTES,
+        "max_total_bytes": METADATA_MAX_TOTAL_BYTES,
+        "max_findings": METADATA_MAX_FINDINGS,
+        "findings_truncated": len(unique) > METADATA_MAX_FINDINGS,
+        "disclosure": (
+            "file, JSON path or line number and detector category only; "
+            "matched text is never reported"
+        ),
+        "findings": unique[:METADATA_MAX_FINDINGS],
+    }
+
+
 def _check_privacy(
     root: Path,
     *,
@@ -603,17 +791,9 @@ def _check_privacy(
     max_bytes: int = DATASET_SCAN_MAX_BYTES,
 ) -> dict[str, Any]:
     """Report privacy per inspection scope; never widen one scope into another."""
-    problems = []
-    for path in root.rglob("*"):
-        if not path.is_file() or path.suffix in {".parquet", ".safetensors"}:
-            continue
-        try:
-            text = path.read_text(encoding="utf-8")
-        except UnicodeDecodeError:
-            continue
-        if _ABSOLUTE_PATH.search(text):
-            problems.append(path.relative_to(root).as_posix())
-    metadata_passed = not problems
+    metadata = _scan_portable_metadata(root, sentinels=sentinels)
+    problems = sorted({finding["file"] for finding in metadata["findings"]})
+    metadata_passed = metadata["status"] == "heuristic_passed"
 
     if scan_dataset_text:
         dataset = _scan_dataset_text(
@@ -630,7 +810,8 @@ def _check_privacy(
         # ``ok``/``fail`` drives the overall verdict and never reflects a scope
         # that was not inspected.
         "status": "ok" if metadata_passed and dataset_status != "failed" else "fail",
-        "portable_metadata_privacy": "passed" if metadata_passed else "failed",
+        "portable_metadata_privacy": metadata["status"],
+        "metadata_scan": metadata,
         "dataset_content_privacy": dataset_status,
         "model_weight_privacy": "not_inspected",
         "model_weight_reason": (
@@ -668,6 +849,128 @@ def _installed_verl() -> dict[str, Any]:
     }
 
 
+#: Facts a bundle can only *assert*. Nothing in a doctor run recomputes them:
+#: they describe events that happened elsewhere, earlier, on other hardware.
+_DECLARED_ONLY_CLAIMS = (
+    "upstream_config_parse_passed",
+    "model_data_load_smoke_passed",
+    "distributed_execution_tested",
+    "algorithm_semantic_parity",
+    "launchable",
+    "distributed_execution_status",
+)
+
+
+def _bundle_declared_claims(compatibility: dict[str, Any], *, present: bool) -> dict[str, Any]:
+    """Everything the bundle says about itself, labelled as its own testimony."""
+    declared: dict[str, Any] = {
+        "source": "provenance/compatibility-report.json" if present else "absent",
+        "trust": "unsigned_self_consistent" if present else "not_verified",
+        "note": (
+            "these values are copied from the bundle and describe events this doctor run "
+            "did not observe; they are claims, not results"
+        ),
+    }
+    for name in _DECLARED_ONLY_CLAIMS:
+        if name in compatibility:
+            declared[name] = compatibility[name]
+    declared["unsupported_semantics"] = compatibility.get("unsupported_semantics", [])
+    return declared
+
+
+def _locally_recomputed_checks(
+    *,
+    target: dict[str, Any],
+    model: dict[str, Any],
+    tokenizer: dict[str, Any],
+    parquet: dict[str, Any],
+    config: dict[str, Any],
+    reward: dict[str, Any],
+    hashes: dict[str, Any],
+    privacy: dict[str, Any],
+    installed: dict[str, Any],
+    upstream: dict[str, Any],
+) -> dict[str, Any]:
+    """Only checks this process performed against the bytes on disk."""
+
+    def _verdict(check: dict[str, Any]) -> str:
+        return "passed" if check.get("status") == "ok" else "failed"
+
+    return {
+        "checksum_consistency": _verdict(hashes),
+        "pinned_requirement_file": _verdict(target),
+        "config_structure": _verdict(config),
+        "adapter_safetensors_structure": _verdict(model),
+        "tokenizer_identity": _verdict(tokenizer),
+        "parquet_schema": _verdict(parquet),
+        "reward_interface_static": _verdict(reward),
+        "portable_metadata_privacy": (
+            "passed" if privacy["portable_metadata_privacy"] == "heuristic_passed" else "failed"
+        ),
+        "installed_verl_identity": installed.get("status", "not installed"),
+        "upstream_config_parse": upstream["status"],
+        # A doctor run never launches a job and never compares algorithms.
+        "distributed_execution": "not_run",
+        "algorithm_semantic_parity": "not_run",
+    }
+
+
+def _provenance_trust(hashes: dict[str, Any]) -> dict[str, Any]:
+    """State exactly what the bundle's own checksum file can and cannot prove."""
+    consistent = hashes.get("status") == "ok"
+    return {
+        "level": "unsigned_self_consistent" if consistent else "not_verified",
+        "signature_verification": "not_available",
+        "note": (
+            "SHA256SUMS ships inside the bundle it describes, so agreement proves "
+            "internal consistency only; anyone who edits a file can regenerate it. "
+            "miniVERL implements no signature or transparency-log verification."
+        ),
+    }
+
+
+def _recompute_upstream_smoke(
+    root: Path, installed: dict[str, Any], *, enabled: bool
+) -> dict[str, Any]:
+    """Re-run the documented upstream parse/merge locally, in this process.
+
+    ``--require-verl`` used to compare only an installed commit id, which said
+    nothing about whether this bundle's config still merges into the pinned
+    upstream schema. This performs the merge now rather than trusting the
+    bundle's record of a merge someone else performed.
+    """
+    if not enabled:
+        return {"status": "not_run", "reason": "pass --require-verl to recompute the local smoke"}
+    if installed.get("status") == "not installed":
+        return {"status": "failed", "reason": "the pinned verl distribution is not installed"}
+    try:
+        from omegaconf import OmegaConf
+    except ImportError:
+        return {"status": "failed", "reason": "omegaconf is not installed"}
+    try:
+        import importlib.metadata
+
+        distribution = importlib.metadata.distribution("verl")
+        generated = Path(
+            str(distribution.locate_file("verl/trainer/config/_generated_ppo_trainer.yaml"))
+        )
+        if not generated.is_file():
+            return {"status": "failed", "reason": "installed verl omits the generated PPO config"}
+        official = OmegaConf.load(generated)
+        exported = OmegaConf.load(root / "recipe" / "verl-overrides.yaml")
+        OmegaConf.set_struct(official, True)
+        OmegaConf.merge(official, exported)
+    except Exception as exc:
+        return {"status": "failed", "reason": f"{type(exc).__name__}: {exc}"}
+    return {
+        "status": "passed",
+        "scope": (
+            "the bundle's verl-overrides.yaml parsed and merged into the installed pinned "
+            "upstream schema in this process; no distributed job was launched"
+        ),
+    }
+
+
 def inspect_bridge_bundle(
     root: str | Path,
     *,
@@ -701,17 +1004,32 @@ def inspect_bridge_bundle(
         max_bytes=dataset_scan_max_bytes,
     )
     installed = _installed_verl()
+    compatibility_path = bundle / "provenance" / "compatibility-report.json"
     try:
-        compatibility = json.loads(
-            (bundle / "provenance" / "compatibility-report.json").read_text(encoding="utf-8")
-        )
+        compatibility = json.loads(compatibility_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         compatibility = {}
     checks = (target, model, tokenizer, parquet, config, reward, hashes, privacy)
     artifact_failed = any(check.get("status") != "ok" for check in checks)
-    pinned_verl_failed = require_verl and installed.get("status") != "ok"
+    upstream = _recompute_upstream_smoke(bundle, installed, enabled=require_verl)
+    pinned_verl_failed = require_verl and (
+        installed.get("status") != "ok" or upstream["status"] != "passed"
+    )
     failed = artifact_failed or pinned_verl_failed
     local_smoke = "failed" if artifact_failed else "passed"
+    declared = _bundle_declared_claims(compatibility, present=compatibility_path.is_file())
+    recomputed = _locally_recomputed_checks(
+        target=target,
+        model=model,
+        tokenizer=tokenizer,
+        parquet=parquet,
+        config=config,
+        reward=reward,
+        hashes=hashes,
+        privacy=privacy,
+        installed=installed,
+        upstream=upstream,
+    )
     return {
         "target_verl": target,
         "installed_verl": installed,
@@ -729,25 +1047,27 @@ def inspect_bridge_bundle(
         "reward_scaffold_interface": reward,
         "reward_verification_level": reward["verification_level"],
         "reward_code_executed": bool(reward.get("code_executed", False)),
+        # Copied from the bundle for the reader's information; the doctor did not
+        # verify that this list is complete.
         "unsupported_semantics": compatibility.get("unsupported_semantics", []),
         "artifact_hashes": hashes,
         "privacy": privacy,
         "local_smoke_status": local_smoke,
         "artifact_bundle_complete": not artifact_failed,
-        "upstream_config_parse_passed": bool(
-            compatibility.get("upstream_config_parse_passed", False)
-        ),
-        "model_data_load_smoke_passed": bool(
-            compatibility.get("model_data_load_smoke_passed", False)
-        ),
+        "bundle_declared_claims": declared,
+        "locally_recomputed_checks": recomputed,
+        "provenance_trust": _provenance_trust(hashes),
+        "upstream_config_parse_recheck": upstream,
+        # Every flag below reflects what *this* process recomputed. A bundle
+        # cannot raise any of them by describing itself favourably.
+        "upstream_config_parse_passed": upstream["status"] == "passed",
+        "model_data_load_smoke_passed": upstream["status"] == "passed"
+        and not artifact_failed
+        and require_verl,
         "reward_implementation_complete": bool(reward.get("implementation_complete", False)),
         "launchable": False,
-        "distributed_execution_tested": bool(
-            compatibility.get("distributed_execution_tested", False)
-        ),
-        "algorithm_semantic_parity": bool(compatibility.get("algorithm_semantic_parity", False)),
-        "distributed_execution_status": compatibility.get(
-            "distributed_execution_status", "not tested"
-        ),
+        "distributed_execution_tested": False,
+        "algorithm_semantic_parity": False,
+        "distributed_execution_status": "not tested",
         "verdict": "fail" if failed else "ok",
     }

--- a/src/miniverl/bridge/reward_static.py
+++ b/src/miniverl/bridge/reward_static.py
@@ -10,9 +10,18 @@ This module replaces that with an AST walk. Parsing does not evaluate the code:
 ``ast.parse`` builds a tree from source text and never executes a statement, so a
 bundle can no longer act merely by being inspected.
 
-Static inspection proves the *interface* is present and that importing the module
-would not obviously run code. It proves nothing about whether the reward logic is
-correct, meaningful, or safe to run later.
+The policy covers *definition-time* expressions, not only top-level statements.
+Class bases, class keywords such as ``metaclass=``, decorators, default
+arguments, annotations and type-parameter bounds are all evaluated when a module
+is imported, so a scaffold whose body is otherwise inert can still run code
+through any of them. The v0.6.3 release candidate audited only decorators and
+defaults and therefore accepted ``class Hidden(exploit())`` with no finding at
+all.
+
+What this proves is deliberately narrow: the expected interface is *shaped*
+correctly and no executable definition-time expression forbidden by this policy
+is present. It does not prove the reward body is correct, that imported modules
+are side-effect free, or that the file is safe to import.
 """
 
 from __future__ import annotations
@@ -22,24 +31,37 @@ from pathlib import Path
 from typing import Any
 
 __all__ = [
+    "MAX_AST_DEPTH",
+    "MAX_AST_NODES",
+    "MAX_FINDINGS",
+    "MAX_SOURCE_BYTES",
     "REWARD_LEVELS",
     "REQUIRED_REWARD_PARAMETERS",
     "inspect_reward_scaffold",
 ]
 
 #: Ordered weakest to strongest. The default doctor path stops at
-#: ``interface_statically_verified``; the strongest level requires an explicit
-#: opt-in that executes untrusted code and is never reached by default.
+#: ``interface_shape_verified`` -- deliberately weaker wording than the release
+#: candidate's ``interface_statically_verified``, which read as a safety claim.
+#: The strongest level requires an explicit opt-in that executes untrusted code
+#: and is never reached by default.
 REWARD_LEVELS = (
     "not_present",
     "syntax_valid",
-    "interface_statically_verified",
+    "interface_shape_verified",
     "trusted_dynamic_import_verified",
 )
 
 #: verl calls ``compute_score(data_source, solution_str, ground_truth, extra_info)``.
 REQUIRED_REWARD_PARAMETERS = ("data_source", "solution_str", "ground_truth")
 _OPTIONAL_REWARD_PARAMETER = "extra_info"
+
+#: Fail-closed bounds. A hostile bundle must produce a bounded diagnostic rather
+#: than exhaust the process that merely asked for a diagnosis.
+MAX_SOURCE_BYTES = 1_000_000
+MAX_AST_NODES = 200_000
+MAX_AST_DEPTH = 60
+MAX_FINDINGS = 50
 
 #: The generated fail-closed scaffold carries this sentinel inside a raised
 #: message. It is found by reading the parsed constants, never by running it.
@@ -61,6 +83,22 @@ _SIDE_EFFECT_HINTS = {
     "compile": "dynamic_evaluation",
     "__import__": "dynamic_import",
 }
+
+#: Expression forms that run code where they appear. A bare ``Name``,
+#: ``Attribute`` or ``Subscript`` is how ordinary type annotations and base
+#: classes are written, so flagging those would reject every normal scaffold.
+_EXECUTABLE_FORMS: tuple[type[ast.AST], ...] = (
+    ast.Call,
+    ast.Lambda,
+    ast.Await,
+    ast.NamedExpr,
+    ast.ListComp,
+    ast.SetComp,
+    ast.DictComp,
+    ast.GeneratorExp,
+    ast.Yield,
+    ast.YieldFrom,
+)
 
 
 def _finding(category: str, line: int, detail: str) -> dict[str, Any]:
@@ -97,6 +135,90 @@ def _contains_call(node: ast.expr | None) -> ast.Call | None:
     return None
 
 
+def _executable_form(node: ast.expr | None) -> ast.AST | None:
+    """First sub-expression that would run code where ``node`` appears."""
+    if node is None:
+        return None
+    for child in ast.walk(node):
+        if isinstance(child, _EXECUTABLE_FORMS):
+            return child
+    return None
+
+
+def _hint_for(node: ast.AST) -> str:
+    if isinstance(node, ast.Call):
+        return _call_hint(node.func)
+    return type(node).__name__.lower()
+
+
+def _audit_definition_expression(
+    node: ast.expr | None,
+    *,
+    category: str,
+    fallback_line: int,
+    description: str,
+) -> list[dict[str, Any]]:
+    """Flag an expression that is evaluated when the module is imported."""
+    offender = _executable_form(node)
+    if offender is None:
+        return []
+    line = getattr(node, "lineno", fallback_line)
+    return [
+        _finding(
+            category,
+            line,
+            f"{description} is evaluated at import time ({_hint_for(offender)})",
+        )
+    ]
+
+
+def _audit_type_params(node: ast.AST, *, owner: str) -> list[dict[str, Any]]:
+    """Python 3.12 type-parameter bounds and defaults are definition-time code."""
+    findings: list[dict[str, Any]] = []
+    for parameter in getattr(node, "type_params", ()) or ():
+        for attribute in ("bound", "default_value"):
+            findings.extend(
+                _audit_definition_expression(
+                    getattr(parameter, attribute, None),
+                    category="annotation_executes",
+                    fallback_line=getattr(node, "lineno", 0),
+                    description=f"the type-parameter {attribute} of {owner}",
+                )
+            )
+    return findings
+
+
+def _audit_annotations(function: ast.FunctionDef | ast.AsyncFunctionDef) -> list[dict[str, Any]]:
+    """Parameter and return annotations run unless they are strings."""
+    findings: list[dict[str, Any]] = []
+    args = function.args
+    parameters = [
+        *args.posonlyargs,
+        *args.args,
+        *args.kwonlyargs,
+        *(item for item in (args.vararg, args.kwarg) if item is not None),
+    ]
+    for parameter in parameters:
+        findings.extend(
+            _audit_definition_expression(
+                parameter.annotation,
+                category="annotation_executes",
+                fallback_line=function.lineno,
+                description=f"the annotation of parameter {parameter.arg!r}",
+            )
+        )
+    findings.extend(
+        _audit_definition_expression(
+            function.returns,
+            category="annotation_executes",
+            fallback_line=function.lineno,
+            description=f"the return annotation of {function.name}",
+        )
+    )
+    findings.extend(_audit_type_params(function, owner=f"function {function.name}"))
+    return findings
+
+
 def _check_signature(function: ast.FunctionDef) -> list[dict[str, Any]]:
     """Verify the parameter contract without evaluating defaults."""
     findings: list[dict[str, Any]] = []
@@ -122,6 +244,15 @@ def _check_signature(function: ast.FunctionDef) -> list[dict[str, Any]]:
                 f"the fourth parameter must be {_OPTIONAL_REWARD_PARAMETER!r}; got {extra[0]!r}",
             )
         )
+    if len(extra) > 1:
+        findings.append(
+            _finding(
+                "signature_mismatch",
+                function.lineno,
+                f"compute_score accepts at most one parameter after "
+                f"{required[-1]}; got {len(extra)}",
+            )
+        )
     # Every parameter past the required three must be optional so verl can call
     # the function with three positional arguments.
     if len(extra) > len(args.defaults):
@@ -132,6 +263,28 @@ def _check_signature(function: ast.FunctionDef) -> list[dict[str, Any]]:
                 "parameters after ground_truth must have defaults",
             )
         )
+    # Keyword-only parameters were never inspected before v0.6.3 final, so a
+    # required keyword-only ``extra_info`` -- which raises TypeError on verl's
+    # three-argument call -- passed as a verified interface.
+    for index, keyword_only in enumerate(args.kwonlyargs):
+        if keyword_only.arg != _OPTIONAL_REWARD_PARAMETER:
+            findings.append(
+                _finding(
+                    "signature_mismatch",
+                    function.lineno,
+                    f"unexpected keyword-only parameter {keyword_only.arg!r}; compute_score "
+                    f"accepts only {_OPTIONAL_REWARD_PARAMETER!r} past {required[-1]}",
+                )
+            )
+        elif args.kw_defaults[index] is None:
+            findings.append(
+                _finding(
+                    "signature_mismatch",
+                    function.lineno,
+                    f"keyword-only {_OPTIONAL_REWARD_PARAMETER!r} must have a default; verl "
+                    "calls compute_score with three positional arguments",
+                )
+            )
     if args.vararg is not None or args.kwarg is not None:
         findings.append(
             _finding(
@@ -151,6 +304,7 @@ def _check_signature(function: ast.FunctionDef) -> list[dict[str, Any]]:
                     f"this one is {_call_hint(call.func) if call else 'not a literal'}",
                 )
             )
+    findings.extend(_audit_annotations(function))
     return findings
 
 
@@ -167,12 +321,31 @@ def _check_top_level(body: list[ast.stmt], *, context: str) -> list[dict[str, An
                 _finding(
                     "top_level_call" if call else "top_level_expression",
                     statement.lineno,
-                    f"{context} expression runs at import ({_call_hint(call.func) if call else 'evaluated'})",
+                    f"{context} expression runs at import "
+                    f"({_call_hint(call.func) if call else 'evaluated'})",
                 )
             )
         elif isinstance(statement, (ast.Import, ast.ImportFrom, ast.Pass)):
+            if isinstance(statement, ast.ImportFrom) and (statement.level or 0) > 0:
+                findings.append(
+                    _finding(
+                        "relative_import",
+                        statement.lineno,
+                        "the scaffold must be self-contained; a relative import pulls in "
+                        "bundle-local code this check never inspected",
+                    )
+                )
             continue
         elif isinstance(statement, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+            if isinstance(statement, ast.AnnAssign):
+                findings.extend(
+                    _audit_definition_expression(
+                        statement.annotation,
+                        category="annotation_executes",
+                        fallback_line=statement.lineno,
+                        description=f"the {context} variable annotation",
+                    )
+                )
             value = statement.value
             if isinstance(statement, ast.AugAssign) or not _is_literal(value):
                 call = _contains_call(value)
@@ -193,6 +366,29 @@ def _check_top_level(body: list[ast.stmt], *, context: str) -> list[dict[str, An
                         f"class {statement.name} has a decorator that is evaluated at import",
                     )
                 )
+            # Bases and keywords -- including ``metaclass=`` -- are evaluated
+            # when the class statement executes.
+            for base in statement.bases:
+                findings.extend(
+                    _audit_definition_expression(
+                        base,
+                        category="class_base_executes",
+                        fallback_line=statement.lineno,
+                        description=f"a base class of {statement.name}",
+                    )
+                )
+            for keyword in statement.keywords:
+                findings.extend(
+                    _audit_definition_expression(
+                        keyword.value,
+                        category="class_keyword_executes",
+                        fallback_line=statement.lineno,
+                        description=(
+                            f"the {keyword.arg or '**kwargs'} class keyword of {statement.name}"
+                        ),
+                    )
+                )
+            findings.extend(_audit_type_params(statement, owner=f"class {statement.name}"))
             findings.extend(_check_top_level(statement.body, context=f"class {statement.name}"))
         elif isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
             if statement.decorator_list:
@@ -212,6 +408,16 @@ def _check_top_level(body: list[ast.stmt], *, context: str) -> list[dict[str, An
                             f"default argument of {statement.name} is evaluated at import",
                         )
                     )
+            findings.extend(_audit_annotations(statement))
+        elif type(statement).__name__ == "TypeAlias":  # Python 3.12+
+            findings.extend(
+                _audit_definition_expression(
+                    getattr(statement, "value", None),
+                    category="annotation_executes",
+                    fallback_line=statement.lineno,
+                    description=f"the {context} type alias",
+                )
+            )
         else:
             findings.append(
                 _finding(
@@ -238,8 +444,33 @@ def _dynamic_assignment(tree: ast.Module) -> ast.stmt | None:
     return None
 
 
+def _ast_metrics(tree: ast.AST) -> tuple[int, int]:
+    """Bounded node count and depth. Stops early once a bound is exceeded."""
+    nodes = 0
+    deepest = 0
+    stack: list[tuple[ast.AST, int]] = [(tree, 1)]
+    while stack:
+        node, depth = stack.pop()
+        nodes += 1
+        deepest = max(deepest, depth)
+        if nodes > MAX_AST_NODES or deepest > MAX_AST_DEPTH:
+            break
+        stack.extend((child, depth + 1) for child in ast.iter_child_nodes(node))
+    return nodes, deepest
+
+
+def _imported_modules(tree: ast.Module) -> list[str]:
+    names: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            names.append(node.module)
+    return sorted(set(names))
+
+
 def inspect_reward_scaffold(path: str | Path, *, trust_and_import: bool = False) -> dict[str, Any]:
-    """Statically verify the reward interface. Never executes the file by default.
+    """Statically verify the reward interface shape. Never executes by default.
 
     ``trust_and_import`` re-enables the historical dynamic import for trusted
     developer workflows. It runs untrusted code in this process; it is not a
@@ -252,28 +483,74 @@ def inspect_reward_scaffold(path: str | Path, *, trust_and_import: bool = False)
         "code_executed": False,
         "untrusted_code_executed": False,
         "findings": [],
+        "findings_truncated": False,
         "signature": None,
         "implementation_complete": False,
+        "imports_present": [],
+        "import_runtime_safety": "not_verified",
+        "limits": {
+            "max_source_bytes": MAX_SOURCE_BYTES,
+            "max_ast_nodes": MAX_AST_NODES,
+            "max_ast_depth": MAX_AST_DEPTH,
+            "max_findings": MAX_FINDINGS,
+        },
         "scope": (
             "static AST inspection only; the file is parsed, never imported or executed. "
-            "This does not prove the reward logic is correct or safe to run."
+            "It shows the expected interface shape is present and that no definition-time "
+            "expression forbidden by this policy was found. It does not prove the reward "
+            "logic is correct, that imported modules are side-effect free, or that the "
+            "file is safe to import."
         ),
     }
+
+    def _finish(findings: list[dict[str, Any]]) -> dict[str, Any]:
+        check["findings_truncated"] = len(findings) > MAX_FINDINGS
+        check["findings"] = findings[:MAX_FINDINGS]
+        return check
+
     try:
-        source = source_path.read_text(encoding="utf-8")
+        raw = source_path.read_bytes()
     except OSError as exc:
         check["detail"] = f"no reward scaffold at {source_path.name}: {exc}"
         return check
 
+    if len(raw) > MAX_SOURCE_BYTES:
+        check["detail"] = (
+            f"reward scaffold is {len(raw)} bytes; this static check refuses to parse "
+            f"more than {MAX_SOURCE_BYTES}"
+        )
+        return _finish([_finding("source_too_large", 0, "source exceeds the inspection bound")])
+
+    try:
+        source = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        check["detail"] = f"reward scaffold is not valid UTF-8: {exc.reason}"
+        return _finish([_finding("encoding_error", 0, "source is not decodable as UTF-8")])
+
     try:
         tree = ast.parse(source, filename=str(source_path))
-    except (SyntaxError, ValueError) as exc:
-        check["detail"] = f"reward scaffold is not valid Python: {exc}"
-        check["findings"] = [_finding("syntax_error", getattr(exc, "lineno", 0) or 0, str(exc))]
-        return check
+    except (SyntaxError, ValueError, MemoryError, RecursionError) as exc:
+        check["detail"] = f"reward scaffold is not parseable Python: {type(exc).__name__}"
+        return _finish(
+            [_finding("syntax_error", getattr(exc, "lineno", 0) or 0, type(exc).__name__)]
+        )
+
+    nodes, depth = _ast_metrics(tree)
+    if nodes > MAX_AST_NODES:
+        check["detail"] = f"reward scaffold exceeds {MAX_AST_NODES} AST nodes"
+        return _finish([_finding("ast_too_large", 0, "syntax tree exceeds the inspection bound")])
+    if depth > MAX_AST_DEPTH:
+        check["detail"] = f"reward scaffold nests deeper than {MAX_AST_DEPTH} AST levels"
+        return _finish([_finding("ast_too_deep", 0, "syntax tree exceeds the depth bound")])
 
     check["verification_level"] = "syntax_valid"
-    findings = _check_top_level(tree.body, context="module")
+    check["imports_present"] = _imported_modules(tree)
+
+    try:
+        findings = _check_top_level(tree.body, context="module")
+    except RecursionError:
+        check["detail"] = "reward scaffold nests too deeply to inspect"
+        return _finish([_finding("ast_too_deep", 0, "static inspection exceeded its depth bound")])
 
     functions = [
         node
@@ -326,17 +603,18 @@ def inspect_reward_scaffold(path: str | Path, *, trust_and_import: bool = False)
         _PLACEHOLDER_SENTINEL in constant for constant in constants
     )
 
-    check["findings"] = findings
     if findings:
         categories = sorted({item["category"] for item in findings})
         check["detail"] = "static inspection rejected the reward scaffold: " + ", ".join(categories)
-        return check
+        return _finish(findings)
 
+    _finish(findings)
     check["status"] = "ok"
-    check["verification_level"] = "interface_statically_verified"
+    check["verification_level"] = "interface_shape_verified"
     check["detail"] = (
-        "compute_score is declared with the expected parameters and the module "
-        "contains no top-level executable statement; the file was not imported"
+        "the expected compute_score interface was found and no executable definition-time "
+        "expression forbidden by this static policy was detected; the reward body and any "
+        "imported modules were not executed and are not proven safe"
     )
 
     if trust_and_import:

--- a/tests/unit/test_text_integrity.py
+++ b/tests/unit/test_text_integrity.py
@@ -1,0 +1,74 @@
+"""The repository's tracked text stays UTF-8 clean.
+
+`docs/release-checklist.md` shipped `鈥?not applicable` and `CHANGELOG.md`
+shipped `base 鈫?SFT checkpoint` -- UTF-8 punctuation written back through a
+GBK console. The bytes are valid UTF-8 afterwards, so nothing raised.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.check_text_integrity import check_text_integrity
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_the_repository_is_clean() -> None:
+    assert check_text_integrity(ROOT) == []
+
+
+def _repository(tmp_path: Path, name: str, content: bytes) -> Path:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    target = tmp_path / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    ("name", "content", "expected"),
+    [
+        (
+            "checklist.md",
+            "- `鈥?not applicable` rather than zero.\n".encode(),
+            "mis-decoded",
+        ),
+        (
+            "changelog.md",
+            "base 鈫?SFT checkpoint\n".encode(),
+            "mis-decoded",
+        ),
+        ("bom.md", b"\xef\xbb\xbf# Title\n", "byte-order mark"),
+        ("broken.md", "text � here\n".encode(), "replacement character"),
+    ],
+)
+def test_damage_is_reported(tmp_path: Path, name: str, content: bytes, expected: str) -> None:
+    root = _repository(tmp_path, name, content)
+
+    problems = check_text_integrity(root)
+
+    assert len(problems) == 1
+    assert expected in problems[0]
+    assert name in problems[0]
+
+
+def test_intentional_cjk_is_not_flagged(tmp_path: Path) -> None:
+    """The Chinese README and the Unicode test fixtures must stay allowed."""
+    root = _repository(
+        tmp_path,
+        "README.zh-CN.md",
+        "# 中文文档\n\n这是一个单卡运行时。\n".encode(),
+    )
+
+    assert check_text_integrity(root) == []
+
+
+def test_binary_files_are_not_read_as_text(tmp_path: Path) -> None:
+    root = _repository(tmp_path, "model.safetensors", b"\x00\xff\xfe binary \x93")
+
+    assert check_text_integrity(root) == []

--- a/tests/unit/test_text_integrity.py
+++ b/tests/unit/test_text_integrity.py
@@ -17,6 +17,10 @@ from scripts.check_text_integrity import check_text_integrity
 ROOT = Path(__file__).resolve().parents[2]
 
 
+@pytest.mark.skipif(
+    not (ROOT / ".git").exists(),
+    reason="repository-level gate; the extracted sdist is not a git checkout",
+)
 def test_the_repository_is_clean() -> None:
     assert check_text_integrity(ROOT) == []
 

--- a/tests/unit/test_verl_bridge_claim_trust.py
+++ b/tests/unit/test_verl_bridge_claim_trust.py
@@ -1,0 +1,146 @@
+"""A bundle's own claims are never promoted to locally verified facts.
+
+``provenance/SHA256SUMS`` lives inside the bundle it describes. An attacker who
+edits ``compatibility-report.json`` can regenerate the checksum file just as
+easily, so agreement between them proves internal consistency and nothing more.
+
+Up to the v0.6.3 release candidate the doctor read
+``upstream_config_parse_passed``, ``model_data_load_smoke_passed``,
+``distributed_execution_tested`` and ``algorithm_semantic_parity`` straight out
+of that report and exposed them as top-level results, which read as verified
+outcomes of the diagnosis that just ran.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from tests.unit.test_verl_bridge_hostile_bundles import _run
+
+LIES: dict[str, Any] = {
+    "upstream_config_parse_passed": True,
+    "model_data_load_smoke_passed": True,
+    "distributed_execution_tested": True,
+    "algorithm_semantic_parity": True,
+    "distributed_execution_status": "verified on 512 GPUs",
+    "launchable": True,
+    "unsupported_semantics": [],
+}
+
+
+def _reseal(bundle: Path) -> None:
+    """Rewrite SHA256SUMS so the tampered bundle is internally consistent."""
+    checksum = bundle / "provenance" / "SHA256SUMS"
+    lines = []
+    for path in sorted(bundle.rglob("*")):
+        if not path.is_file() or path == checksum:
+            continue
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        lines.append(f"{digest}  {path.relative_to(bundle).as_posix()}")
+    checksum.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _lying_bundle(tmp_path: Path) -> Path:
+    from miniverl.bridge.contract import VERL_TAG
+    from miniverl.bridge.export import export_verl_bundle
+
+    out = tmp_path / "export"
+    export_verl_bundle(_run(tmp_path), target_verl=VERL_TAG, out=out)
+    report = out / "provenance" / "compatibility-report.json"
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    payload.update(LIES)
+    report.write_text(json.dumps(payload), encoding="utf-8")
+    _reseal(out)
+    return out
+
+
+def test_self_consistent_hashes_do_not_make_claims_trustworthy(tmp_path: Path) -> None:
+    from miniverl.bridge.doctor import inspect_bridge_bundle
+
+    diagnosis = inspect_bridge_bundle(_lying_bundle(tmp_path))
+
+    # The bundle really is internally consistent -- that is the whole point.
+    assert diagnosis["artifact_hashes"]["status"] == "ok"
+    assert diagnosis["provenance_trust"]["level"] == "unsigned_self_consistent"
+    assert diagnosis["provenance_trust"]["signature_verification"] == "not_available"
+
+    declared = diagnosis["bundle_declared_claims"]
+    assert declared["upstream_config_parse_passed"] is True
+    assert declared["distributed_execution_tested"] is True
+    assert declared["algorithm_semantic_parity"] is True
+    assert declared["trust"] == "unsigned_self_consistent"
+
+    # None of it is promoted.
+    assert diagnosis["upstream_config_parse_passed"] is False
+    assert diagnosis["model_data_load_smoke_passed"] is False
+    assert diagnosis["distributed_execution_tested"] is False
+    assert diagnosis["algorithm_semantic_parity"] is False
+    assert diagnosis["launchable"] is False
+    assert diagnosis["distributed_execution_status"] == "not tested"
+
+
+def test_locally_recomputed_checks_are_listed_separately(tmp_path: Path) -> None:
+    from miniverl.bridge.doctor import inspect_bridge_bundle
+
+    diagnosis = inspect_bridge_bundle(_lying_bundle(tmp_path))
+    local = diagnosis["locally_recomputed_checks"]
+
+    # Recomputed in this process from the bytes on disk.
+    for name in (
+        "checksum_consistency",
+        "pinned_requirement_file",
+        "config_structure",
+        "adapter_safetensors_structure",
+        "tokenizer_identity",
+        "parquet_schema",
+        "reward_interface_static",
+        "portable_metadata_privacy",
+    ):
+        assert name in local, name
+        assert local[name] in {"passed", "failed"}, name
+
+    # Never recomputed by a doctor run.
+    assert local["upstream_config_parse"] == "not_run"
+    assert local["distributed_execution"] == "not_run"
+    assert local["algorithm_semantic_parity"] == "not_run"
+
+
+def test_upstream_smoke_claim_is_not_recomputed_without_require_verl(tmp_path: Path) -> None:
+    from miniverl.bridge.doctor import inspect_bridge_bundle
+
+    diagnosis = inspect_bridge_bundle(_lying_bundle(tmp_path))
+
+    assert diagnosis["locally_recomputed_checks"]["upstream_config_parse"] == "not_run"
+    assert diagnosis["installed_verl"]["status"] in {"not installed", "unverified", "ok"}
+
+
+def test_declared_claims_are_absent_rather_than_false_when_no_report_exists(
+    tmp_path: Path,
+) -> None:
+    from miniverl.bridge.contract import VERL_TAG
+    from miniverl.bridge.doctor import inspect_bridge_bundle
+    from miniverl.bridge.export import export_verl_bundle
+
+    out = tmp_path / "export"
+    export_verl_bundle(_run(tmp_path), target_verl=VERL_TAG, out=out)
+    (out / "provenance" / "compatibility-report.json").unlink()
+    _reseal(out)
+
+    diagnosis = inspect_bridge_bundle(out)
+
+    assert diagnosis["bundle_declared_claims"]["source"] == "absent"
+    assert diagnosis["bundle_declared_claims"]["trust"] == "not_verified"
+    assert diagnosis["upstream_config_parse_passed"] is False
+
+
+def test_report_never_calls_the_bundle_trusted(tmp_path: Path) -> None:
+    from miniverl.bridge.doctor import inspect_bridge_bundle
+
+    diagnosis = inspect_bridge_bundle(_lying_bundle(tmp_path))
+    note = diagnosis["provenance_trust"]["note"].lower()
+
+    assert "internal consistency" in note
+    assert "trusted" not in diagnosis["provenance_trust"]["level"]

--- a/tests/unit/test_verl_bridge_dataset_semantics.py
+++ b/tests/unit/test_verl_bridge_dataset_semantics.py
@@ -193,7 +193,9 @@ def test_invalid_row_fails_conversion_by_default(tmp_path: Path) -> None:
         _convert(source, tmp_path / "out.parquet")
 
     message = str(excinfo.value)
-    assert "1 of 2 source row(s) failed validation" in message
+    # Streaming conversion stops at the first bad row instead of reading the
+    # rest of the file to report a total it does not need.
+    assert "source row 1 failed validation" in message
     assert "--allow-rejected-rows" in message
     assert not (tmp_path / "out.parquet").exists()
 

--- a/tests/unit/test_verl_bridge_dataset_streaming.py
+++ b/tests/unit/test_verl_bridge_dataset_streaming.py
@@ -1,0 +1,298 @@
+"""Strict sidecar input contract and streaming Parquet conversion.
+
+Two defects survived into the v0.6.3 release candidate:
+
+* an existing ``.miniverl.json`` sidecar was accepted whenever it parsed as a
+  JSON object, so ``{}``, ``{"rows": []}`` and a wrong-namespace file were all
+  silently treated as "this dataset has no extensions" -- losing provenance
+  rather than failing closed;
+* conversion called ``pq.read_table(source).to_pylist()``, materializing the
+  entire dataset and every Python object before converting a single row.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from miniverl.bridge.dataset import convert_dataset
+from miniverl.errors import ConfigError
+
+
+def _row(index: int, *, extension: Any = None) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "data_source": "calculator",
+        "prompt": [{"role": "user", "content": f"{index}+{index}"}],
+        "ability": "math",
+        "reward_model": {"style": "rule", "ground_truth": str(index * 2)},
+        "extra_info": {"split": "train"},
+    }
+    if extension is not None:
+        row["extra_info"] = {"split": "train", "miniverl": extension}
+    return row
+
+
+def _write(path: Path, rows: list[dict[str, Any]], *, row_group_size: int | None = None) -> Path:
+    table = pa.Table.from_pylist(rows)
+    if row_group_size is None:
+        pq.write_table(table, path)
+    else:
+        pq.write_table(table, path, row_group_size=row_group_size)
+    return path
+
+
+def _sidecar(path: Path, payload: Any) -> None:
+    path.with_suffix(path.suffix + ".miniverl.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+# ------------------------------------------------------------- sidecar contract
+
+
+@pytest.mark.parametrize(
+    ("name", "payload"),
+    [
+        ("empty_object", {}),
+        ("rows_is_a_list", {"schema_version": 1, "namespace": "extra_info.miniverl", "rows": []}),
+        ("missing_rows", {"schema_version": 1, "namespace": "extra_info.miniverl"}),
+        (
+            "unsupported_version",
+            {"schema_version": 999, "namespace": "extra_info.miniverl", "rows": {}},
+        ),
+        ("wrong_namespace", {"schema_version": 1, "namespace": "wrong", "rows": {}}),
+        (
+            "non_canonical_key",
+            {"schema_version": 1, "namespace": "extra_info.miniverl", "rows": {"01": {"a": 1}}},
+        ),
+        (
+            "negative_key",
+            {"schema_version": 1, "namespace": "extra_info.miniverl", "rows": {"-1": {"a": 1}}},
+        ),
+        (
+            "non_integer_key",
+            {"schema_version": 1, "namespace": "extra_info.miniverl", "rows": {"x": {"a": 1}}},
+        ),
+        (
+            "out_of_bounds_key",
+            {"schema_version": 1, "namespace": "extra_info.miniverl", "rows": {"99": {"a": 1}}},
+        ),
+        (
+            "unknown_critical_field",
+            {
+                "schema_version": 1,
+                "namespace": "extra_info.miniverl",
+                "rows": {},
+                "encryption": "aes",
+            },
+        ),
+        ("not_an_object", [1, 2, 3]),
+    ],
+)
+def test_malformed_sidecar_fails_closed(tmp_path: Path, name: str, payload: Any) -> None:
+    source = _write(tmp_path / "train.parquet", [_row(0), _row(1)])
+    _sidecar(source, payload)
+
+    with pytest.raises(ConfigError) as error:
+        convert_dataset(source, out=tmp_path / "out" / "train.parquet", direction="to-verl-parquet")
+
+    assert "sidecar" in str(error.value).lower(), name
+    assert not (tmp_path / "out" / "train.parquet").exists(), name
+
+
+def test_valid_v1_sidecar_from_a_public_release_still_reads(tmp_path: Path) -> None:
+    """Exactly the shape miniVERL 0.6.0-0.6.2 published."""
+    source = _write(tmp_path / "train.parquet", [_row(0), _row(1)])
+    _sidecar(
+        source,
+        {
+            "schema_version": 1,
+            "namespace": "extra_info.miniverl",
+            "semantics": "miniVERL token provenance and teacher targets",
+            "rows": {"0": {"teacher": "t"}},
+        },
+    )
+
+    report = convert_dataset(
+        source, out=tmp_path / "out" / "train.parquet", direction="to-verl-parquet"
+    )
+
+    assert report["accepted_rows"] == 2
+    written = pq.read_table(tmp_path / "out" / "train.parquet").to_pylist()
+    assert written[0]["extra_info"]["miniverl"] == {"teacher": "t"}
+
+
+def test_optional_v2_binding_fields_are_accepted_and_checked(tmp_path: Path) -> None:
+    from miniverl.bridge.dataset import _sha256
+
+    source = _write(tmp_path / "train.parquet", [_row(0)])
+    _sidecar(
+        source,
+        {
+            "schema_version": 1,
+            "namespace": "extra_info.miniverl",
+            "rows": {"0": {"teacher": "t"}},
+            "source_sha256": _sha256(source),
+            "source_rows": 1,
+        },
+    )
+
+    report = convert_dataset(
+        source, out=tmp_path / "out" / "train.parquet", direction="to-verl-parquet"
+    )
+
+    assert report["accepted_rows"] == 1
+
+
+def test_sidecar_bound_to_a_different_source_fails_closed(tmp_path: Path) -> None:
+    source = _write(tmp_path / "train.parquet", [_row(0)])
+    _sidecar(
+        source,
+        {
+            "schema_version": 1,
+            "namespace": "extra_info.miniverl",
+            "rows": {"0": {"teacher": "t"}},
+            "source_sha256": "0" * 64,
+        },
+    )
+
+    with pytest.raises(ConfigError) as error:
+        convert_dataset(source, out=tmp_path / "out" / "train.parquet", direction="to-verl-parquet")
+
+    assert "source_sha256" in str(error.value)
+
+
+def test_sidecar_values_are_never_printed_in_diagnostics(tmp_path: Path) -> None:
+    secret = "TEACHER_LOGIT_SECRET_123456"
+    source = _write(tmp_path / "train.parquet", [_row(0)])
+    _sidecar(
+        source,
+        {"schema_version": 1, "namespace": "extra_info.miniverl", "rows": {"5": {"t": secret}}},
+    )
+
+    with pytest.raises(ConfigError) as error:
+        convert_dataset(source, out=tmp_path / "out" / "train.parquet", direction="to-verl-parquet")
+
+    assert secret not in str(error.value)
+
+
+# ---------------------------------------------------------------- streaming
+
+
+def test_conversion_never_materializes_the_whole_table(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`read_table` reads every row group at once; conversion must not call it."""
+    source = _write(tmp_path / "train.parquet", [_row(i) for i in range(64)], row_group_size=8)
+
+    def _forbidden(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("conversion materialized the whole table via read_table")
+
+    monkeypatch.setattr(pq, "read_table", _forbidden)
+
+    report = convert_dataset(
+        source, out=tmp_path / "out" / "train.parquet", direction="to-verl-parquet"
+    )
+
+    assert report["accepted_rows"] == 64
+
+
+def test_strict_failure_stops_before_reading_later_row_groups(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    rows = [_row(index) for index in range(64)]
+    rows[9]["data_source"] = ""  # invalid, lands in the second row group
+    source = _write(tmp_path / "train.parquet", rows, row_group_size=8)
+
+    seen: list[int] = []
+    original = pq.ParquetFile.iter_batches
+
+    def _counting(self: Any, *args: Any, **kwargs: Any) -> Any:
+        for index, batch in enumerate(original(self, *args, **kwargs)):
+            seen.append(index)
+            yield batch
+
+    monkeypatch.setattr(pq.ParquetFile, "iter_batches", _counting)
+
+    with pytest.raises(ConfigError):
+        convert_dataset(source, out=tmp_path / "out" / "train.parquet", direction="to-verl-parquet")
+
+    # The whole file is 8 batches; the failure is in the second one.
+    assert len(seen) <= 2
+    assert not (tmp_path / "out" / "train.parquet").exists()
+
+
+def test_many_row_groups_convert_deterministically(tmp_path: Path) -> None:
+    source = _write(tmp_path / "train.parquet", [_row(i) for i in range(200)], row_group_size=7)
+
+    first = convert_dataset(
+        source, out=tmp_path / "a" / "train.parquet", direction="to-verl-parquet"
+    )
+    second = convert_dataset(
+        source, out=tmp_path / "b" / "train.parquet", direction="to-verl-parquet"
+    )
+
+    assert first["accepted_rows"] == 200
+    assert first["output_sha256"] == second["output_sha256"]
+
+
+def test_optional_nested_field_appearing_only_in_a_later_row_group(tmp_path: Path) -> None:
+    """Per-batch type inference would produce incompatible schemas here."""
+    rows = [_row(index) for index in range(16)]
+    for row in rows:
+        row["extra_info"] = {"split": "train", "note": None}
+    rows[15]["extra_info"] = {"split": "train", "note": "only the last row has this"}
+    source = _write(tmp_path / "train.parquet", rows, row_group_size=4)
+
+    report = convert_dataset(
+        source, out=tmp_path / "out" / "train.parquet", direction="to-verl-parquet"
+    )
+
+    assert report["accepted_rows"] == 16
+    written = pq.read_table(tmp_path / "out" / "train.parquet").to_pylist()
+    assert written[15]["extra_info"]["note"] == "only the last row has this"
+
+
+def test_partial_conversion_still_requires_the_explicit_option(tmp_path: Path) -> None:
+    rows = [_row(index) for index in range(10)]
+    rows[3]["reward_model"] = {"style": "rule"}
+    source = _write(tmp_path / "train.parquet", rows, row_group_size=4)
+
+    with pytest.raises(ConfigError):
+        convert_dataset(source, out=tmp_path / "out" / "train.parquet", direction="to-verl-parquet")
+
+    report = convert_dataset(
+        source,
+        out=tmp_path / "out" / "train.parquet",
+        direction="to-verl-parquet",
+        allow_rejected_rows=True,
+    )
+    assert report["complete_dataset_conversion"] is False
+    assert report["accepted_rows"] == 9
+    assert report["rejected_rows"] == 1
+    assert report["source_row_indices"]["3"] == 4
+
+
+def test_rejection_detail_is_bounded(tmp_path: Path) -> None:
+    from miniverl.bridge.dataset import MAX_REPORTED_REJECTIONS
+
+    rows = [_row(index) for index in range(MAX_REPORTED_REJECTIONS + 40)]
+    for row in rows[:-1]:
+        row["data_source"] = ""  # valid Arrow type, invalid per the prompt schema
+    source = _write(tmp_path / "train.parquet", rows, row_group_size=16)
+
+    report = convert_dataset(
+        source,
+        out=tmp_path / "out" / "train.parquet",
+        direction="to-verl-parquet",
+        allow_rejected_rows=True,
+    )
+
+    assert report["rejected_rows"] == MAX_REPORTED_REJECTIONS + 39
+    assert len(report["rejections"]) == MAX_REPORTED_REJECTIONS
+    assert report["rejections_truncated"] is True

--- a/tests/unit/test_verl_bridge_doctor_levels.py
+++ b/tests/unit/test_verl_bridge_doctor_levels.py
@@ -248,7 +248,7 @@ def test_default_doctor_never_claims_dataset_or_weight_inspection(tmp_path: Path
 
     payload = inspect_bridge_bundle(_bundle(tmp_path))
     assert payload["verdict"] == "ok"
-    assert payload["portable_metadata_privacy"] == "passed"
+    assert payload["portable_metadata_privacy"] == "heuristic_passed"
     assert payload["dataset_content_privacy"] == "not_inspected"
     assert payload["model_weight_privacy"] == "not_inspected"
     privacy = payload["privacy"]
@@ -329,7 +329,7 @@ def test_privacy_report_serializes_as_canonical_machine_json(tmp_path: Path) -> 
 
     payload = inspect_bridge_bundle(_bundle(tmp_path), scan_dataset_text=True)
     restored = json.loads(canonical_json(payload))
-    assert restored["privacy"]["portable_metadata_privacy"] == "passed"
+    assert restored["privacy"]["portable_metadata_privacy"] == "heuristic_passed"
     assert restored["privacy"]["model_weight_privacy"] == "not_inspected"
     assert restored["tokenizer_identity"]["verification_level"] == "metadata_only"
 
@@ -340,6 +340,6 @@ def test_metadata_privacy_failure_is_scoped_to_metadata(tmp_path: Path) -> None:
     bundle = _bundle(tmp_path)
     (bundle / "recipe" / "leak.txt").write_text("C:\\Users\\someone\\secret", encoding="utf-8")
     payload = inspect_bridge_bundle(bundle)
-    assert payload["portable_metadata_privacy"] == "failed"
+    assert payload["portable_metadata_privacy"] == "heuristic_failed"
     assert payload["dataset_content_privacy"] == "not_inspected"
     assert payload["privacy"]["problems"] == ["recipe/leak.txt"]

--- a/tests/unit/test_verl_bridge_export.py
+++ b/tests/unit/test_verl_bridge_export.py
@@ -136,7 +136,7 @@ def test_export_verl_emits_a_fail_closed_bundle_and_doctor_verifies_artifacts(
     assert diagnosis["parquet_schema"]["status"] == "ok"
     assert diagnosis["reward_scaffold_interface"]["status"] == "ok"
     # The exported scaffold is verified without ever being imported.
-    assert diagnosis["reward_verification_level"] == "interface_statically_verified"
+    assert diagnosis["reward_verification_level"] == "interface_shape_verified"
     assert diagnosis["reward_code_executed"] is False
     # The payload is validated structurally with no optional dependency; the
     # materialization level is only reachable where the official reader runs,

--- a/tests/unit/test_verl_bridge_hostile_bundles.py
+++ b/tests/unit/test_verl_bridge_hostile_bundles.py
@@ -113,7 +113,7 @@ def test_untampered_bundle_passes(bundle: Path) -> None:
     report = _inspect(bundle)
     assert report["verdict"] == "ok"
     assert report["artifact_hashes"]["status"] == "ok"
-    assert report["reward_verification_level"] == "interface_statically_verified"
+    assert report["reward_verification_level"] == "interface_shape_verified"
     assert report["reward_code_executed"] is False
 
 
@@ -312,4 +312,4 @@ def test_trusted_import_is_never_reached_through_require_verl(bundle: Path, tmp_
     assert not marker.exists()
     assert report["reward_code_executed"] is False
     # A clean interface still verifies statically; the body is never run.
-    assert report["reward_verification_level"] == "interface_statically_verified"
+    assert report["reward_verification_level"] == "interface_shape_verified"

--- a/tests/unit/test_verl_bridge_metadata_privacy.py
+++ b/tests/unit/test_verl_bridge_metadata_privacy.py
@@ -1,0 +1,198 @@
+"""Portable metadata privacy covers credentials, not only absolute paths.
+
+Up to the v0.6.3 release candidate the default metadata scan ran exactly one
+detector -- an absolute-path regex -- so a manifest carrying an API key, a
+bearer token and a database URL with inline credentials passed as
+``portable_metadata_privacy: passed``.
+
+Every value below is a fabricated test fixture, not a real credential.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+FAKE_API_KEY = "FAKE_SUPER_SECRET_1234567890"
+FAKE_BEARER = "Bearer abcdefghijklmnopqrstuvwxyz012345"
+FAKE_DB_URL = "postgresql://user:password@example.com/db"
+FAKE_AWS = "AKIAIOSFODNN7EXAMPLE"
+
+
+def _scan(root: Path, **kwargs: Any) -> dict[str, Any]:
+    from miniverl.bridge.doctor import _check_privacy
+
+    return _check_privacy(root, **kwargs)
+
+
+def _bundle(tmp_path: Path, payload: dict[str, Any]) -> Path:
+    provenance = tmp_path / "provenance"
+    provenance.mkdir(parents=True, exist_ok=True)
+    (provenance / "miniverl-manifest.json").write_text(json.dumps(payload), encoding="utf-8")
+    return tmp_path
+
+
+# --------------------------------------------------------------- structured data
+
+
+def test_credentials_in_json_metadata_are_detected(tmp_path: Path) -> None:
+    root = _bundle(
+        tmp_path,
+        {
+            "api_key": FAKE_API_KEY,
+            "authorization": FAKE_BEARER,
+            "database_url": FAKE_DB_URL,
+        },
+    )
+
+    privacy = _scan(root)
+
+    assert privacy["portable_metadata_privacy"] == "heuristic_failed"
+    assert privacy["status"] == "fail"
+    categories = {finding["category"] for finding in privacy["metadata_scan"]["findings"]}
+    assert "semantic_secret_key" in categories
+    assert "url_userinfo" in categories
+
+
+def test_findings_report_the_json_path_but_never_the_value(tmp_path: Path) -> None:
+    root = _bundle(tmp_path, {"nested": {"credentials": {"api_key": FAKE_API_KEY}}})
+
+    privacy = _scan(root)
+    findings = privacy["metadata_scan"]["findings"]
+
+    assert findings
+    assert any(finding["path"] == "$.nested.credentials.api_key" for finding in findings)
+    assert FAKE_API_KEY not in json.dumps(privacy)
+
+
+def test_secret_inside_a_list_reports_an_indexed_path(tmp_path: Path) -> None:
+    root = _bundle(tmp_path, {"items": [{"token": FAKE_API_KEY}]})
+
+    privacy = _scan(root)
+
+    assert any(
+        finding["path"] == "$.items[0].token" for finding in privacy["metadata_scan"]["findings"]
+    )
+
+
+def test_aws_style_key_in_a_value_is_detected(tmp_path: Path) -> None:
+    root = _bundle(tmp_path, {"note": f"deploy with {FAKE_AWS} please"})
+
+    privacy = _scan(root)
+
+    categories = {finding["category"] for finding in privacy["metadata_scan"]["findings"]}
+    assert "aws_access_key_id" in categories
+    assert FAKE_AWS not in json.dumps(privacy)
+
+
+def test_yaml_metadata_is_scanned_too(tmp_path: Path) -> None:
+    recipe = tmp_path / "recipe"
+    recipe.mkdir(parents=True)
+    (recipe / "verl-overrides.yaml").write_text(f"trainer:\n  api_key: {FAKE_API_KEY}\n", "utf-8")
+
+    privacy = _scan(tmp_path)
+
+    assert privacy["portable_metadata_privacy"] == "heuristic_failed"
+    assert any(
+        finding["path"] == "$.trainer.api_key" for finding in privacy["metadata_scan"]["findings"]
+    )
+
+
+# ------------------------------------------------------------- unstructured text
+
+
+def test_markdown_secret_reports_a_line_number_not_the_value(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text(
+        f"# Bundle\n\nRun with\n\n    export API_TOKEN={FAKE_API_KEY}\n", encoding="utf-8"
+    )
+
+    privacy = _scan(tmp_path)
+    findings = privacy["metadata_scan"]["findings"]
+
+    assert findings
+    assert all(finding.get("line") != 0 for finding in findings)
+    assert FAKE_API_KEY not in json.dumps(privacy)
+
+
+def test_absolute_local_path_is_still_detected(tmp_path: Path) -> None:
+    (tmp_path / "notes.txt").write_text("saved to C:\\Users\\someone\\secret\n", encoding="utf-8")
+
+    privacy = _scan(tmp_path)
+
+    categories = {finding["category"] for finding in privacy["metadata_scan"]["findings"]}
+    assert "absolute_local_path" in categories
+
+
+def test_user_sentinels_are_honoured(tmp_path: Path) -> None:
+    root = _bundle(tmp_path, {"comment": "contains CANARY-99 somewhere"})
+
+    privacy = _scan(root, sentinels=("CANARY-99",))
+
+    categories = {finding["category"] for finding in privacy["metadata_scan"]["findings"]}
+    assert "user_sentinel" in categories
+    assert "CANARY-99" not in json.dumps(privacy)
+
+
+# ------------------------------------------------------------------------ bounds
+
+
+def test_clean_metadata_passes_with_the_heuristic_name(tmp_path: Path) -> None:
+    root = _bundle(tmp_path, {"run_id": "fixture", "model_id": "Qwen/Qwen3-0.6B"})
+
+    privacy = _scan(root)
+
+    assert privacy["portable_metadata_privacy"] == "heuristic_passed"
+    assert privacy["status"] == "ok"
+    assert privacy["metadata_scan"]["findings"] == []
+    assert "de-identification" in privacy["metadata_scan"]["method"]
+
+
+def test_oversized_metadata_file_is_skipped_and_recorded(tmp_path: Path) -> None:
+    from miniverl.bridge.doctor import METADATA_MAX_FILE_BYTES
+
+    (tmp_path / "huge.txt").write_text("A" * (METADATA_MAX_FILE_BYTES + 10), encoding="utf-8")
+
+    privacy = _scan(tmp_path)
+
+    assert privacy["metadata_scan"]["files_skipped_too_large"] == 1
+    assert privacy["metadata_scan"]["scan_scope"] == "sampled"
+
+
+def test_findings_are_bounded(tmp_path: Path) -> None:
+    from miniverl.bridge.doctor import METADATA_MAX_FINDINGS
+
+    payload = {
+        f"entry_{index}": {"api_key": FAKE_API_KEY} for index in range(METADATA_MAX_FINDINGS + 50)
+    }
+    root = _bundle(tmp_path, payload)
+
+    privacy = _scan(root)
+
+    assert len(privacy["metadata_scan"]["findings"]) <= METADATA_MAX_FINDINGS
+    assert privacy["metadata_scan"]["findings_truncated"] is True
+
+
+def test_binary_payloads_are_never_read_as_text(tmp_path: Path) -> None:
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "train.parquet").write_bytes(b"PAR1" + FAKE_API_KEY.encode() + b"PAR1")
+    (tmp_path / "model").mkdir()
+    (tmp_path / "model" / "adapter_model.safetensors").write_bytes(b"\x00" * 32)
+
+    privacy = _scan(tmp_path)
+
+    assert privacy["portable_metadata_privacy"] == "heuristic_passed"
+    assert privacy["dataset_content_privacy"] == "not_inspected"
+    assert privacy["model_weight_privacy"] == "not_inspected"
+
+
+@pytest.mark.parametrize("scope", ["dataset_content_privacy", "model_weight_privacy"])
+def test_uninspected_scopes_never_become_passed(tmp_path: Path, scope: str) -> None:
+    root = _bundle(tmp_path, {"run_id": "fixture"})
+
+    privacy = _scan(root)
+
+    assert privacy[scope] == "not_inspected"

--- a/tests/unit/test_verl_bridge_reward_definition_time.py
+++ b/tests/unit/test_verl_bridge_reward_definition_time.py
@@ -1,0 +1,237 @@
+"""Definition-time expressions and signature contracts the v0.6.3 RC accepted.
+
+Every source below was accepted by the pre-fix static policy with
+``status: ok``, ``findings: []`` and the strongest default level, even though
+importing the module would have run ``exploit()``. The static checker never
+executes any of it -- these tests assert that the checker *names* what would
+run, and that the marker file is never created while doing so.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from miniverl.bridge.reward_static import inspect_reward_scaffold
+
+PRELUDE = """\
+from pathlib import Path
+
+
+def exploit():
+    Path("PWNED.txt").write_text("executed", encoding="utf-8")
+    return object
+
+
+"""
+
+VALID = """\
+def compute_score(data_source, solution_str, ground_truth, extra_info=None):
+    return 0.0
+"""
+
+
+def _inspect(tmp_path: Path, source: str) -> dict:
+    target = tmp_path / "reward_or_verifier_scaffold.py"
+    target.write_text(source, encoding="utf-8")
+    check = inspect_reward_scaffold(target)
+    # No inspection may ever run the file, whatever the verdict is.
+    assert not (tmp_path / "PWNED.txt").exists()
+    assert check["code_executed"] is False
+    assert check["untrusted_code_executed"] is False
+    return check
+
+
+def _categories(check: dict) -> set[str]:
+    return {finding["category"] for finding in check["findings"]}
+
+
+# --------------------------------------------------- definition-time expressions
+
+
+@pytest.mark.parametrize(
+    ("name", "source", "category"),
+    [
+        (
+            "class_base",
+            PRELUDE + "class Hidden(exploit()):\n    pass\n\n\n" + VALID,
+            "class_base_executes",
+        ),
+        (
+            "class_metaclass",
+            PRELUDE + "class Hidden(object, metaclass=exploit()):\n    pass\n\n\n" + VALID,
+            "class_keyword_executes",
+        ),
+        (
+            "parameter_annotation",
+            PRELUDE + "def compute_score(data_source: exploit(), solution_str, ground_truth,"
+            " extra_info=None):\n    return 0.0\n",
+            "annotation_executes",
+        ),
+        (
+            "return_annotation",
+            PRELUDE + "def compute_score(data_source, solution_str, ground_truth,"
+            " extra_info=None) -> exploit():\n    return 0.0\n",
+            "annotation_executes",
+        ),
+        (
+            "annotated_assignment",
+            PRELUDE + "VALUE: exploit() = 1\n\n\n" + VALID,
+            "annotation_executes",
+        ),
+        (
+            "class_body_annotation",
+            PRELUDE + "class Hidden:\n    VALUE: exploit() = 1\n\n\n" + VALID,
+            "annotation_executes",
+        ),
+        (
+            "nested_call_in_base",
+            PRELUDE + "class Hidden(tuple([exploit()])):\n    pass\n\n\n" + VALID,
+            "class_base_executes",
+        ),
+    ],
+)
+def test_definition_time_expression_is_rejected(
+    tmp_path: Path, name: str, source: str, category: str
+) -> None:
+    check = _inspect(tmp_path, source)
+
+    assert check["status"] == "fail", name
+    assert category in _categories(check), name
+
+
+def test_plain_type_annotations_remain_acceptable(tmp_path: Path) -> None:
+    """A normal annotated scaffold must not be collateral damage."""
+    check = _inspect(
+        tmp_path,
+        "from typing import Any\n\n\n"
+        "def compute_score(\n"
+        "    data_source: str,\n"
+        "    solution_str: str,\n"
+        "    ground_truth: str,\n"
+        "    extra_info: dict[str, Any] | None = None,\n"
+        ") -> float:\n"
+        "    return 0.0\n",
+    )
+
+    assert check["status"] == "ok"
+    assert check["findings"] == []
+
+
+def test_benign_class_base_remains_acceptable(tmp_path: Path) -> None:
+    check = _inspect(tmp_path, "class Scorer(object):\n    pass\n\n\n" + VALID)
+
+    assert check["status"] == "ok"
+
+
+# ------------------------------------------------------------ signature contract
+
+
+def test_required_keyword_only_extra_info_is_rejected(tmp_path: Path) -> None:
+    """verl may call with three positional arguments, so this would TypeError."""
+    check = _inspect(
+        tmp_path,
+        "def compute_score(data_source, solution_str, ground_truth, *, extra_info):\n"
+        "    return 0.0\n",
+    )
+
+    assert check["status"] == "fail"
+    assert "signature_mismatch" in _categories(check)
+
+
+def test_unknown_keyword_only_parameter_is_rejected(tmp_path: Path) -> None:
+    check = _inspect(
+        tmp_path,
+        "def compute_score(data_source, solution_str, ground_truth, *, other=1):\n    return 0.0\n",
+    )
+
+    assert check["status"] == "fail"
+    assert "signature_mismatch" in _categories(check)
+
+
+def test_keyword_only_extra_info_with_a_default_is_accepted(tmp_path: Path) -> None:
+    check = _inspect(
+        tmp_path,
+        "def compute_score(data_source, solution_str, ground_truth, *, extra_info=None):\n"
+        "    return 0.0\n",
+    )
+
+    assert check["status"] == "ok"
+
+
+# ------------------------------------------------------------------- terminology
+
+
+def test_the_strongest_default_level_does_not_claim_import_safety(tmp_path: Path) -> None:
+    check = _inspect(tmp_path, VALID)
+
+    assert check["status"] == "ok"
+    assert check["verification_level"] == "interface_shape_verified"
+    detail = check["detail"].lower()
+    assert "safe to import" not in detail
+    assert "not executed" in detail or "were not executed" in detail
+    assert check["import_runtime_safety"] == "not_verified"
+
+
+def test_imports_are_recorded_but_never_called_verified(tmp_path: Path) -> None:
+    check = _inspect(tmp_path, "import json\nimport os.path\n\n\n" + VALID)
+
+    assert check["status"] == "ok"
+    assert check["imports_present"] == ["json", "os.path"]
+    assert check["import_runtime_safety"] == "not_verified"
+
+
+def test_relative_bundle_local_import_is_rejected(tmp_path: Path) -> None:
+    check = _inspect(tmp_path, "from . import helper\n\n\n" + VALID)
+
+    assert check["status"] == "fail"
+    assert "relative_import" in _categories(check)
+
+
+# ----------------------------------------------------------------- hostile bounds
+
+
+def test_oversized_source_is_bounded_not_parsed(tmp_path: Path) -> None:
+    check = _inspect(tmp_path, "# " + "A" * (2 * 1024 * 1024) + "\n" + VALID)
+
+    assert check["status"] == "fail"
+    assert "source_too_large" in _categories(check)
+    assert check["verification_level"] == "not_present"
+
+
+def test_pathologically_nested_source_is_bounded(tmp_path: Path) -> None:
+    depth = 400
+    source = "VALUE = " + "[" * depth + "]" * depth + "\n\n\n" + VALID
+    check = _inspect(tmp_path, source)
+
+    assert check["status"] == "fail"
+    assert {"ast_too_deep", "ast_too_large", "syntax_error"} & _categories(check)
+
+
+def test_findings_are_bounded(tmp_path: Path) -> None:
+    source = "".join(f"call_{index}()\n" for index in range(500)) + "\n\n" + VALID
+    check = _inspect(tmp_path, source)
+
+    assert check["status"] == "fail"
+    assert len(check["findings"]) <= 50
+    assert check["findings_truncated"] is True
+
+
+def test_undecodable_source_fails_closed(tmp_path: Path) -> None:
+    target = tmp_path / "reward_or_verifier_scaffold.py"
+    target.write_bytes(b"\xff\xfe\x00invalid utf-8 \xc3\x28\n")
+
+    check = inspect_reward_scaffold(target)
+
+    assert check["status"] == "fail"
+    assert "encoding_error" in _categories(check)
+    assert check["code_executed"] is False
+
+
+def test_findings_do_not_echo_source_content(tmp_path: Path) -> None:
+    secret = "SUPER_SECRET_VALUE_9876543210"
+    check = _inspect(tmp_path, PRELUDE + f'TOKEN = exploit_call("{secret}")\n\n\n' + VALID)
+
+    assert check["status"] == "fail"
+    assert secret not in repr(check)

--- a/tests/unit/test_verl_bridge_reward_static.py
+++ b/tests/unit/test_verl_bridge_reward_static.py
@@ -119,7 +119,7 @@ def test_generated_scaffold_verifies_statically(tmp_path: Path) -> None:
     check = inspect_reward_scaffold(path)
 
     assert check["status"] == "ok"
-    assert check["verification_level"] == "interface_statically_verified"
+    assert check["verification_level"] == "interface_shape_verified"
     assert check["findings"] == []
     assert check["code_executed"] is False
     assert check["signature"] == [


### PR DESCRIPTION
Final correctness and trust-boundary pass before `v0.6.3` is tagged. Every
defect below was reproduced against `b769251` first; the reproducers are kept as
regressions.

## The static reward verifier accepted definition-time code

PR #45 stopped `bridge doctor` importing an untrusted reward scaffold, but the
static policy only audited decorators and default arguments. Everything else
that runs when a module is imported passed with `status: ok`, `findings: []` and
the strongest level:

```python
def exploit():
    Path("PWNED.txt").write_text("executed")
    return object

class Hidden(exploit()):          # accepted, no finding
    pass
```

Class bases, `metaclass=` and other class keywords, parameter and return
annotations, annotated-assignment annotations and Python 3.12 type-parameter
bounds are now audited. Only expressions that actually evaluate — calls,
lambdas, comprehensions, `await`, walrus — are rejected, so ordinary
annotations such as `-> float` and bases such as `(object)` still pass.

Keyword-only parameters were never inspected either, so this passed as a
verified interface despite raising `TypeError` on verl's three-argument call:

```python
def compute_score(data_source, solution_str, ground_truth, *, extra_info): ...
```

The strongest default level is renamed `interface_statically_verified` →
`interface_shape_verified`: the old name read as a safety claim the check
cannot make. Imports are listed with `import_runtime_safety: not_verified`,
relative bundle-local imports are refused, and source bytes, AST nodes, AST
depth and finding count are bounded so a hostile file yields a bounded
diagnostic. 20 new regressions; none of them ever creates the marker file.

## A bundle's claims were reported as results

The doctor read `upstream_config_parse_passed`, `distributed_execution_tested`
and `algorithm_semantic_parity` out of the bundle's own
`compatibility-report.json` and exposed them as top-level fields.
`provenance/SHA256SUMS` ships inside the bundle it describes, so anyone who
edits a claim can reseal it — the test builds exactly that bundle.

Output is now split into `bundle_declared_claims` (testimony,
`trust: unsigned_self_consistent`), `locally_recomputed_checks` (this process,
against bytes on disk) and `provenance_trust`
(`signature_verification: not_available`). Top-level flags reflect only what was
recomputed. `--require-verl` now performs the upstream OmegaConf parse and
structured merge locally instead of comparing an installed commit id.

## Portable metadata privacy ran one regex

A manifest holding an API key, a bearer token and a database URL with inline
credentials passed, because the only detector was an absolute-path pattern.
Structured JSON/YAML is now walked so a finding names a JSON path
(`$.nested.credentials.api_key`), unstructured text reports a line number, and
the scan is bounded by file size, total bytes and finding count. Matched text is
still never returned. Status is `heuristic_passed`/`heuristic_failed` — it is a
detector, not de-identification proof.

## Malformed sidecars were read as empty

`{}`, `{"rows": []}`, a wrong namespace and `schema_version: 999` were all
accepted as "this dataset has no extensions", silently discarding the provenance
the sidecar exists to carry. Schema version, exact namespace, a `rows` mapping,
canonical integer keys within the source row count, JSON-compatible values,
unknown top-level fields and optional `source_sha256`/`source_rows` binding are
now validated. Sidecars published by 0.6.0–0.6.2 still read. Diagnostics name
the location, never the payload.

## Conversion materialized the whole dataset

`convert-dataset` called `pq.read_table(source).to_pylist()`. It now streams
record batches through a `ParquetWriter`, with the output schema derived once
from the source schema so an optional nested field appearing only in a later
row group cannot produce a second incompatible schema. Publication still happens
only at commit, so strict conversion stays complete-or-nothing, and a rejected
row stops the run before the next row group is read — both proven by
instrumented tests that fail if `read_table` is called or if a later batch is
fetched.

## Text integrity

`docs/release-checklist.md` shipped `— not applicable` and `CHANGELOG.md`
shipped `base → SFT` as GBK-mangled sequences; three files carried a BOM. The
result is valid UTF-8, so nothing ever raised. All repaired, and
`scripts/check_text_integrity.py` now gates CI on the mis-decoding leaders,
U+FFFD and unexpected BOMs. Its allowlist is exactly two files: the detector and
its own tests, which must spell the sequences out.

## Validation

| Gate | Result |
| --- | --- |
| CPU (`not gpu and not network`) | 1830 passed, 2 skipped, 6 deselected |
| Branch coverage | 86.10% |
| GPU (RTX 4080) | 5 passed |
| Network | 3 passed |
| ruff / format / mypy | clean, 107 source files |
| `mkdocs build --strict` | clean |
| Browser visual gate | 28 rendered SVG instances across 4 viewports |
| Frozen artifacts | all byte-identical |

No frozen scientific result, task JSONL or published adapter is touched. No new
benchmark, algorithm, distributed claim or OPD/PPO parity claim is added. Issue
#39 remains out of scope.
