### PR TITLE
Advance development to 0.8.0.dev0

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -6,7 +6,7 @@ and what it printed.
 
 Last updated: 2026-08-11.
 
-Canonical release state: releasing `v0.7.1`.
+Canonical release state: stable `v0.7.1` (`830a4ca5d873bce4cdcc7c43a44d827b096e8c0c`), development `0.8.0.dev0`.
 Every public version claim is generated from `release-state.yaml` and gated by
 `python scripts/release_state.py --check`.
 

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.7.1/docs/banner.svg" alt="miniVERL — single-GPU LLM post-training" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — single-GPU LLM post-training" width="880">
 </p>
 
 <div align="center">
@@ -8,7 +8,7 @@
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE)
 
 </div>
 
@@ -16,7 +16,7 @@
   <a href="https://pypi.org/project/miniverl/"><strong>PyPI</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/"><strong>Stable docs</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/dev/">Development docs</a> ·
-  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/README.zh-CN.md">中文</a>
+  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/main/README.zh-CN.md">中文</a>
 </p>
 
 **miniVERL is a local, inspectable single-GPU alignment and distillation
@@ -51,7 +51,7 @@ device-name agnostic, but fit depends on model pair, context, kernels and VRAM.
 Install the matching CUDA-enabled PyTorch build first, then
 `miniverl[train,cuda]`; that extra does not select a CUDA PyTorch wheel.
 Ray, FSDP, Megatron, PPO, GRPO and distributed launch are outside the runtime.
-See the [single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/docs/single-gpu-guide.md).
+See the [single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md).
 
 ## verl compatibility summary
 
@@ -66,7 +66,7 @@ Current exports remain `launchable: false`: the base snapshot is absent, the
 reward scaffold fails closed and required mappings remain placeholders. The
 entry point is `launch.template.sh`; readiness, parse/load evidence,
 launchability, distributed execution and semantic parity are separate facts.
-[Read the bridge contract](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/docs/verl-bridge.md).
+[Read the bridge contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md).
 
 ## One measured systems result
 
@@ -77,17 +77,17 @@ versus 3.035 GiB for dual model while running 10.1% slower. All 12
 preregistered equivalence comparisons passed. This is one workload on one
 machine, not a promise for other GPUs.
 
-![Measured throughput and reserved VRAM for dual-model and shared-backbone runtime cells](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.7.1/docs/consumer-runtime-v1-pareto.svg)
+![Measured throughput and reserved VRAM for dual-model and shared-backbone runtime cells](https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/consumer-runtime-v1-pareto.svg)
 
-[Consumer Runtime v1 methods and caveats](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/docs/consumer-runtime-v1.md)
+[Consumer Runtime v1 methods and caveats](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/consumer-runtime-v1.md)
 
 ## Three paths
 
 | Path | Start with | Concrete artifact | Next |
 | --- | --- | --- | --- |
-| **Align** — use SFT, DPO, KD or OPD only when pilot evidence supports the cost | `miniverl pilot recipes/alignment_policy_conditioned_qwen.yaml` | `alignment-card.json` | [Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/docs/alignment-lab/alignment-lab-v1.md) |
-| **Distill locally** — strict OPD, shared backbones and padded updates on one CUDA GPU | `miniverl train recipes/qwen_consumer_gpu_shared.yaml --dry-run` | resolved config and revision-pinned PEFT adapter | [Bring your own GPU](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/docs/single-gpu-guide.md) |
-| **Scale out** — convert Parquet, export standard artifacts and inspect the unsupported boundary | `miniverl bridge doctor scaleout-bundle` | `provenance/compatibility-report.json` | [Verified artifact bridge](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/docs/verl-bridge.md) |
+| **Align** — use SFT, DPO, KD or OPD only when pilot evidence supports the cost | `miniverl pilot recipes/alignment_policy_conditioned_qwen.yaml` | `alignment-card.json` | [Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md) |
+| **Distill locally** — strict OPD, shared backbones and padded updates on one CUDA GPU | `miniverl train recipes/qwen_consumer_gpu_shared.yaml --dry-run` | resolved config and revision-pinned PEFT adapter | [Bring your own GPU](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) |
+| **Scale out** — convert Parquet, export standard artifacts and inspect the unsupported boundary | `miniverl bridge doctor scaleout-bundle` | `provenance/compatibility-report.json` | [Verified artifact bridge](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md) |
 
 ## Research notes and preserved negative evidence
 
@@ -108,7 +108,7 @@ miniverl pilot --builtin-study alignment-external-v1 --json
 The result is `do_not_continue_this_study` and `insufficient_evidence`, not a
 recommendation among SFT/DPO/KD/OPD. Granite Guardian values are unqualified
 selection diagnostics; Granite, PairRM and teacher qualification and the
-reserved final test did not run. [Study and limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/docs/alignment-external/alignment-external-v1.md).
+reserved final test did not run. [Study and limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-external/alignment-external-v1.md).
 
 ### Earlier measured alignment case study
 
@@ -118,17 +118,17 @@ ceiling; continued SFT and both OPD variants retained measured regressions.
 The two sandbox safety checks tied at zero while utility still regressed.
 IFEval, XSTest, HarmBench and RewardBench were not executed, and “preference
 win rate” is a deterministic Minipolicy paired outcome, not human preference.
-[Seed-level evidence](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/docs/alignment-lab/alignment-lab-v1.md).
+[Seed-level evidence](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md).
 
-- [RecoveryBench v1](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/docs/recoverybench/recoverybench-v1.md): frozen-student KD
+- [RecoveryBench v1](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md): frozen-student KD
   beat slower fresh-state OPD on the preregistered primary view; the verifier
   gate remained `insufficient_evidence`.
-- [Calculator benchmark](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/docs/benchmarking.md): both negative controls completed
+- [Calculator benchmark](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md): both negative controls completed
   normally at 0%; the ambiguous historical protocol-v1 prompt prevents
   attributing failure solely to intrinsic teacher behavior.
-- [Limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/docs/limitations.md), [math](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/docs/math.md),
-  [reproducibility](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/docs/reproducibility.md) and
-  [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/docs/compatibility.md).
+- [Limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md), [math](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/math.md),
+  [reproducibility](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/reproducibility.md) and
+  [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md).
 
 New runs establish tokenizer compatibility through structural identity. The
 legacy behavioral fingerprint is only a migration fallback, not identity proof.
@@ -142,8 +142,8 @@ python -m pip install -e ".[dev]"
 pytest -q -m "not gpu and not network"
 ```
 
-Apache-2.0 licensed. See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/CONTRIBUTING.md),
-[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/SECURITY.md), the [changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/CHANGELOG.md) and
-[citation](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/CITATION.cff). Project records: [default GPU recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/recipes/qwen_consumer_gpu_calc.yaml),
-[frozen calculator result](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/benchmarks/results/gpu-calc-hard-equal-update-v2.json)
-and [license](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.7.1/LICENSE).
+Apache-2.0 licensed. See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md),
+[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md), the [changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md) and
+[citation](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff). Project records: [default GPU recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/main/recipes/qwen_consumer_gpu_calc.yaml),
+[frozen calculator result](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/results/gpu-calc-hard-equal-update-v2.json)
+and [license](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE).

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "release": "0.7.1",
-  "status": "candidate",
+  "status": "released",
   "quality_floor": "2,000+ tests and 85%+ branch coverage at v0.7.1",
   "local_validation": {
     "scope": "the maintainer's workstation, where the GPU and Windows-specific paths actually run",
@@ -28,9 +28,15 @@
   },
   "release_validation": {
     "scope": "the exact published commit, validated by CI rather than locally",
-    "commit": "pending",
-    "workflows": {},
-    "conclusion": "pending",
+    "commit": "830a4ca5d873bce4cdcc7c43a44d827b096e8c0c",
+    "workflows": {
+      "ci": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31566406949",
+      "build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31566406885",
+      "docs": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31566406859",
+      "pinned_verl_bridge": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31566406861",
+      "release": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31566663507"
+    },
+    "conclusion": "success",
     "gpu_coverage": "none; no GPU runner is configured for this repository, so the GPU counts above exist only from the local measurement"
   }
 }

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  <div class="docs-channel" data-stable-version="0.7.1" data-dev-version="0.7.1">
+  <div class="docs-channel" data-stable-version="0.7.1" data-dev-version="0.8.0.dev0">
     <strong id="docs-channel-label">Stable documentation</strong>
     <label for="docs-version-selector">Version</label>
     <select id="docs-version-selector" aria-label="Documentation version">
       <option value="stable">Stable 0.7.1</option>
-      <option value="dev">Development 0.7.1</option>
+      <option value="dev">Development 0.8.0.dev0</option>
     </select>
   </div>
 {% endblock %}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,6 +4,12 @@ This is the release gate and publication record for miniVERL. A checked item
 names an invariant exercised on the stated source. Publication begins only
 after the exact release commit and its remote checks are green.
 
+## v0.8.0 single-GPU verl OPD pivot
+
+- [ ] Implement and validate the documented verl v0.8 single-GPU OPD subset.
+- [ ] Preserve every frozen benchmark and keep unsupported distributed semantics fail-closed.
+- [ ] Complete the v0.8.0 release gates and public-distribution verification.
+
 ## v0.7.1 Product correction
 
 - [x] README, Chinese README, PyPI description and docs landing page lead with
@@ -95,6 +101,17 @@ unauthorized after checkpoint-selection failure**.
       generated-artifact, visual, package and attribution gates before merge.
 
 ## After the tag
+
+- [x] v0.7.1 release run
+      [`31566663507`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31566663507)
+      completed OIDC Trusted Publishing, attestation verification, exact clean
+      install and GitHub Release creation for commit
+      `830a4ca5d873bce4cdcc7c43a44d827b096e8c0c`.
+- [x] PyPI and the GitHub Release expose identical v0.7.1 files: wheel SHA-256
+      `7d29669eaf53de0fd9b3056f3d00ad1d61c990fbe4f6cc97ccaf8e628c60e785`,
+      sdist SHA-256
+      `8131faee22e8b668bb0ff010f92ffafd9224aa046a017ad6f85fe7774301dea1`.
+- [x] This separate state-sync PR advances main to `0.8.0.dev0` after v0.7.1.
 
 - [x] Release run
       [`31468663273`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31468663273)

--- a/release-state.yaml
+++ b/release-state.yaml
@@ -17,13 +17,13 @@
 # such distinction, which is how its tag shipped a docs selector still
 # advertising "Stable 0.6.1 / Development 0.6.2.dev0".
 schema_version: 1
-phase: release
+phase: development
 
 stable:
   version: "0.7.1"
   tag: "v0.7.1"
-  release_commit: "pending"
+  release_commit: "830a4ca5d873bce4cdcc7c43a44d827b096e8c0c"
   released_at: "2026-08-11"
 
 development:
-  version: "0.7.1"
+  version: "0.8.0.dev0"

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.7.1"
+__version__ = "0.8.0.dev0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
﻿## Summary

- record the verified v0.7.1 release commit, workflows, public hashes, and successful OIDC publication
- advance package and documentation development state to `0.8.0.dev0`
- add the v0.8.0 release-gate placeholder without changing any frozen result

## Validation

- `python scripts/release_state.py --check`
- `python scripts/build_pypi_readme.py --check`
- `python scripts/check_markdown_links.py`
- focused release-state and packaging tests: 22 passed
- ruff check and format check
- frozen benchmark/evidence/preregistration diff against v0.7.1: clean

## Published v0.7.1 evidence

- release run: https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31566663507
- wheel SHA-256: `7d29669eaf53de0fd9b3056f3d00ad1d61c990fbe4f6cc97ccaf8e628c60e785`
- sdist SHA-256: `8131faee22e8b668bb0ff010f92ffafd9224aa046a017ad6f85fe7774301dea1`
