### PR TITLE
Start v0.6.4 development and record the v0.6.3 release evidence

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ title: "miniVERL: Auditable single-GPU alignment and distillation runtime"
 message: "If you use miniVERL in your work, please cite it as below."
 type: software
 version: 0.6.3
-date-released: 2026-08-05
+date-released: 2026-08-06
 license: Apache-2.0
 repository-code: "https://github.com/DaoyuanLi2816/mini-verl"
 url: "https://github.com/DaoyuanLi2816/mini-verl"

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -6,7 +6,7 @@ and what it printed.
 
 Last updated: 2026-08-05.
 
-Canonical release state: releasing `v0.6.3`.
+Canonical release state: stable `v0.6.3` (`005a4549da713716e64c3ae80ff55fb131519f79`), development `0.6.4.dev0`.
 Every public version claim is generated from `release-state.yaml` and gated by
 `python scripts/release_state.py --check`.
 

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.3/docs/banner.svg" alt="miniVERL — single-GPU LLM post-training" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — single-GPU LLM post-training" width="880">
 </p>
 
 <div align="center">
@@ -8,7 +8,7 @@
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE)
 
 </div>
 
@@ -16,7 +16,7 @@
   <a href="https://pypi.org/project/miniverl/"><strong>PyPI</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/"><strong>Stable docs</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/dev/">Development docs</a> ·
-  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/README.zh-CN.md">中文</a>
+  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/main/README.zh-CN.md">中文</a>
 </p>
 
 **miniVERL is a local, inspectable runtime for a documented subset of
@@ -44,15 +44,15 @@ optimization in about 50 seconds on the measured laptop CPU. For inspection,
 schemas and reports without the ML stack, use `pip install miniverl`. For CUDA
 training, install the matching CUDA-enabled PyTorch wheel first, then install
 `miniverl[train,cuda]`; the extra does not select a CUDA PyTorch build. See the
-[single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/docs/single-gpu-guide.md).
+[single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md).
 
 ## Three paths
 
 | Path | Start with | Concrete artifact | Next |
 | --- | --- | --- | --- |
-| **Align** — compare SFT, DPO, KD and OPD only when the pilot evidence supports the cost | `miniverl pilot recipes/alignment_policy_conditioned_qwen.yaml` | `alignment-card.json` | [Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/docs/alignment-lab/alignment-lab-v1.md) |
-| **Distill locally** — strict OPD, shared backbones and padded trajectory updates on one CUDA GPU | `miniverl train recipes/qwen_consumer_gpu_shared.yaml --dry-run` | `config.resolved.yaml` plus a revision-pinned PEFT adapter | [Bring your own GPU](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/docs/single-gpu-guide.md) |
-| **Scale out** — import a documented profile, convert Parquet, export a bundle and run bridge checks | `miniverl bridge doctor scaleout-bundle` | `provenance/compatibility-report.json` | [Verified verl artifact bridge](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/docs/verl-bridge.md) |
+| **Align** — compare SFT, DPO, KD and OPD only when the pilot evidence supports the cost | `miniverl pilot recipes/alignment_policy_conditioned_qwen.yaml` | `alignment-card.json` | [Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md) |
+| **Distill locally** — strict OPD, shared backbones and padded trajectory updates on one CUDA GPU | `miniverl train recipes/qwen_consumer_gpu_shared.yaml --dry-run` | `config.resolved.yaml` plus a revision-pinned PEFT adapter | [Bring your own GPU](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) |
+| **Scale out** — import a documented profile, convert Parquet, export a bundle and run bridge checks | `miniverl bridge doctor scaleout-bundle` | `provenance/compatibility-report.json` | [Verified verl artifact bridge](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md) |
 
 The bridge is a **verified artifact bridge**: a pinned config/data/model
 parse-load smoke at miniVERL-defined compatibility Level 3. It has never run a
@@ -94,12 +94,12 @@ improved it; continued SFT and both OPD variants retained measured regressions.
 | standard OPD | 98.6% | 97.2% | 100.0% | 76.7 s |
 | verifier-gated OPD | 97.9% | 95.8% | 46.8% | 66.0 s |
 
-![Alignment and utility deltas from the saturated SFT checkpoint; small marks are all three seeds and large marks are means](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.3/docs/alignment-lab/delta-from-sft.svg)
+![Alignment and utility deltas from the saturated SFT checkpoint; small marks are all three seeds and large marks are means](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/alignment-lab/delta-from-sft.svg)
 
 The two sandbox safety checks tied at zero while utility still regressed.
 IFEval, XSTest, HarmBench and RewardBench were **not executed**. “Preference
 win rate” is a deterministic Minipolicy paired outcome, not human preference.
-Read the [study, seed-level values and limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/docs/alignment-lab/alignment-lab-v1.md).
+Read the [study, seed-level values and limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md).
 
 ## One measured systems result
 
@@ -110,13 +110,13 @@ reserved memory versus 3.035 GiB for dual model, while running 10.1% slower.
 All 12 preregistered equivalence comparisons passed. These are one-workload,
 one-machine measurements, not promises for other GPUs.
 
-![Measured throughput and reserved VRAM for dual-model and shared-backbone runtime cells](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.3/docs/consumer-runtime-v1-pareto.svg)
+![Measured throughput and reserved VRAM for dual-model and shared-backbone runtime cells](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/consumer-runtime-v1-pareto.svg)
 
-[Consumer Runtime v1 methods and caveats](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/docs/consumer-runtime-v1.md)
+[Consumer Runtime v1 methods and caveats](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/consumer-runtime-v1.md)
 
 ## Compatibility boundary
 
-![Verified local runtime, portable artifact bundle and pinned upstream smoke; distributed verl execution remains untested](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.6.3/docs/verl-bridge-architecture.svg)
+![Verified local runtime, portable artifact bundle and pinned upstream smoke; distributed verl execution remains untested](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-bridge-architecture.svg)
 
 The bridge targets official verl `v0.8.0` at commit `7aed6b23` and uses the
 term **miniVERL-defined compatibility Level 3**. That means a checksummed
@@ -133,21 +133,21 @@ PPO/reward scaffold, not an executable continuation of miniVERL OPD semantics.
 
 ## Detailed studies and preserved negative evidence
 
-- [RecoveryBench v1](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/docs/recoverybench/recoverybench-v1.md): frozen-student KD
+- [RecoveryBench v1](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md): frozen-student KD
   outperformed much slower fresh-state OPD on the preregistered primary view;
   the verifier gate remained `insufficient_evidence`.
-- [Alignment Lab v1](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/docs/alignment-lab/alignment-lab-v1.md): the starting SFT
+- [Alignment Lab v1](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md): the starting SFT
   checkpoint was at the ceiling, so no positive OPD result is claimed.
-- [Calculator benchmark](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/docs/benchmarking.md): both negative controls completed
+- [Calculator benchmark](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md): both negative controls completed
   normally and measured 0% strict success. They were not configuration
   failures. Because they used the historical ambiguous protocol-v1 prompt,
   their failure cannot be attributed solely to intrinsic teacher behavior.
-- [Consumer Runtime v1](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/docs/consumer-runtime-v1.md): padded update batches and
+- [Consumer Runtime v1](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/consumer-runtime-v1.md): padded update batches and
   shared adapters preserve the measured one-update objective within declared
   tolerances; rollout generation remains sequential.
-- [Limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/docs/limitations.md), [math](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/docs/math.md),
-  [reproducibility](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/docs/reproducibility.md) and
-  [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/docs/compatibility.md).
+- [Limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md), [math](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/math.md),
+  [reproducibility](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/reproducibility.md) and
+  [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md).
 
 New runs establish tokenizer compatibility through structural identity. The
 legacy behavioral fingerprint—token IDs for one fixed probe plus metadata—is
@@ -167,7 +167,7 @@ python -m pip install -e ".[dev]"
 pytest -q -m "not gpu and not network"
 ```
 
-Apache-2.0 licensed. See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/CONTRIBUTING.md) and
-[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/SECURITY.md). Project records: [default GPU recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/recipes/qwen_consumer_gpu_calc.yaml),
-[frozen calculator JSON](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/benchmarks/results/gpu-calc-hard-equal-update-v2.json),
-[changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/CHANGELOG.md), [citation](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/CITATION.cff) and [license](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.6.3/LICENSE).
+Apache-2.0 licensed. See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md) and
+[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md). Project records: [default GPU recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/main/recipes/qwen_consumer_gpu_calc.yaml),
+[frozen calculator JSON](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/results/gpu-calc-hard-equal-update-v2.json),
+[changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md), [citation](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff) and [license](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE).

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "release": "0.6.3",
-  "status": "validated",
+  "status": "released",
   "measured_commit": "e8a36db60b2146b684204df8a8bea3e20c11d8e4",
   "measured_at": "2026-08-05T18:20:00-07:00",
   "platform": "Windows 11 Pro 10.0.22631, CPython 3.12, coverage branch mode",

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  <div class="docs-channel" data-stable-version="0.6.3" data-dev-version="0.6.3">
+  <div class="docs-channel" data-stable-version="0.6.3" data-dev-version="0.6.4.dev0">
     <strong id="docs-channel-label">Stable documentation</strong>
     <label for="docs-version-selector">Version</label>
     <select id="docs-version-selector" aria-label="Documentation version">
       <option value="stable">Stable 0.6.3</option>
-      <option value="dev">Development 0.6.3</option>
+      <option value="dev">Development 0.6.4.dev0</option>
     </select>
   </div>
 {% endblock %}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,6 +4,14 @@ This is the release gate and publication record for miniVERL. A checked item
 names an invariant exercised on the stated source. Publication begins only
 after the exact release commit and its remote checks are green.
 
+## v0.6.4 (in development)
+
+- [ ] A reward scaffold saved with a UTF-8 byte-order mark parses instead of
+      being reported as a syntax error. CPython strips the BOM when it reads a
+      source file; the static checker did not, so a scaffold written by a
+      Windows editor was refused as unparseable. Found while verifying the
+      published v0.6.3 wheel.
+
 ## v0.6.3 Security, artifact integrity and release-state hardening
 
 - [x] `bridge doctor` executes zero Python from the inspected bundle by
@@ -37,6 +45,24 @@ after the exact release commit and its remote checks are green.
 - [x] Transactional wording is limited to in-process rollback; no multi-file
       crash atomicity is claimed.
 - [x] Every frozen scientific artifact remains byte-identical.
+
+### After the v0.6.3 tag
+
+- [x] Annotated tag `v0.6.3` resolves to release commit
+      `005a4549da713716e64c3ae80ff55fb131519f79`; release run
+      [`31084165317`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31084165317)
+      completed OIDC Trusted Publishing and GitHub Release creation.
+- [x] PyPI and the GitHub Release expose identical files. Wheel SHA-256
+      `1c620c310e8e4156f515d52128a0f26a037096347a2bc105c63f173e6563f5e0`,
+      sdist SHA-256
+      `b93d2fad63432ecd680b72fe0bf79f6b0be212af1aab82780ed8e31636edeefe`.
+- [x] The PyPI integrity API exposes one Trusted Publisher attestation bundle
+      per distribution, bound to `DaoyuanLi2816/mini-verl` and `release.yml`.
+- [x] A clean Windows Python 3.12 install from `https://pypi.org/simple`
+      reported `miniverl 0.6.3`, kept torch absent, and refused to execute a
+      hostile reward scaffold: the top-level marker write never ran and the
+      doctor reported `top_level_call` with `code_executed: false`.
+- [x] This separate state-sync change advances development to `0.6.4.dev0`.
 
 ## v0.6.1 Visual integrity and bridge correctness release
 

--- a/release-state.yaml
+++ b/release-state.yaml
@@ -17,15 +17,13 @@
 # such distinction, which is how its tag shipped a docs selector still
 # advertising "Stable 0.6.1 / Development 0.6.2.dev0".
 schema_version: 1
-phase: release
+phase: development
 
 stable:
   version: "0.6.3"
   tag: "v0.6.3"
-  # This tree is the release, so it cannot name its own merge commit yet. The
-  # post-release state-sync replaces this with the exact tagged SHA.
-  release_commit: "pending"
-  released_at: "2026-08-05"
+  release_commit: "005a4549da713716e64c3ae80ff55fb131519f79"
+  released_at: "2026-08-06"
 
 development:
-  version: "0.6.3"
+  version: "0.6.4.dev0"

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.6.3"
+__version__ = "0.6.4.dev0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
`v0.6.3` is public. This advances the source to `0.6.4.dev0` and records the
release evidence.

## Published identity

| | |
| --- | --- |
| Release commit | `005a4549da713716e64c3ae80ff55fb131519f79` |
| Tag | `v0.6.3` (annotated, resolves to that commit) |
| PyPI | https://pypi.org/project/miniverl/0.6.3/ |
| GitHub Release | https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.6.3 |
| Release run | https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31084165317 |
| Wheel SHA-256 | `1c620c310e8e4156f515d52128a0f26a037096347a2bc105c63f173e6563f5e0` |
| sdist SHA-256 | `b93d2fad63432ecd680b72fe0bf79f6b0be212af1aab82780ed8e31636edeefe` |

PyPI and the GitHub Release expose identical files. The PyPI integrity API
exposes one Trusted Publisher attestation bundle per distribution, bound to
`DaoyuanLi2816/mini-verl` and `release.yml`.

A clean Windows Python 3.12 install from `https://pypi.org/simple` reported
`miniverl 0.6.3`, kept torch absent, and — given a reward scaffold whose top
level writes a marker file — refused to run it: the marker was never created
and the doctor reported `top_level_call` with `code_executed: false`.

## One defect found during that verification

A scaffold saved with a UTF-8 byte-order mark is reported as `syntax_error` at
level `not_present`. CPython strips the BOM when it reads a source file; the
static checker decodes the bytes and hands the leading `﻿` to `ast.parse`,
which rejects it. A scaffold written by a Windows editor is therefore refused as
unparseable.

The direction is fail-closed — a legitimate file is rejected, nothing unsafe is
accepted — so it is not a security defect, but it is wrong. It is recorded as
the first v0.6.4 checklist item and fixed in a separate PR; `v0.6.3` is
immutable and keeps the behaviour.

## Changes here

- `release-state.yaml`: `phase: development`, stable `0.6.3` with its real
  release commit, development `0.6.4.dev0`
- `__version__`, `CITATION.cff` and the docs version selector follow from it
- `PROJECT_STATE.md` canonical release line
- `docs/generated/quality.json`: `status: released`
- release checklist: an "After the v0.6.3 tag" record and a v0.6.4 section

`python scripts/release_state.py --check` passes. No frozen scientific artifact
is touched.
