### PR TITLE
Start v0.7.1 development and record v0.7.0 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ title: "miniVERL: Auditable single-GPU alignment and distillation runtime"
 message: "If you use miniVERL in your work, please cite it as below."
 type: software
 version: 0.7.0
-date-released: 2026-08-10
+date-released: 2026-08-11
 license: Apache-2.0
 repository-code: "https://github.com/DaoyuanLi2816/mini-verl"
 url: "https://github.com/DaoyuanLi2816/mini-verl"

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -4,9 +4,9 @@ Living build log for **miniVERL** (`mini-verl` / `miniverl` / CLI `miniverl`).
 A checkbox is not evidence: every completed item names the command that was run
 and what it printed.
 
-Last updated: 2026-08-10.
+Last updated: 2026-08-11.
 
-Canonical release state: releasing `v0.7.0`.
+Canonical release state: stable `v0.7.0` (`148822964dbb73e97ce06ef740f907364166a724`), development `0.7.1.dev0`.
 Every public version claim is generated from `release-state.yaml` and gated by
 `python scripts/release_state.py --check`.
 

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.7.0/docs/banner.svg" alt="miniVERL — single-GPU LLM post-training" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — single-GPU LLM post-training" width="880">
 </p>
 
 <div align="center">
@@ -8,7 +8,7 @@
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE)
 
 </div>
 
@@ -16,7 +16,7 @@
   <a href="https://pypi.org/project/miniverl/"><strong>PyPI</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/"><strong>Stable docs</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/dev/">Development docs</a> ·
-  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/README.zh-CN.md">中文</a>
+  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/main/README.zh-CN.md">中文</a>
 </p>
 
 **miniVERL is a local, inspectable runtime for a documented subset of
@@ -51,8 +51,8 @@ The command returns `do_not_continue_this_study` and
 `insufficient_evidence`, not SFT/DPO/KD/OPD. Granite Guardian was used only as
 an unqualified selection diagnostic; Granite qualification, PairRM
 qualification, teacher qualification and the reserved final test did not run.
-Read the [early-stop study](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/docs/alignment-external/alignment-external-v1.md)
-and [typed result](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/benchmarks/results/alignment-external-v1.json).
+Read the [early-stop study](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-external/alignment-external-v1.md)
+and [typed result](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/results/alignment-external-v1.json).
 
 ## Install and run the 60-second demo
 
@@ -68,15 +68,15 @@ optimization in about 50 seconds on the measured laptop CPU. For inspection,
 schemas and reports without the ML stack, use `pip install miniverl`. For CUDA
 training, install the matching CUDA-enabled PyTorch wheel first, then install
 `miniverl[train,cuda]`; the extra does not select a CUDA PyTorch build. See the
-[single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/docs/single-gpu-guide.md).
+[single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md).
 
 ## Three paths
 
 | Path | Start with | Concrete artifact | Next |
 | --- | --- | --- | --- |
-| **Align** — compare SFT, DPO, KD and OPD only when the pilot evidence supports the cost | `miniverl pilot recipes/alignment_policy_conditioned_qwen.yaml` | `alignment-card.json` | [Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/docs/alignment-lab/alignment-lab-v1.md) |
-| **Distill locally** — strict OPD, shared backbones and padded trajectory updates on one CUDA GPU | `miniverl train recipes/qwen_consumer_gpu_shared.yaml --dry-run` | `config.resolved.yaml` plus a revision-pinned PEFT adapter | [Bring your own GPU](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/docs/single-gpu-guide.md) |
-| **Scale out** — import a documented profile, convert Parquet, export a bundle and run bridge checks | `miniverl bridge doctor scaleout-bundle` | `provenance/compatibility-report.json` | [Verified verl artifact bridge](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/docs/verl-bridge.md) |
+| **Align** — compare SFT, DPO, KD and OPD only when the pilot evidence supports the cost | `miniverl pilot recipes/alignment_policy_conditioned_qwen.yaml` | `alignment-card.json` | [Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md) |
+| **Distill locally** — strict OPD, shared backbones and padded trajectory updates on one CUDA GPU | `miniverl train recipes/qwen_consumer_gpu_shared.yaml --dry-run` | `config.resolved.yaml` plus a revision-pinned PEFT adapter | [Bring your own GPU](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) |
+| **Scale out** — import a documented profile, convert Parquet, export a bundle and run bridge checks | `miniverl bridge doctor scaleout-bundle` | `provenance/compatibility-report.json` | [Verified verl artifact bridge](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md) |
 
 The bridge is a **verified artifact bridge**: a pinned config/data/model
 parse-load smoke at miniVERL-defined compatibility Level 3. It has never run a
@@ -118,12 +118,12 @@ improved it; continued SFT and both OPD variants retained measured regressions.
 | standard OPD | 98.6% | 97.2% | 100.0% | 76.7 s |
 | verifier-gated OPD | 97.9% | 95.8% | 46.8% | 66.0 s |
 
-![Alignment and utility deltas from the saturated SFT checkpoint; small marks are all three seeds and large marks are means](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.7.0/docs/alignment-lab/delta-from-sft.svg)
+![Alignment and utility deltas from the saturated SFT checkpoint; small marks are all three seeds and large marks are means](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/alignment-lab/delta-from-sft.svg)
 
 The two sandbox safety checks tied at zero while utility still regressed.
 IFEval, XSTest, HarmBench and RewardBench were **not executed**. “Preference
 win rate” is a deterministic Minipolicy paired outcome, not human preference.
-Read the [study, seed-level values and limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/docs/alignment-lab/alignment-lab-v1.md).
+Read the [study, seed-level values and limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md).
 
 ## One measured systems result
 
@@ -134,13 +134,13 @@ reserved memory versus 3.035 GiB for dual model, while running 10.1% slower.
 All 12 preregistered equivalence comparisons passed. These are one-workload,
 one-machine measurements, not promises for other GPUs.
 
-![Measured throughput and reserved VRAM for dual-model and shared-backbone runtime cells](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.7.0/docs/consumer-runtime-v1-pareto.svg)
+![Measured throughput and reserved VRAM for dual-model and shared-backbone runtime cells](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/consumer-runtime-v1-pareto.svg)
 
-[Consumer Runtime v1 methods and caveats](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/docs/consumer-runtime-v1.md)
+[Consumer Runtime v1 methods and caveats](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/consumer-runtime-v1.md)
 
 ## Compatibility boundary
 
-![Verified local runtime, portable artifact bundle and pinned upstream smoke; distributed verl execution remains untested](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.7.0/docs/verl-bridge-architecture.svg)
+![Verified local runtime, portable artifact bundle and pinned upstream smoke; distributed verl execution remains untested](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-bridge-architecture.svg)
 
 The bridge targets official verl `v0.8.0` at commit `7aed6b23` and uses the
 term **miniVERL-defined compatibility Level 3**. That means a checksummed
@@ -157,21 +157,21 @@ PPO/reward scaffold, not an executable continuation of miniVERL OPD semantics.
 
 ## Detailed studies and preserved negative evidence
 
-- [RecoveryBench v1](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/docs/recoverybench/recoverybench-v1.md): frozen-student KD
+- [RecoveryBench v1](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md): frozen-student KD
   outperformed much slower fresh-state OPD on the preregistered primary view;
   the verifier gate remained `insufficient_evidence`.
-- [Alignment Lab v1](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/docs/alignment-lab/alignment-lab-v1.md): the starting SFT
+- [Alignment Lab v1](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md): the starting SFT
   checkpoint was at the ceiling, so no positive OPD result is claimed.
-- [Calculator benchmark](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/docs/benchmarking.md): both negative controls completed
+- [Calculator benchmark](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md): both negative controls completed
   normally and measured 0% strict success. They were not configuration
   failures. Because they used the historical ambiguous protocol-v1 prompt,
   their failure cannot be attributed solely to intrinsic teacher behavior.
-- [Consumer Runtime v1](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/docs/consumer-runtime-v1.md): padded update batches and
+- [Consumer Runtime v1](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/consumer-runtime-v1.md): padded update batches and
   shared adapters preserve the measured one-update objective within declared
   tolerances; rollout generation remains sequential.
-- [Limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/docs/limitations.md), [math](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/docs/math.md),
-  [reproducibility](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/docs/reproducibility.md) and
-  [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/docs/compatibility.md).
+- [Limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md), [math](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/math.md),
+  [reproducibility](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/reproducibility.md) and
+  [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md).
 
 New runs establish tokenizer compatibility through structural identity. The
 legacy behavioral fingerprint—token IDs for one fixed probe plus metadata—is
@@ -191,7 +191,7 @@ python -m pip install -e ".[dev]"
 pytest -q -m "not gpu and not network"
 ```
 
-Apache-2.0 licensed. See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/CONTRIBUTING.md) and
-[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/SECURITY.md). Project records: [default GPU recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/recipes/qwen_consumer_gpu_calc.yaml),
-[frozen calculator JSON](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/benchmarks/results/gpu-calc-hard-equal-update-v2.json),
-[changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/CHANGELOG.md), [citation](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/CITATION.cff) and [license](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.0/LICENSE).
+Apache-2.0 licensed. See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md) and
+[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md). Project records: [default GPU recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/main/recipes/qwen_consumer_gpu_calc.yaml),
+[frozen calculator JSON](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/results/gpu-calc-hard-equal-update-v2.json),
+[changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md), [citation](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff) and [license](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE).

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "release": "0.7.0",
-  "status": "candidate",
+  "status": "released",
   "quality_floor": "2,000+ tests and 85%+ branch coverage at v0.7.0",
   "local_validation": {
     "scope": "the maintainer's workstation, where the GPU and Windows-specific paths actually run",
@@ -28,14 +28,14 @@
   },
   "release_validation": {
     "scope": "the exact published commit, validated by CI rather than locally",
-    "commit": "pending",
+    "commit": "148822964dbb73e97ce06ef740f907364166a724",
     "workflows": {
-      "ci": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31080175904",
-      "build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31080175961",
-      "docs": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31080175972",
-      "release": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31084165317"
+      "ci": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31468298531",
+      "build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31468298548",
+      "docs": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31468298534",
+      "release": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31468663273"
     },
-    "conclusion": "pending exact release-commit CI",
+    "conclusion": "success",
     "gpu_coverage": "none; no GPU runner is configured for this repository, so the GPU counts above exist only from the local measurement"
   }
 }

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  <div class="docs-channel" data-stable-version="0.7.0" data-dev-version="0.7.0">
+  <div class="docs-channel" data-stable-version="0.7.0" data-dev-version="0.7.1.dev0">
     <strong id="docs-channel-label">Stable documentation</strong>
     <label for="docs-version-selector">Version</label>
     <select id="docs-version-selector" aria-label="Documentation version">
       <option value="stable">Stable 0.7.0</option>
-      <option value="dev">Development 0.7.0</option>
+      <option value="dev">Development 0.7.1.dev0</option>
     </select>
   </div>
 {% endblock %}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,6 +4,11 @@ This is the release gate and publication record for miniVERL. A checked item
 names an invariant exercised on the stated source. Publication begins only
 after the exact release commit and its remote checks are green.
 
+## v0.7.1 (in development)
+
+- [ ] Define and review the next maintenance scope before implementation. No
+      new scientific experiment is authorized by the v0.7.0 state sync.
+
 ## v0.7.0 External Alignment Gate evidence release
 
 The preregistered study terminated at checkpoint selection. Later experimental
@@ -73,10 +78,17 @@ unauthorized after checkpoint-selection failure**.
 
 ## After the tag
 
-- [ ] Verify the OIDC workflow, PyPI hashes/attestations, GitHub Release and
-      clean public installs.
-- [ ] Comment on issue #39 with the public evidence and keep it open.
-- [ ] Merge the separate state-sync PR advancing main to `0.7.1.dev0`.
+- [x] Release run
+      [`31468663273`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31468663273)
+      completed OIDC Trusted Publishing, attestation verification, exact clean
+      install and GitHub Release creation for commit
+      `148822964dbb73e97ce06ef740f907364166a724`.
+- [x] PyPI and the GitHub Release expose identical files: wheel SHA-256
+      `469ae44fe414cd5f56af0fe36091cbd8f12ba34072f67132800aebd7e2746420`,
+      sdist SHA-256
+      `0ec9e43384b749a64e8263c10e314fce1df87769d053939559917400cfecbce4`.
+- [x] Issue #39 has an owner-authored public evidence comment and remains open.
+- [x] This separate state-sync PR advances main to `0.7.1.dev0` after merge.
 
 ## v0.6.4 (superseded by v0.7.0)
 

--- a/release-state.yaml
+++ b/release-state.yaml
@@ -17,16 +17,13 @@
 # such distinction, which is how its tag shipped a docs selector still
 # advertising "Stable 0.6.1 / Development 0.6.2.dev0".
 schema_version: 1
-phase: release
+phase: development
 
 stable:
   version: "0.7.0"
   tag: "v0.7.0"
-  release_commit: pending
-  released_at: "2026-08-10"
+  release_commit: "148822964dbb73e97ce06ef740f907364166a724"
+  released_at: "2026-08-11"
 
 development:
-  # v0.7.0 is the external alignment study. There is no v0.6.4 release: the
-  # foundation hardening in this cycle ships as part of it rather than as an
-  # intermediate maintenance version.
-  version: "0.7.0"
+  version: "0.7.1.dev0"

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.7.0"
+__version__ = "0.7.1.dev0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

- record v0.7.0 as the stable release at `148822964dbb73e97ce06ef740f907364166a724`
- bind the quality record to the successful main CI/build/docs and OIDC release runs
- record the public PyPI/GitHub Release hashes and issue #39 evidence comment
- advance source and documentation development state to `0.7.1.dev0`

This is metadata-only state synchronization after the verified v0.7.0 release. It changes no benchmark, task evidence, scientific conclusion, runtime behavior, or published tag.

## Verification

- `python scripts/release_state.py --check`
- `python scripts/build_pypi_readme.py --check`
- 124 release-state and packaging tests
- `mkdocs build --strict`
- Ruff check and format
- mypy over `src/miniverl`
- Markdown links and text integrity
- frozen calculator SHA-256 remains `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`