### PR TITLE
Advance development to 0.8.1.dev0

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -6,7 +6,7 @@ and what it printed.
 
 Last updated: 2026-08-12.
 
-Canonical release state: releasing `v0.8.0`.
+Canonical release state: stable `v0.8.0` (`657f774ce15ad85052b8a88919f774d700264595`), development `0.8.1.dev0`.
 Every public version claim is generated from `release-state.yaml` and gated by
 `python scripts/release_state.py --check`.
 

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.8.0/docs/banner.svg" alt="miniVERL — single-GPU LLM post-training" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — single-GPU LLM post-training" width="880">
 </p>
 
 <div align="center">
@@ -8,7 +8,7 @@
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE)
 
 </div>
 
@@ -16,7 +16,7 @@
   <a href="https://pypi.org/project/miniverl/"><strong>PyPI</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/"><strong>Stable docs</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/dev/">Development docs</a> ·
-  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/README.zh-CN.md">中文</a>
+  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/main/README.zh-CN.md">中文</a>
 </p>
 
 **Run a documented subset of verl-style on-policy distillation on one consumer
@@ -42,7 +42,7 @@ miniverl run --profile verl-opd-v0.8-single-gpu-v1 --config builtin:qwen3-0.6b-1
 
 The sample, plan and dry run need no Git checkout; planning loads no weights.
 Remove `--dry-run` on one CUDA GPU to execute the pinned Qwen3-0.6B/1.7B NF4
-recipe and produce a loadable PEFT adapter. [Follow the OPD quickstart](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/docs/opd-quickstart.md).
+recipe and produce a loadable PEFT adapter. [Follow the OPD quickstart](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/opd-quickstart.md).
 
 ## Supported hardware and runtime boundary
 
@@ -51,7 +51,7 @@ device-name agnostic, but fit depends on model pair, context, kernels and VRAM.
 Install the matching CUDA-enabled PyTorch build first, then
 `miniverl[train,cuda]`; that extra does not select a CUDA PyTorch wheel.
 Ray, FSDP, Megatron, PPO, GRPO and distributed launch are outside the runtime.
-See the [single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/docs/single-gpu-guide.md).
+See the [single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md).
 
 ## verl compatibility summary
 
@@ -64,7 +64,7 @@ Compatible OPD exports contain no reward scaffold. They preserve student and
 teacher identities, Parquet bytes and OPD overrides, but remain
 `launchable: false` until exact base snapshots are materialized. Parse status,
 artifact loadability, launchability and distributed execution are separate.
-[Read the bridge contract](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/docs/verl-bridge.md).
+[Read the bridge contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md).
 
 ## Measured RTX 4080 runtime
 
@@ -72,15 +72,15 @@ The packaged Qwen3-0.6B/1.7B recipe completed two 16-token rollouts and one OPD
 update with **3.1758 GiB peak reserved VRAM**; the first update completed in
 **12.0224 s** and the standard PEFT adapter reloaded successfully. This proves
 one runtime/artifact path only—no alignment-quality endpoint or method
-comparison ran. [Exact recipe, timings and hashes](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/docs/opd-quickstart.md).
+comparison ran. [Exact recipe, timings and hashes](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/opd-quickstart.md).
 
 ## Three paths
 
 | Path | Start with | Concrete artifact | Next |
 | --- | --- | --- | --- |
-| **Run OPD locally** | `miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml` | compiled plan, trajectories, targets and PEFT adapter | [Plan and run](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/docs/opd-quickstart.md) |
-| **Bring a verl config** | `miniverl import-verl --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml --out local-opd.yaml` | field report plus round-trippable profile | [Compatibility](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/docs/compatibility.md) |
-| **Move data and artifacts** | `miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout` | Parquet + PEFT + OPD override bundle | [Bridge contract](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/docs/verl-bridge.md) |
+| **Run OPD locally** | `miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml` | compiled plan, trajectories, targets and PEFT adapter | [Plan and run](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/opd-quickstart.md) |
+| **Bring a verl config** | `miniverl import-verl --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml --out local-opd.yaml` | field report plus round-trippable profile | [Compatibility](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md) |
+| **Move data and artifacts** | `miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout` | Parquet + PEFT + OPD override bundle | [Bridge contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md) |
 
 ## Research notes and preserved negative evidence
 
@@ -101,7 +101,7 @@ miniverl pilot --builtin-study alignment-external-v1 --json
 The result is `do_not_continue_this_study` and `insufficient_evidence`, not a
 recommendation among SFT/DPO/KD/OPD. Granite Guardian values are unqualified
 selection diagnostics; Granite, PairRM and teacher qualification and the
-reserved final test did not run. [Study and limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/docs/alignment-external/alignment-external-v1.md).
+reserved final test did not run. [Study and limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-external/alignment-external-v1.md).
 
 ### Earlier measured alignment case study
 
@@ -111,17 +111,17 @@ ceiling; continued SFT and both OPD variants retained measured regressions.
 The two sandbox safety checks tied at zero while utility still regressed.
 IFEval, XSTest, HarmBench and RewardBench were not executed, and “preference
 win rate” is a deterministic Minipolicy paired outcome, not human preference.
-[Seed-level evidence](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/docs/alignment-lab/alignment-lab-v1.md).
+[Seed-level evidence](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md).
 
-- [RecoveryBench v1](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/docs/recoverybench/recoverybench-v1.md): frozen-student KD
+- [RecoveryBench v1](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md): frozen-student KD
   beat slower fresh-state OPD on the preregistered primary view; the verifier
   gate remained `insufficient_evidence`.
-- [Calculator benchmark](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/docs/benchmarking.md): both negative controls completed
+- [Calculator benchmark](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md): both negative controls completed
   normally at 0%; the ambiguous historical protocol-v1 prompt prevents
   attributing failure solely to intrinsic teacher behavior.
-- [Limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/docs/limitations.md), [math](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/docs/math.md),
-  [reproducibility](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/docs/reproducibility.md) and
-  [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/docs/compatibility.md).
+- [Limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md), [math](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/math.md),
+  [reproducibility](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/reproducibility.md) and
+  [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md).
 
 New runs establish tokenizer compatibility through structural identity. The
 legacy behavioral fingerprint is only a migration fallback, not identity proof.
@@ -135,8 +135,8 @@ python -m pip install -e ".[dev]"
 pytest -q -m "not gpu and not network"
 ```
 
-Apache-2.0 licensed. See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/CONTRIBUTING.md),
-[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/SECURITY.md), the [changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/CHANGELOG.md) and
-[citation](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/CITATION.cff). Project records: [default GPU recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/recipes/qwen_consumer_gpu_calc.yaml),
-[frozen calculator result](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/benchmarks/results/gpu-calc-hard-equal-update-v2.json)
-and [license](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.0/LICENSE).
+Apache-2.0 licensed. See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md),
+[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md), the [changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md) and
+[citation](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff). Project records: [default GPU recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/main/recipes/qwen_consumer_gpu_calc.yaml),
+[frozen calculator result](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/results/gpu-calc-hard-equal-update-v2.json)
+and [license](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE).

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "release": "0.8.0",
-  "status": "candidate",
+  "status": "released",
   "quality_floor": "2,000+ tests and 85%+ branch coverage at v0.8.0",
   "local_validation": {
     "scope": "the maintainer's workstation, where the GPU and Windows-specific paths actually run",
@@ -28,15 +28,15 @@
   },
   "release_validation": {
     "scope": "the exact published commit, validated by CI rather than locally",
-    "commit": "pending",
+    "commit": "657f774ce15ad85052b8a88919f774d700264595",
     "workflows": {
-      "ci": null,
-      "build": null,
-      "docs": null,
-      "pinned_verl_bridge": null,
-      "release": null
+      "ci": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31579172119",
+      "build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31579172102",
+      "docs": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31579172137",
+      "pinned_verl_bridge": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31579172225",
+      "release": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31579635238"
     },
-    "conclusion": "pending",
+    "conclusion": "success",
     "gpu_coverage": "none; no GPU runner is configured for this repository, so the GPU counts above exist only from the local measurement"
   }
 }

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  <div class="docs-channel" data-stable-version="0.8.0" data-dev-version="0.8.0">
+  <div class="docs-channel" data-stable-version="0.8.0" data-dev-version="0.8.1.dev0">
     <strong id="docs-channel-label">Stable documentation</strong>
     <label for="docs-version-selector">Version</label>
     <select id="docs-version-selector" aria-label="Documentation version">
       <option value="stable">Stable 0.8.0</option>
-      <option value="dev">Development 0.8.0</option>
+      <option value="dev">Development 0.8.1.dev0</option>
     </select>
   </div>
 {% endblock %}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,6 +4,12 @@ This is the release gate and publication record for miniVERL. A checked item
 names an invariant exercised on the stated source. Publication begins only
 after the exact release commit and its remote checks are green.
 
+## v0.8.1 development
+
+- [ ] Define the focused v0.8.1 scope before changing runtime semantics.
+- [ ] Preserve v0.8.0 tags, public artifacts and frozen benchmark bytes.
+- [ ] Complete the full release, compatibility and public-distribution gates.
+
 ## v0.8.0 single-GPU verl OPD pivot
 
 - [x] Implement and validate the documented `verl-opd-v0.8-single-gpu-v1`
@@ -117,10 +123,13 @@ unauthorized after checkpoint-selection failure**.
 
 ## After the tag
 
-- [ ] Verify the exact v0.8.0 merge-commit release workflow, OIDC publication,
+- [x] Verify the exact v0.8.0 merge-commit release workflow, OIDC publication,
       PyPI attestations, public clean install and GitHub Release.
-- [ ] Record identical public wheel/sdist hashes and advance main to
-      `0.8.1.dev0` in a separate state-sync PR.
+- [x] PyPI and the GitHub Release expose identical v0.8.0 files: wheel SHA-256
+      `1f1e608f894bc79451db752412fd82101b327ab74ffa7726ebcc98aeb66c57b9`,
+      sdist SHA-256
+      `c2a6576c4583990900baa0f2b36c25fe37959c6bb773d29529cf50606a7dc175`.
+- [x] Advance development to `0.8.1.dev0` in this separate state-sync PR.
 
 - [x] v0.7.1 release run
       [`31566663507`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31566663507)

--- a/release-state.yaml
+++ b/release-state.yaml
@@ -17,13 +17,13 @@
 # such distinction, which is how its tag shipped a docs selector still
 # advertising "Stable 0.6.1 / Development 0.6.2.dev0".
 schema_version: 1
-phase: release
+phase: development
 
 stable:
   version: "0.8.0"
   tag: "v0.8.0"
-  release_commit: pending
+  release_commit: "657f774ce15ad85052b8a88919f774d700264595"
   released_at: "2026-08-12"
 
 development:
-  version: "0.8.0"
+  version: "0.8.1.dev0"

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.8.0"
+__version__ = "0.8.1.dev0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

- record v0.8.0 as released from 657f774ce15ad85052b8a88919f774d700264595
- bind the quality record to successful main and release workflows
- record the public wheel/sdist hashes verified identically on PyPI and GitHub Release
- advance main metadata and docs selector to 