### PR TITLE
Make the verl OPD workflow product-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to miniVERL are recorded here. The format follows
 
 ## [Unreleased]
 
+### Product surface
+
+- Reframed the English, Chinese and PyPI landing pages around the bounded
+  single-GPU verl-style OPD workflow, with a responsive architecture diagram,
+  a concise research index and a dedicated migration guide for verl users.
+- Made the packaged Qwen3 profile use familiar upstream-shaped `vllm` engine
+  values while retaining explicit `locally_reinterpreted` classifications for
+  the sequential local-HF runtime.
+- Aligned the banner, package metadata, CLI and citation summary without
+  expanding the supported algorithm or implying distributed execution.
+
 ## [0.8.0] - 2026-08-12
 
 ### Single-GPU verl v0.8 OPD runtime

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-title: "miniVERL: Auditable single-GPU alignment and distillation runtime"
+title: "miniVERL: A bounded single-GPU runtime for verl-style OPD"
 message: "If you use miniVERL in your work, please cite it as below."
 type: software
 version: 0.8.0
@@ -8,7 +8,8 @@ license: Apache-2.0
 repository-code: "https://github.com/DaoyuanLi2816/mini-verl"
 url: "https://github.com/DaoyuanLi2816/mini-verl"
 abstract: >-
-  miniVERL is a local single-GPU runtime for a documented subset of verl v0.8
+  miniVERL runs a documented subset of verl-style on-policy distillation on one
+  consumer GPU. It is a local single-GPU runtime for a documented subset of verl v0.8
   on-policy distillation. It consumes typed verl-shaped configuration and
   Parquet prompts, executes actor rollout, teacher scoring and actor update in
   one inspectable process, and exports standard PEFT, Parquet and configuration

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -10,6 +10,16 @@ Canonical release state: stable `v0.8.0` (`657f774ce15ad85052b8a88919f774d700264
 Every public version claim is generated from `release-state.yaml` and gated by
 `python scripts/release_state.py --check`.
 
+## v0.8.1 product surface
+
+The landing pages now lead with the documented one-GPU verl-style OPD journey,
+a responsive compiler/runtime/artifact diagram and a direct migration mapping.
+`docs/for-verl-users.md` explains reusable config/data, local role semantics and
+the scale-out boundary. The packaged Qwen3 profile now carries familiar
+`name: vllm` source values while the generated compatibility matrix continues
+to classify both engines as local-HF reinterpretations. No scientific result,
+algorithm, model revision or distributed claim changed.
+
 ## v0.8.0 single-GPU verl OPD pivot — PR A
 
 Development starts with the config-only profile

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — single-GPU LLM post-training" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — run verl-style OPD on one consumer GPU" width="880">
 </p>
 
 <div align="center">
@@ -20,113 +20,203 @@
 </p>
 
 **Run a documented subset of verl-style on-policy distillation on one consumer
-GPU.** miniVERL accepts a typed verl v0.8 OPD profile and Parquet prompts,
-executes actor rollout → teacher scoring → actor update locally, and exports
-standard PEFT/Parquet/config artifacts for scale-out. Native SFT, DPO, KD and
-tool-agent recipes remain available.
+GPU.** miniVERL takes typed verl-shaped YAML and Parquet prompts through actor
+rollout → teacher scoring → actor update, records every local reinterpretation,
+and exports standard PEFT, Parquet and config artifacts for a pinned scale-out
+handoff.
 
-PyPI `v0.8.0` is stable; `main` is development. miniVERL is independent from
-verl. It does not claim arbitrary verl YAML execution, distributed execution,
-or full algorithmic compatibility.
+PyPI `v0.8.0` is stable; `main` is development. miniVERL is an independent
+project with no upstream endorsement. It does not execute arbitrary verl YAML,
+launch distributed jobs, or claim full algorithmic compatibility.
 
-## Pip-only OPD quickstart
+## Pip-only quickstart
+
+Install the matching CUDA-enabled PyTorch build for your machine first, then:
 
 ```bash
 python -m pip install "miniverl[train]"
 miniverl data sample --format verl-parquet --out prompts.parquet
-miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config builtin:qwen3-0.6b-1.7b-opd \
+miniverl plan --profile verl-opd-v0.8-single-gpu-v1 \
+  --config builtin:qwen3-0.6b-1.7b-opd \
   --set 'data.train_files=["prompts.parquet"]'
-miniverl run --profile verl-opd-v0.8-single-gpu-v1 --config builtin:qwen3-0.6b-1.7b-opd \
+miniverl run --profile verl-opd-v0.8-single-gpu-v1 \
+  --config builtin:qwen3-0.6b-1.7b-opd \
   --set 'data.train_files=["prompts.parquet"]' --dry-run
 ```
 
-The sample, plan and dry run need no Git checkout; planning loads no weights.
-Remove `--dry-run` on one CUDA GPU to execute the pinned Qwen3-0.6B/1.7B NF4
-recipe and produce a loadable PEFT adapter. [Follow the OPD quickstart](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/opd-quickstart.md).
+These commands need no Git checkout. `data sample` creates a real structured
+Parquet file, `plan` compiles the complete field matrix without loading weights,
+and `run --dry-run` validates the native execution contract. On one NVIDIA CUDA
+GPU, remove `--dry-run` to run the pinned Qwen3-0.6B actor and Qwen3-1.7B teacher
+recipe and produce an inspectable PEFT adapter.
 
-## Supported hardware and runtime boundary
+The `train` extra installs the ML runtime, but does not choose the correct CUDA
+PyTorch wheel. The optional `cuda` extra adds bitsandbytes only. Follow the
+[one-GPU installation and memory guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) before a real
+run.
 
-miniVERL runs one local process on CPU or one NVIDIA CUDA GPU. The CUDA path is
-device-name agnostic, but fit depends on model pair, context, kernels and VRAM.
-Install the matching CUDA-enabled PyTorch build first, then
-`miniverl[train,cuda]`; that extra does not select a CUDA PyTorch wheel.
-Ray, FSDP, Megatron, PPO, GRPO and distributed launch are outside the runtime.
-See the [single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md).
+## Architecture
 
-## verl compatibility summary
+<picture>
+  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime-mobile.svg">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime.svg" alt="verl-shaped YAML, overrides and Parquet prompts pass through a typed compiler; one CUDA GPU runs actor rollout, teacher scoring and actor update; inspectable artifacts can be handed to pinned verl while distributed execution remains outside miniVERL.">
+</picture>
 
-The executable profile targets official verl `v0.8.0` at commit `7aed6b23` and
-supports one actor, one teacher, `n=1`, pure GKD `forward_kl_topk`, token-mean
-aggregation, LoRA/QLoRA and no reward/KL penalty. PG OPD, task-reward mixtures,
-multi-teacher, multimodal and distributed fields fail closed.
+miniVERL uses one ordinary process and schedules model roles in phases. It does
+not emulate Ray resource pools or pretend local Hugging Face generation is
+vLLM. Instead, the compatibility report retains the source value, explains the
+local meaning, assigns a risk level, and fails closed when a field would change
+the algorithm or distributed semantics.
 
-Compatible OPD exports contain no reward scaffold. They preserve student and
-teacher identities, Parquet bytes and OPD overrides, but remain
-`launchable: false` until exact base snapshots are materialized. Parse status,
-artifact loadability, launchability and distributed execution are separate.
-[Read the bridge contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md).
+The native runtime also remains available for SFT, DPO, offline KD and
+tool-aware OPD recipes. Those workflows share strict token provenance,
+pickle-free teacher caches, transactional checkpoints and adapter export, but
+the verl-shaped profile is the shortest route for an existing verl user.
 
-## Measured RTX 4080 runtime
+### One local scheduler, explicit roles
 
-The packaged Qwen3-0.6B/1.7B recipe completed two 16-token rollouts and one OPD
-update with **3.1758 GiB peak reserved VRAM**; the first update completed in
-**12.0224 s** and the standard PEFT adapter reloaded successfully. This proves
-one runtime/artifact path only—no alignment-quality endpoint or method
-comparison ran. [Exact recipe, timings and hashes](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/opd-quickstart.md).
+The actor generates from the current adapter; the teacher scores exactly those
+visited token positions; the actor then receives a padded, token-mean update.
+The teacher is never treated as a reward model, tool output never becomes a
+training label, and a stale actor-policy version cannot enter an on-policy
+batch. Memory planning chooses resident, swap, or compatible shared-backbone
+placement while keeping actor, teacher and reference identities distinct.
 
-## Three paths
+Each phase writes evidence before the next boundary: structured trajectories
+carry per-token provenance, top-k teacher targets are checksummed without
+pickle, checkpoints publish transactionally, and the final adapter is verified
+with the standard PEFT loader. A crash can therefore be inspected and resumed
+without reconstructing intent from console text.
 
-| Path | Start with | Concrete artifact | Next |
-| --- | --- | --- | --- |
-| **Run OPD locally** | `miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml` | compiled plan, trajectories, targets and PEFT adapter | [Plan and run](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/opd-quickstart.md) |
-| **Bring a verl config** | `miniverl import-verl --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml --out local-opd.yaml` | field report plus round-trippable profile | [Compatibility](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md) |
-| **Move data and artifacts** | `miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout` | Parquet + PEFT + OPD override bundle | [Bridge contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md) |
+## Coming from verl?
 
-## Research notes and preserved negative evidence
+| What you do in verl | miniVERL equivalent |
+| --- | --- |
+| pass Hydra overrides | repeat `--set key=value` in v0.8.1 |
+| inspect the resolved config | `miniverl plan --json` |
+| execute pure OPD | `miniverl run` |
+| reuse prompt Parquet | point `data.train_files` at it directly |
+| allocate rollout/teacher workers | compile resource intent into local phases |
+| save an FSDP/Megatron checkpoint | unsupported |
+| prepare a scale-out handoff | `miniverl export-verl` |
 
-### v0.7 External Alignment Gate
-
-The preregistered external study stopped before teacher or method training.
-Both declared starting-policy lineages scored **0/64** retained JSONNav utility
-for every candidate against the unchanged 20% floor.
-
-| selected checkpoints | qualified teachers | continuation arms | final-test tasks accessed |
-| ---: | ---: | ---: | ---: |
-| **0** | **0** | **0** | **0** |
+The same field names stay visible:
 
 ```bash
-miniverl pilot --builtin-study alignment-external-v1 --json
+# familiar resolved intent
+actor_rollout_ref.model.path=Qwen/Qwen3-0.6B
+distillation.teacher_models.teacher_model.model_path=Qwen/Qwen3-1.7B
+
+# bounded local compilation
+miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml \
+  --set actor_rollout_ref.actor.optim.lr=1e-5
 ```
 
-The result is `do_not_continue_this_study` and `insufficient_evidence`, not a
-recommendation among SFT/DPO/KD/OPD. Granite Guardian values are unqualified
-selection diagnostics; Granite, PairRM and teacher qualification and the
-reserved final test did not run. [Study and limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-external/alignment-external-v1.md).
+The public built-in profile deliberately uses upstream-shaped `name: vllm`
+values. miniVERL classifies both rollout and teacher engine names as local
+reinterpretations and executes them with sequential local HF phases; this is
+not vLLM equivalence. See [For verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/for-verl-users.md) for config,
+data, role and error mappings.
 
-### Earlier measured alignment case study
+## Tested profile boundary
 
-Alignment Lab v1 began from an SFT checkpoint already at 100% policy compliance
-and 100% retained tool utility in all three seeds. No continuation improved the
-ceiling; continued SFT and both OPD variants retained measured regressions.
-The two sandbox safety checks tied at zero while utility still regressed.
-IFEval, XSTest, HarmBench and RewardBench were not executed, and “preference
-win rate” is a deterministic Minipolicy paired outcome, not human preference.
-[Seed-level evidence](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md).
+`verl-opd-v0.8-single-gpu-v1` pins official verl `v0.8.0` at commit
+`7aed6b230776f963fa09509c10d9c3a767d1102c`. Its executable path is intentionally
+narrow:
 
-- [RecoveryBench v1](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md): frozen-student KD
-  beat slower fresh-state OPD on the preregistered primary view; the verifier
-  gate remained `insufficient_evidence`.
-- [Calculator benchmark](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md): both negative controls completed
-  normally at 0%; the ambiguous historical protocol-v1 prompt prevents
-  attributing failure solely to intrinsic teacher behavior.
-- [Limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md), [math](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/math.md),
-  [reproducibility](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/reproducibility.md) and
-  [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md).
+- one trainable actor and one teacher;
+- one generated response per prompt (`n=1`);
+- reward-free generalized knowledge distillation;
+- `forward_kl_topk` with top-k plus tail targets and token-mean aggregation;
+- LoRA or QLoRA adapter updates on one CUDA GPU;
+- immutable model revisions and verl-style structured prompt Parquet.
+
+Policy-gradient OPD, task rewards, KL penalties, multi-teacher routing,
+multimodal inputs, PPO, GRPO, critics, Ray, FSDP, Megatron, multi-GPU and
+multi-node execution are unsupported. Known unsupported values receive a
+machine-readable classification; unknown fields and unresolved `${...}`
+interpolations are rejected. A resolved profile subset is input—not an
+arbitrary launch script.
+
+## Measured RTX 4080 path
+
+The packaged Qwen3-0.6B/1.7B smoke completed two 16-token rollouts and one OPD
+update on one RTX 4080 with **3.1758 GiB peak reserved VRAM**. The first update
+completed in **12.0224 seconds**, the final adapter was exported as standard
+PEFT/safetensors, and a clean reload passed. The recipe records immutable model
+revisions, phase timings, cache identity, checkpoint bytes and adapter hashes.
+
+This is deliberately a runtime and artifact proof. It is not a throughput
+benchmark, an alignment-quality endpoint, or evidence that OPD beats SFT, DPO
+or KD. Other NVIDIA GPUs use the same device-name-agnostic CUDA path, but model
+fit depends on VRAM, context length, quantization and installed kernels. Read
+the [exact smoke record and limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/opd-quickstart.md).
+
+### Choose a path by hardware, not GPU branding
+
+| Situation | Recommended starting point | What remains constant |
+| --- | --- | --- |
+| inspect on CPU or a laptop | `plan` and `run --dry-run` | full config classification |
+| one CUDA GPU with limited VRAM | QLoRA plus role swapping | logical batch and loss semantics |
+| same-base actor and teacher adapters | shared-backbone mode | explicit role provenance |
+| more VRAM available | larger physical phase batches | source data and optimizer intent |
+
+Automatic BF16/FP16 selection follows device support; it is not inferred from
+marketing names such as 3070, 4080, 5090 or Titan. `miniverl doctor` reports the
+installed CUDA/PyTorch path, and the planner keeps estimates visibly separate
+from measurements. There is no automatic downgrade to a different model,
+teacher, context, top-k or loss when memory is tight.
+
+## Data and artifact interoperability
+
+The profile consumes structured verl-style Parquet without substituting a toy
+environment. Prompt roles and content remain structured; data source, ability
+and extra metadata survive conversion. `miniverl convert-dataset` is available
+when crossing the native trajectory boundary, and rejects lossy rows unless the
+operator explicitly permits a partial conversion.
+
+A completed local run contains the resolved source config, compatibility
+matrix, local execution plan, trajectories, selected teacher targets,
+checkpoints, measurements and a PEFT adapter. Inspect before moving it:
+
+```bash
+miniverl inspect runs/my-opd/trajectories.jsonl
+miniverl cache stats runs/my-opd/teacher-cache
+miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout
+miniverl bridge doctor scaleout --json
+```
+
+The v0.8.1 export preserves student/teacher identities, Parquet bytes and pure
+OPD overrides, but reports `launchable: false` until exact base snapshots are
+materialized. Artifact completeness, upstream parse/load smoke, launchability,
+algorithm semantics and distributed execution are separate statuses. A
+successful bridge check never means that a distributed verl job ran. Review
+the [bridge contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md) and [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md).
+
+The intended operating loop is **plan → inspect → run → inspect → export**.
+Direct execution remains convenient for experiments, but the JSON plan and
+compatibility report are the durable review surfaces: they expose model pins,
+data paths, loss details, physical batches, unsupported fields, estimated
+memory and every local reinterpretation before weights are allocated. Run
+artifacts then add measurements and hashes without rewriting the original
+source intent.
+
+## Research and validation
+
+miniVERL keeps every measured study—including negative results, superseded
+runs and preregistered early stops—public under the documentation. None is used
+as a claim that OPD universally beats SFT, DPO or KD: see the
+[v0.7 External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-external/alignment-external-v1.md),
+[Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md),
+[RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md), and the
+[calculator study](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md).
 
 New runs establish tokenizer compatibility through structural identity. The
-legacy behavioral fingerprint is only a migration fallback, not identity proof.
+legacy behavioral fingerprint is retained only for migration and is not an
+identity proof. Scientific caveats and immutable source hashes remain in the
+detailed reports and [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md).
 
-## Develop
+## Development, security and license
 
 ```bash
 git clone https://github.com/DaoyuanLi2816/mini-verl.git
@@ -135,8 +225,8 @@ python -m pip install -e ".[dev]"
 pytest -q -m "not gpu and not network"
 ```
 
-Apache-2.0 licensed. See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md),
-[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md), the [changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md) and
-[citation](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff). Project records: [default GPU recipe](https://github.com/DaoyuanLi2816/mini-verl/blob/main/recipes/qwen_consumer_gpu_calc.yaml),
-[frozen calculator result](https://github.com/DaoyuanLi2816/mini-verl/blob/main/benchmarks/results/gpu-calc-hard-equal-update-v2.json)
-and [license](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE).
+Contributions should keep the one-GPU boundary explicit and include tests for
+new failure modes. Report vulnerabilities privately through
+[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md). See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md), the
+[changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md), [citation metadata](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff),
+[reproducibility guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/reproducibility.md), and [Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — single-GPU LLM post-training" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — run verl-style OPD on one consumer GPU" width="880">
 </p>
 
 <div align="center">
@@ -20,113 +20,203 @@
 </p>
 
 **Run a documented subset of verl-style on-policy distillation on one consumer
-GPU.** miniVERL accepts a typed verl v0.8 OPD profile and Parquet prompts,
-executes actor rollout → teacher scoring → actor update locally, and exports
-standard PEFT/Parquet/config artifacts for scale-out. Native SFT, DPO, KD and
-tool-agent recipes remain available.
+GPU.** miniVERL takes typed verl-shaped YAML and Parquet prompts through actor
+rollout → teacher scoring → actor update, records every local reinterpretation,
+and exports standard PEFT, Parquet and config artifacts for a pinned scale-out
+handoff.
 
-PyPI `v0.8.0` is stable; `main` is development. miniVERL is independent from
-verl. It does not claim arbitrary verl YAML execution, distributed execution,
-or full algorithmic compatibility.
+PyPI `v0.8.0` is stable; `main` is development. miniVERL is an independent
+project with no upstream endorsement. It does not execute arbitrary verl YAML,
+launch distributed jobs, or claim full algorithmic compatibility.
 
-## Pip-only OPD quickstart
+## Pip-only quickstart
+
+Install the matching CUDA-enabled PyTorch build for your machine first, then:
 
 ```bash
 python -m pip install "miniverl[train]"
 miniverl data sample --format verl-parquet --out prompts.parquet
-miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config builtin:qwen3-0.6b-1.7b-opd \
+miniverl plan --profile verl-opd-v0.8-single-gpu-v1 \
+  --config builtin:qwen3-0.6b-1.7b-opd \
   --set 'data.train_files=["prompts.parquet"]'
-miniverl run --profile verl-opd-v0.8-single-gpu-v1 --config builtin:qwen3-0.6b-1.7b-opd \
+miniverl run --profile verl-opd-v0.8-single-gpu-v1 \
+  --config builtin:qwen3-0.6b-1.7b-opd \
   --set 'data.train_files=["prompts.parquet"]' --dry-run
 ```
 
-The sample, plan and dry run need no Git checkout; planning loads no weights.
-Remove `--dry-run` on one CUDA GPU to execute the pinned Qwen3-0.6B/1.7B NF4
-recipe and produce a loadable PEFT adapter. [Follow the OPD quickstart](docs/opd-quickstart.md).
+These commands need no Git checkout. `data sample` creates a real structured
+Parquet file, `plan` compiles the complete field matrix without loading weights,
+and `run --dry-run` validates the native execution contract. On one NVIDIA CUDA
+GPU, remove `--dry-run` to run the pinned Qwen3-0.6B actor and Qwen3-1.7B teacher
+recipe and produce an inspectable PEFT adapter.
 
-## Supported hardware and runtime boundary
+The `train` extra installs the ML runtime, but does not choose the correct CUDA
+PyTorch wheel. The optional `cuda` extra adds bitsandbytes only. Follow the
+[one-GPU installation and memory guide](docs/single-gpu-guide.md) before a real
+run.
 
-miniVERL runs one local process on CPU or one NVIDIA CUDA GPU. The CUDA path is
-device-name agnostic, but fit depends on model pair, context, kernels and VRAM.
-Install the matching CUDA-enabled PyTorch build first, then
-`miniverl[train,cuda]`; that extra does not select a CUDA PyTorch wheel.
-Ray, FSDP, Megatron, PPO, GRPO and distributed launch are outside the runtime.
-See the [single-GPU guide](docs/single-gpu-guide.md).
+## Architecture
 
-## verl compatibility summary
+<picture>
+  <source media="(max-width: 640px)" srcset="docs/verl-local-runtime-mobile.svg">
+  <img src="docs/verl-local-runtime.svg" alt="verl-shaped YAML, overrides and Parquet prompts pass through a typed compiler; one CUDA GPU runs actor rollout, teacher scoring and actor update; inspectable artifacts can be handed to pinned verl while distributed execution remains outside miniVERL.">
+</picture>
 
-The executable profile targets official verl `v0.8.0` at commit `7aed6b23` and
-supports one actor, one teacher, `n=1`, pure GKD `forward_kl_topk`, token-mean
-aggregation, LoRA/QLoRA and no reward/KL penalty. PG OPD, task-reward mixtures,
-multi-teacher, multimodal and distributed fields fail closed.
+miniVERL uses one ordinary process and schedules model roles in phases. It does
+not emulate Ray resource pools or pretend local Hugging Face generation is
+vLLM. Instead, the compatibility report retains the source value, explains the
+local meaning, assigns a risk level, and fails closed when a field would change
+the algorithm or distributed semantics.
 
-Compatible OPD exports contain no reward scaffold. They preserve student and
-teacher identities, Parquet bytes and OPD overrides, but remain
-`launchable: false` until exact base snapshots are materialized. Parse status,
-artifact loadability, launchability and distributed execution are separate.
-[Read the bridge contract](docs/verl-bridge.md).
+The native runtime also remains available for SFT, DPO, offline KD and
+tool-aware OPD recipes. Those workflows share strict token provenance,
+pickle-free teacher caches, transactional checkpoints and adapter export, but
+the verl-shaped profile is the shortest route for an existing verl user.
 
-## Measured RTX 4080 runtime
+### One local scheduler, explicit roles
 
-The packaged Qwen3-0.6B/1.7B recipe completed two 16-token rollouts and one OPD
-update with **3.1758 GiB peak reserved VRAM**; the first update completed in
-**12.0224 s** and the standard PEFT adapter reloaded successfully. This proves
-one runtime/artifact path only—no alignment-quality endpoint or method
-comparison ran. [Exact recipe, timings and hashes](docs/opd-quickstart.md).
+The actor generates from the current adapter; the teacher scores exactly those
+visited token positions; the actor then receives a padded, token-mean update.
+The teacher is never treated as a reward model, tool output never becomes a
+training label, and a stale actor-policy version cannot enter an on-policy
+batch. Memory planning chooses resident, swap, or compatible shared-backbone
+placement while keeping actor, teacher and reference identities distinct.
 
-## Three paths
+Each phase writes evidence before the next boundary: structured trajectories
+carry per-token provenance, top-k teacher targets are checksummed without
+pickle, checkpoints publish transactionally, and the final adapter is verified
+with the standard PEFT loader. A crash can therefore be inspected and resumed
+without reconstructing intent from console text.
 
-| Path | Start with | Concrete artifact | Next |
-| --- | --- | --- | --- |
-| **Run OPD locally** | `miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml` | compiled plan, trajectories, targets and PEFT adapter | [Plan and run](docs/opd-quickstart.md) |
-| **Bring a verl config** | `miniverl import-verl --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml --out local-opd.yaml` | field report plus round-trippable profile | [Compatibility](docs/compatibility.md) |
-| **Move data and artifacts** | `miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout` | Parquet + PEFT + OPD override bundle | [Bridge contract](docs/verl-bridge.md) |
+## Coming from verl?
 
-## Research notes and preserved negative evidence
+| What you do in verl | miniVERL equivalent |
+| --- | --- |
+| pass Hydra overrides | repeat `--set key=value` in v0.8.1 |
+| inspect the resolved config | `miniverl plan --json` |
+| execute pure OPD | `miniverl run` |
+| reuse prompt Parquet | point `data.train_files` at it directly |
+| allocate rollout/teacher workers | compile resource intent into local phases |
+| save an FSDP/Megatron checkpoint | unsupported |
+| prepare a scale-out handoff | `miniverl export-verl` |
 
-### v0.7 External Alignment Gate
-
-The preregistered external study stopped before teacher or method training.
-Both declared starting-policy lineages scored **0/64** retained JSONNav utility
-for every candidate against the unchanged 20% floor.
-
-| selected checkpoints | qualified teachers | continuation arms | final-test tasks accessed |
-| ---: | ---: | ---: | ---: |
-| **0** | **0** | **0** | **0** |
+The same field names stay visible:
 
 ```bash
-miniverl pilot --builtin-study alignment-external-v1 --json
+# familiar resolved intent
+actor_rollout_ref.model.path=Qwen/Qwen3-0.6B
+distillation.teacher_models.teacher_model.model_path=Qwen/Qwen3-1.7B
+
+# bounded local compilation
+miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml \
+  --set actor_rollout_ref.actor.optim.lr=1e-5
 ```
 
-The result is `do_not_continue_this_study` and `insufficient_evidence`, not a
-recommendation among SFT/DPO/KD/OPD. Granite Guardian values are unqualified
-selection diagnostics; Granite, PairRM and teacher qualification and the
-reserved final test did not run. [Study and limitations](docs/alignment-external/alignment-external-v1.md).
+The public built-in profile deliberately uses upstream-shaped `name: vllm`
+values. miniVERL classifies both rollout and teacher engine names as local
+reinterpretations and executes them with sequential local HF phases; this is
+not vLLM equivalence. See [For verl users](docs/for-verl-users.md) for config,
+data, role and error mappings.
 
-### Earlier measured alignment case study
+## Tested profile boundary
 
-Alignment Lab v1 began from an SFT checkpoint already at 100% policy compliance
-and 100% retained tool utility in all three seeds. No continuation improved the
-ceiling; continued SFT and both OPD variants retained measured regressions.
-The two sandbox safety checks tied at zero while utility still regressed.
-IFEval, XSTest, HarmBench and RewardBench were not executed, and “preference
-win rate” is a deterministic Minipolicy paired outcome, not human preference.
-[Seed-level evidence](docs/alignment-lab/alignment-lab-v1.md).
+`verl-opd-v0.8-single-gpu-v1` pins official verl `v0.8.0` at commit
+`7aed6b230776f963fa09509c10d9c3a767d1102c`. Its executable path is intentionally
+narrow:
 
-- [RecoveryBench v1](docs/recoverybench/recoverybench-v1.md): frozen-student KD
-  beat slower fresh-state OPD on the preregistered primary view; the verifier
-  gate remained `insufficient_evidence`.
-- [Calculator benchmark](docs/benchmarking.md): both negative controls completed
-  normally at 0%; the ambiguous historical protocol-v1 prompt prevents
-  attributing failure solely to intrinsic teacher behavior.
-- [Limitations](docs/limitations.md), [math](docs/math.md),
-  [reproducibility](docs/reproducibility.md) and
-  [compatibility policy](docs/compatibility.md).
+- one trainable actor and one teacher;
+- one generated response per prompt (`n=1`);
+- reward-free generalized knowledge distillation;
+- `forward_kl_topk` with top-k plus tail targets and token-mean aggregation;
+- LoRA or QLoRA adapter updates on one CUDA GPU;
+- immutable model revisions and verl-style structured prompt Parquet.
+
+Policy-gradient OPD, task rewards, KL penalties, multi-teacher routing,
+multimodal inputs, PPO, GRPO, critics, Ray, FSDP, Megatron, multi-GPU and
+multi-node execution are unsupported. Known unsupported values receive a
+machine-readable classification; unknown fields and unresolved `${...}`
+interpolations are rejected. A resolved profile subset is input—not an
+arbitrary launch script.
+
+## Measured RTX 4080 path
+
+The packaged Qwen3-0.6B/1.7B smoke completed two 16-token rollouts and one OPD
+update on one RTX 4080 with **3.1758 GiB peak reserved VRAM**. The first update
+completed in **12.0224 seconds**, the final adapter was exported as standard
+PEFT/safetensors, and a clean reload passed. The recipe records immutable model
+revisions, phase timings, cache identity, checkpoint bytes and adapter hashes.
+
+This is deliberately a runtime and artifact proof. It is not a throughput
+benchmark, an alignment-quality endpoint, or evidence that OPD beats SFT, DPO
+or KD. Other NVIDIA GPUs use the same device-name-agnostic CUDA path, but model
+fit depends on VRAM, context length, quantization and installed kernels. Read
+the [exact smoke record and limitations](docs/opd-quickstart.md).
+
+### Choose a path by hardware, not GPU branding
+
+| Situation | Recommended starting point | What remains constant |
+| --- | --- | --- |
+| inspect on CPU or a laptop | `plan` and `run --dry-run` | full config classification |
+| one CUDA GPU with limited VRAM | QLoRA plus role swapping | logical batch and loss semantics |
+| same-base actor and teacher adapters | shared-backbone mode | explicit role provenance |
+| more VRAM available | larger physical phase batches | source data and optimizer intent |
+
+Automatic BF16/FP16 selection follows device support; it is not inferred from
+marketing names such as 3070, 4080, 5090 or Titan. `miniverl doctor` reports the
+installed CUDA/PyTorch path, and the planner keeps estimates visibly separate
+from measurements. There is no automatic downgrade to a different model,
+teacher, context, top-k or loss when memory is tight.
+
+## Data and artifact interoperability
+
+The profile consumes structured verl-style Parquet without substituting a toy
+environment. Prompt roles and content remain structured; data source, ability
+and extra metadata survive conversion. `miniverl convert-dataset` is available
+when crossing the native trajectory boundary, and rejects lossy rows unless the
+operator explicitly permits a partial conversion.
+
+A completed local run contains the resolved source config, compatibility
+matrix, local execution plan, trajectories, selected teacher targets,
+checkpoints, measurements and a PEFT adapter. Inspect before moving it:
+
+```bash
+miniverl inspect runs/my-opd/trajectories.jsonl
+miniverl cache stats runs/my-opd/teacher-cache
+miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout
+miniverl bridge doctor scaleout --json
+```
+
+The v0.8.1 export preserves student/teacher identities, Parquet bytes and pure
+OPD overrides, but reports `launchable: false` until exact base snapshots are
+materialized. Artifact completeness, upstream parse/load smoke, launchability,
+algorithm semantics and distributed execution are separate statuses. A
+successful bridge check never means that a distributed verl job ran. Review
+the [bridge contract](docs/verl-bridge.md) and [compatibility policy](docs/compatibility.md).
+
+The intended operating loop is **plan → inspect → run → inspect → export**.
+Direct execution remains convenient for experiments, but the JSON plan and
+compatibility report are the durable review surfaces: they expose model pins,
+data paths, loss details, physical batches, unsupported fields, estimated
+memory and every local reinterpretation before weights are allocated. Run
+artifacts then add measurements and hashes without rewriting the original
+source intent.
+
+## Research and validation
+
+miniVERL keeps every measured study—including negative results, superseded
+runs and preregistered early stops—public under the documentation. None is used
+as a claim that OPD universally beats SFT, DPO or KD: see the
+[v0.7 External Alignment Gate](docs/alignment-external/alignment-external-v1.md),
+[Alignment Lab](docs/alignment-lab/alignment-lab-v1.md),
+[RecoveryBench](docs/recoverybench/recoverybench-v1.md), and the
+[calculator study](docs/benchmarking.md).
 
 New runs establish tokenizer compatibility through structural identity. The
-legacy behavioral fingerprint is only a migration fallback, not identity proof.
+legacy behavioral fingerprint is retained only for migration and is not an
+identity proof. Scientific caveats and immutable source hashes remain in the
+detailed reports and [limitations](docs/limitations.md).
 
-## Develop
+## Development, security and license
 
 ```bash
 git clone https://github.com/DaoyuanLi2816/mini-verl.git
@@ -135,8 +225,8 @@ python -m pip install -e ".[dev]"
 pytest -q -m "not gpu and not network"
 ```
 
-Apache-2.0 licensed. See [CONTRIBUTING.md](CONTRIBUTING.md),
-[SECURITY.md](SECURITY.md), the [changelog](CHANGELOG.md) and
-[citation](CITATION.cff). Project records: [default GPU recipe](recipes/qwen_consumer_gpu_calc.yaml),
-[frozen calculator result](benchmarks/results/gpu-calc-hard-equal-update-v2.json)
-and [license](LICENSE).
+Contributions should keep the one-GPU boundary explicit and include tests for
+new failure modes. Report vulnerabilities privately through
+[SECURITY.md](SECURITY.md). See [CONTRIBUTING.md](CONTRIBUTING.md), the
+[changelog](CHANGELOG.md), [citation metadata](CITATION.cff),
+[reproducibility guide](docs/reproducibility.md), and [Apache-2.0 license](LICENSE).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — 单卡 LLM 后训练" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — 在单张个人 GPU 上运行 verl 风格 OPD" width="880">
 </p>
 
 <div align="center">
@@ -7,7 +7,6 @@
 [![CI](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/ci.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/ci.yml)
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
-[![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
 </div>
@@ -19,103 +18,166 @@
   <a href="README.md">English</a>
 </p>
 
-**在一张个人 GPU 上运行有明确边界的 verl 风格在线策略蒸馏。** miniVERL
-读取类型化的 verl v0.8 OPD profile 与 Parquet prompt，在本地执行 actor rollout
-→ teacher scoring → actor update，并导出标准 PEFT/Parquet/config 产物用于扩展。
-原生 SFT、DPO、KD 与 tool-agent recipe 仍然保留。
+**在一张个人 GPU 上运行边界明确的 verl 风格在线策略蒸馏。** miniVERL 读取类型化的
+verl 风格 YAML 与 Parquet prompt，在本地依次执行 actor rollout → teacher scoring →
+actor update，记录每个本地语义重解释，并导出标准 PEFT、Parquet 与配置产物供固定版本
+的 verl 接手扩展。
 
-PyPI `v0.8.0` 是稳定版；`main` 是开发版。miniVERL 独立于 verl，不声称可
-执行任意 verl YAML、分布式任务或具备完整算法兼容性。
+PyPI `v0.8.0` 是稳定版；`main` 是开发版。miniVERL 是独立项目，不代表上游背书；它
+不执行任意 verl YAML、不启动分布式任务，也不声称完整的算法兼容性。
 
-## 仅用 pip 的 OPD quickstart
+## 仅用 pip 的快速开始
+
+请先安装与本机 CUDA 匹配的 PyTorch wheel，然后运行：
 
 ```bash
 python -m pip install "miniverl[train]"
 miniverl data sample --format verl-parquet --out prompts.parquet
-miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config builtin:qwen3-0.6b-1.7b-opd \
+miniverl plan --profile verl-opd-v0.8-single-gpu-v1 \
+  --config builtin:qwen3-0.6b-1.7b-opd \
   --set 'data.train_files=["prompts.parquet"]'
-miniverl run --profile verl-opd-v0.8-single-gpu-v1 --config builtin:qwen3-0.6b-1.7b-opd \
+miniverl run --profile verl-opd-v0.8-single-gpu-v1 \
+  --config builtin:qwen3-0.6b-1.7b-opd \
   --set 'data.train_files=["prompts.parquet"]' --dry-run
 ```
 
-sample、plan 与 dry run 无需 Git checkout，plan 也不加载权重。在一张 CUDA GPU
-上去掉 `--dry-run` 即可执行锁定的 Qwen3-0.6B/1.7B NF4 recipe，并生成可加载的
-PEFT adapter。参见 [OPD quickstart](docs/opd-quickstart.md)。
+这些命令不需要 Git checkout。`data sample` 生成真实的结构化 Parquet；`plan` 在不加载
+权重时编译完整字段矩阵；`run --dry-run` 验证本地执行契约。在一张 NVIDIA CUDA GPU
+上移除 `--dry-run`，即可运行固定版本的 Qwen3-0.6B actor 与 Qwen3-1.7B teacher，并
+得到可检查、可重新加载的 PEFT adapter。
 
-## 支持的硬件与运行边界
+`train` extra 安装训练运行时，但不会选择正确的 CUDA PyTorch；`cuda` extra 只额外安装
+bitsandbytes。真实运行前请阅读[单卡安装与显存指南](docs/single-gpu-guide.md)。
 
-miniVERL 在 CPU 或一张 NVIDIA CUDA GPU 上运行单个本地进程。CUDA 路径不按
-显卡名称设限，但能否装下取决于模型组合、上下文、kernel 与显存。请先安装匹配
-本机 CUDA 的 PyTorch wheel，再安装 `miniverl[train,cuda]`；该 extra 本身不会
-选择 CUDA PyTorch。Ray、FSDP、Megatron、PPO、GRPO 与分布式启动不属于当前
-运行时。参见[单卡指南](docs/single-gpu-guide.md)。
+## 架构
 
-## verl 兼容性摘要
+<picture>
+  <source media="(max-width: 640px)" srcset="docs/verl-local-runtime-mobile.svg">
+  <img src="docs/verl-local-runtime.svg" alt="verl 风格 YAML、override 与 Parquet prompt 经过类型化编译器；一张 CUDA GPU 依次执行 actor rollout、teacher scoring 与 actor update；可检查产物交给固定版本 verl，而分布式执行不属于 miniVERL。">
+</picture>
 
-可执行 profile 锁定官方 verl `v0.8.0`、commit `7aed6b23`，支持单 actor、单 teacher、
-`n=1`、纯 GKD `forward_kl_topk`、token-mean、LoRA/QLoRA，且不使用 reward 或 KL
-penalty。PG OPD、task-reward mixture、多 teacher、多模态与分布式字段会 fail closed。
+miniVERL 在一个普通进程里按阶段调度模型角色。它不模拟 Ray resource pool，也不把本地
+Hugging Face generation 伪装成 vLLM。兼容报告保留源字段、解释本地含义、标注风险，
+并在字段改变算法或分布式语义时 fail closed。
 
-兼容的 OPD 导出不包含 reward scaffold；它保留 student/teacher 身份、Parquet 原始
-字节与 OPD overrides，但在精确 base snapshot 尚未 materialize 时仍为
-`launchable: false`。解析、产物可加载性、launchability 与分布式执行分别报告。
-参见[桥接契约](docs/verl-bridge.md)。
+原生 SFT、DPO、offline KD 与工具型 OPD recipe 仍然保留。它们共享严格 token provenance、
+无 pickle teacher cache、事务化 checkpoint 与 adapter 导出；但对于已有 verl 经验的用户，
+类型化 verl profile 是最短入口。
 
-## RTX 4080 运行时实测
+### 单一本地 scheduler，角色始终明确
 
-打包的 Qwen3-0.6B/1.7B recipe 完成了两条 16-token rollout 与一次 OPD update；
-**peak reserved VRAM 为 3.1758 GiB**，首次 update 在 **12.0224 秒**完成，标准
-PEFT adapter 成功重新加载。这只证明一个运行时/产物路径；没有运行对齐质量
-endpoint 或方法比较。[精确 recipe、计时与哈希](docs/opd-quickstart.md)。
+actor 使用当前 adapter 生成；teacher 只对 actor 实际访问的 token 位置评分；随后 actor 接收
+padded、token-mean update。teacher 不会被当作 reward model，tool output 不会成为训练标签，
+过期 actor-policy version 也不能进入 on-policy batch。显存规划可选择 resident、swap 或兼容
+的 shared-backbone，同时始终区分 actor、teacher 与 reference 身份。
 
-## 三条使用路径
+每个阶段都在跨越下一边界前写入证据：trajectory 带逐 token provenance，top-k teacher
+target 以无 pickle 格式校验，checkpoint 事务化发布，最终 adapter 用标准 PEFT loader 验证。
+因此崩溃后的检查与恢复不需要依靠终端文本猜测原始意图。
 
-| 路径 | 起点 | 真实产物 | 下一步 |
-| --- | --- | --- | --- |
-| **本地运行 OPD** | `miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml` | compiled plan、trajectory、target 与 PEFT adapter | [Plan 与 run](docs/opd-quickstart.md) |
-| **带入 verl config** | `miniverl import-verl --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml --out local-opd.yaml` | 字段报告与可往返 profile | [兼容性](docs/compatibility.md) |
-| **移动数据与产物** | `miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout` | Parquet + PEFT + OPD override bundle | [桥接契约](docs/verl-bridge.md) |
+## 从 verl 迁移？
 
-## 研究记录与保留的负结果
-
-### v0.7 External Alignment Gate
-
-这项预注册外部研究在教师或方法训练前停止。两个已声明的起始策略 lineage 中，
-所有候选的 retained JSONNav utility 都是 **0/64**，未改动下限为 20%。
-
-| 选中 checkpoint | 合格教师 | continuation arm | 已访问 final-test task |
-| ---: | ---: | ---: | ---: |
-| **0** | **0** | **0** | **0** |
+| verl 中的动作 | miniVERL 对应方式 |
+| --- | --- |
+| 传入 Hydra override | v0.8.1 中重复使用 `--set key=value` |
+| 检查 resolved config | `miniverl plan --json` |
+| 执行纯 OPD | `miniverl run` |
+| 复用 prompt Parquet | 直接设置 `data.train_files` |
+| 分配 rollout/teacher worker | 编译为单卡顺序阶段 |
+| 保存 FSDP/Megatron checkpoint | 不支持 |
+| 准备扩展交接 | `miniverl export-verl` |
 
 ```bash
-miniverl pilot --builtin-study alignment-external-v1 --json
+actor_rollout_ref.model.path=Qwen/Qwen3-0.6B
+distillation.teacher_models.teacher_model.model_path=Qwen/Qwen3-1.7B
+
+miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml \
+  --set actor_rollout_ref.actor.optim.lr=1e-5
 ```
 
-结果是 `do_not_continue_this_study` 与 `insufficient_evidence`，不是 SFT/DPO/KD/OPD
-之间的推荐。Granite Guardian 数值仅为未资格认证的 selection diagnostic；Granite、
-PairRM、教师资格认证和保留 final test 均未运行。参见[研究与限制](docs/alignment-external/alignment-external-v1.md)。
+公开内置 profile 刻意使用上游形状的 `name: vllm`。miniVERL 会把 rollout 与 teacher
+engine 名分类为本地重解释，再通过顺序本地 HF 阶段执行；这不等于 vLLM 语义。完整
+config、data、role 与错误映射见[面向 verl 用户的指南](docs/for-verl-users.md)。
 
-### 更早的对齐案例研究
+## 已测试的 profile 边界
 
-Alignment Lab v1 的起始 SFT checkpoint 在三个 seed 中已经达到 100% policy
-compliance 与 100% retained tool utility；没有 continuation 超过这个天花板，
-continued SFT 和两个 OPD arm 保留了实测退化。两个 sandbox safety check 同为零，
-同时 utility 仍然退化。IFEval、XSTest、HarmBench、RewardBench 未执行；
-“preference win rate”是确定性的 Minipolicy 配对结果，不是人类偏好。
-[逐 seed 证据](docs/alignment-lab/alignment-lab-v1.md)。
+`verl-opd-v0.8-single-gpu-v1` 固定官方 verl `v0.8.0` 与 commit
+`7aed6b230776f963fa09509c10d9c3a767d1102c`。可执行边界有意保持狭窄：
 
-- [RecoveryBench v1](docs/recoverybench/recoverybench-v1.md)：在预注册主视图中，
-  frozen-student KD 优于更慢的 fresh-state OPD；verifier gate 仍为
-  `insufficient_evidence`。
-- [Calculator benchmark](docs/benchmarking.md)：两个负对照都正常完成并得到 0%；
-  历史 protocol-v1 prompt 存在歧义，因此不能把失败仅归因于教师内在行为。
-- [限制](docs/limitations.md)、[数学](docs/math.md)、[复现](docs/reproducibility.md)
-  与[兼容性政策](docs/compatibility.md)。
+- 一个可训练 actor 与一个 teacher；
+- 每个 prompt 只生成一个 response（`n=1`）；
+- 无 reward 的 generalized knowledge distillation；
+- `forward_kl_topk`、top-k + tail target 与 token-mean 聚合；
+- 一张 CUDA GPU 上的 LoRA/QLoRA adapter 更新；
+- 不可变模型 revision 与 verl 风格结构化 prompt Parquet。
 
-新运行以结构身份确认 tokenizer 兼容性；旧 behavioral fingerprint 只用于迁移，
-不是身份凭证。
+PG OPD、task reward、KL penalty、多 teacher、多模态、PPO、GRPO、critic、Ray、FSDP、
+Megatron、多 GPU 与多节点均不支持。已知不支持值会得到机器可读分类；未知字段和未解析
+的 `${...}` 会被拒绝。输入必须是 resolved profile 子集，而不是任意启动脚本。
 
-## 开发
+## RTX 4080 实测路径
+
+打包的 Qwen3-0.6B/1.7B smoke 在一张 RTX 4080 上完成两条 16-token rollout 与一次
+OPD update，**peak reserved VRAM 为 3.1758 GiB**，首次 update 在 **12.0224 秒**完成；
+标准 PEFT/safetensors adapter 导出与干净重载均通过。recipe 同时记录不可变模型 revision、
+阶段计时、cache 身份、checkpoint 字节数与 adapter 哈希。
+
+这只证明一个运行时与产物路径，不是吞吐 benchmark、对齐质量 endpoint，也不证明 OPD
+优于 SFT、DPO 或 KD。其他 NVIDIA GPU 使用相同的 device-name-agnostic CUDA 路径，但
+能否装下仍取决于显存、上下文、量化与 kernel。见[精确实测记录](docs/opd-quickstart.md)。
+
+### 按硬件条件选择路径，而不是按显卡名称
+
+| 情况 | 建议起点 | 保持不变的内容 |
+| --- | --- | --- |
+| CPU 或笔记本上先检查 | `plan` 与 `run --dry-run` | 完整配置分类 |
+| 单张小显存 CUDA GPU | QLoRA 与角色 swap | 逻辑 batch 与 loss 语义 |
+| 同 base 的 actor/teacher adapter | shared-backbone | 明确角色 provenance |
+| 显存更充足 | 增大各阶段 physical batch | 数据与 optimizer 意图 |
+
+BF16/FP16 自动选择取决于设备能力，而不是 3070、4080、5090 或 Titan 等市场名称。
+`miniverl doctor` 报告实际 CUDA/PyTorch 路径，planner 会把 estimate 与 measurement 分开。
+显存紧张时不会静默更换模型、teacher、context、top-k 或 loss。
+
+## 数据与产物互操作
+
+profile 直接读取结构化 verl 风格 Parquet，不会在缺失数据时静默换成 calculator 环境。
+prompt 的 role/content 保持结构化，data source、ability 与 extra metadata 也会保留。跨越
+原生 trajectory 边界时可用 `miniverl convert-dataset`；除非明确允许部分转换，任何有损行
+都会被拒绝。
+
+本地 run 包含源配置、兼容矩阵、本地执行计划、trajectory、teacher target、checkpoint、
+实测记录与 PEFT adapter。导出前可执行：
+
+```bash
+miniverl inspect runs/my-opd/trajectories.jsonl
+miniverl cache stats runs/my-opd/teacher-cache
+miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout
+miniverl bridge doctor scaleout --json
+```
+
+v0.8.1 export 保留 student/teacher 身份、Parquet 原始字节与纯 OPD override；精确 base
+snapshot materialize 之前仍报告 `launchable: false`。产物完整性、上游 parse/load smoke、
+launchability、算法语义与 distributed execution 分开报告。bridge doctor 通过并不表示运行过
+分布式 verl。详见[桥接契约](docs/verl-bridge.md)与[兼容性政策](docs/compatibility.md)。
+
+建议操作闭环是 **plan → inspect → run → inspect → export**。JSON plan 与兼容报告在分配
+权重前明确模型 pin、数据路径、loss、physical batch、不支持字段、显存 estimate 与所有本地
+重解释；run artifact 只在其上补充 measurement 与 hash，不会改写源意图。
+
+## 研究与验证
+
+miniVERL 将所有实测研究——包括负结果、被取代的运行与预注册 early stop——继续公开在
+文档中；它们都不会被用来宣称 OPD 普遍优于 SFT、DPO 或 KD。参见
+[v0.7 External Alignment Gate](docs/alignment-external/alignment-external-v1.md)、
+[Alignment Lab](docs/alignment-lab/alignment-lab-v1.md)、
+[RecoveryBench](docs/recoverybench/recoverybench-v1.md)与
+[calculator study](docs/benchmarking.md)。
+
+新运行通过结构身份确认 tokenizer 兼容性；旧 behavioral fingerprint 只用于迁移，不是身份
+证明。科学限制与不可变源哈希继续保留在详细报告和[限制页面](docs/limitations.md)。
+
+## 开发、安全与许可
 
 ```bash
 git clone https://github.com/DaoyuanLi2816/mini-verl.git
@@ -124,5 +186,6 @@ python -m pip install -e ".[dev]"
 pytest -q -m "not gpu and not network"
 ```
 
-Apache-2.0 许可。参见 [CONTRIBUTING.md](CONTRIBUTING.md)、
-[SECURITY.md](SECURITY.md)、[changelog](CHANGELOG.md) 与 [citation](CITATION.cff)。
+贡献应保持单卡边界清晰，并为新失败模式添加测试。安全问题请按 [SECURITY.md](SECURITY.md)
+私下报告。另见 [CONTRIBUTING.md](CONTRIBUTING.md)、[changelog](CHANGELOG.md)、
+[citation](CITATION.cff)、[复现指南](docs/reproducibility.md)与 [Apache-2.0 license](LICENSE)。

--- a/docs/banner.svg
+++ b/docs/banner.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 250" width="880" height="250"
      role="img" aria-labelledby="banner-title banner-desc">
   <title id="banner-title">miniVERL</title>
-  <desc id="banner-desc">A one-GPU CUDA lab for comparing alignment and distillation after SFT.</desc>
+  <desc id="banner-desc">A bounded local runtime for verl-style on-policy distillation on one CUDA GPU.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#030711"/>
@@ -46,13 +46,13 @@
       mini<tspan fill="url(#brand)">VERL</tspan>
     </text>
     <text x="44" y="109" font-size="14.8" font-weight="570" fill="#e2e8f0">
-      Online alignment and distillation after SFT.
+      Run verl-style OPD on one consumer GPU.
     </text>
     <text x="44" y="135" font-size="12.8" fill="#a9b8cf">
-      Compare policy quality, retained utility, and cost
+      Typed config, Parquet prompts, local role scheduling,
     </text>
     <text x="44" y="154" font-size="12.8" fill="#a9b8cf">
-      before choosing SFT, DPO, or OPD.
+      inspectable targets and standard PEFT artifacts.
     </text>
 
     <g font-size="11.2" font-weight="680">
@@ -87,8 +87,8 @@
               stroke="#67e8f9" stroke-opacity=".52"/>
       <path d="M444 57h12M450 51v12" stroke="#a5f3fc" stroke-width="1.8"
             stroke-linecap="round"/>
-      <text x="478" y="52" font-size="14" font-weight="720" fill="#f8fafc">Start</text>
-      <text x="478" y="71" font-size="12" fill="#afbed3">One SFT checkpoint · explicit policy roles</text>
+      <text x="478" y="52" font-size="14" font-weight="720" fill="#f8fafc">Compile</text>
+      <text x="478" y="71" font-size="12" fill="#afbed3">verl-shaped YAML · typed compatibility report</text>
     </g>
 
     <g>
@@ -99,8 +99,8 @@
               stroke="#93c5fd" stroke-opacity=".52"/>
       <path d="M443 121h14M443 125h9M443 129h12" stroke="#dbeafe" stroke-width="1.8"
             stroke-linecap="round"/>
-      <text x="478" y="120" font-size="14" font-weight="720" fill="#f8fafc">Compare</text>
-      <text x="478" y="139" font-size="12" fill="#afbed3">SFT · DPO · offline KD · online OPD</text>
+      <text x="478" y="120" font-size="14" font-weight="720" fill="#f8fafc">Run locally</text>
+      <text x="478" y="139" font-size="12" fill="#afbed3">actor rollout · teacher score · actor update</text>
     </g>
 
     <g>
@@ -111,8 +111,8 @@
               stroke="#d8b4fe" stroke-opacity=".52"/>
       <path d="M443 197l5-7 5 4 5-8" fill="none" stroke="#f3e8ff" stroke-width="1.8"
             stroke-linecap="round" stroke-linejoin="round"/>
-      <text x="478" y="188" font-size="14" font-weight="720" fill="#f8fafc">Decide</text>
-      <text x="478" y="207" font-size="12" fill="#afbed3">Alignment · utility · queries · GPU time</text>
+      <text x="478" y="188" font-size="14" font-weight="720" fill="#f8fafc">Inspect &amp; export</text>
+      <text x="478" y="207" font-size="12" fill="#afbed3">PEFT · Parquet · targets · metrics · provenance</text>
     </g>
   </g>
 </svg>

--- a/docs/for-verl-users.md
+++ b/docs/for-verl-users.md
@@ -1,0 +1,124 @@
+# For verl users
+
+miniVERL is a local runtime for one documented subset of verl v0.8 OPD. It
+keeps familiar field names and Parquet data, then compiles distributed resource
+intent into sequential phases on one CUDA GPU. It is an independent project;
+the mapping is explicit and does not imply endorsement or full compatibility.
+
+<picture>
+  <source media="(max-width: 640px)" srcset="../verl-local-runtime-mobile.svg">
+  <img src="../verl-local-runtime.svg" alt="verl-shaped YAML, overrides and Parquet prompts pass through a typed compiler; one CUDA GPU runs actor rollout, teacher scoring and actor update; portable artifacts can be handed to pinned verl while distributed execution remains outside miniVERL.">
+</picture>
+
+## What you can reuse
+
+- A resolved YAML using the `verl-opd-v0.8-single-gpu-v1` field subset.
+- Reward-free verl-style Parquet prompts with structured chat messages.
+- One actor, one teacher, `n=1`, forward top-k GKD and token-mean aggregation.
+- Immutable Hugging Face revisions, PEFT adapters and tokenizer snapshots.
+- Familiar fields such as `actor_rollout_ref.model.path`,
+  `distillation.teacher_models.teacher_model.model_path`, response bounds,
+  learning rate and LoRA configuration.
+
+What is not reusable: arbitrary Hydra composition, shell launch scripts,
+resource pools, Ray actors, FSDP/Megatron checkpoints, PPO/GRPO, critics,
+policy-gradient OPD, task-reward mixtures, multiple teachers and multimodal
+workers. Unsupported semantics fail closed instead of falling back silently.
+
+## Command mapping
+
+| verl action | miniVERL action |
+| --- | --- |
+| compose or capture a resolved config | provide resolved YAML to `--config` |
+| add a Hydra override | repeat `--set key=value` |
+| inspect resolved intent | `miniverl plan --json` |
+| launch OPD | `miniverl run` |
+| read prompt Parquet | use the file directly |
+| allocate resource pools | compile to sequential local phases |
+| save a distributed checkpoint | unsupported |
+| hand artifacts back | `miniverl export-verl` |
+
+```bash
+miniverl plan --profile verl-opd-v0.8-single-gpu-v1 \
+  --config verl-opd.yaml \
+  --set 'data.train_files=["data/train.parquet"]' \
+  --set actor_rollout_ref.actor.optim.lr=1e-5
+```
+
+Planning is weight-free and offline. Use `--json` to retain the complete field
+matrix. v0.8.1 accepts only repeated `--set`; it does not execute `${...}`
+interpolations or shell text.
+
+## Same fields, different placement
+
+An upstream-shaped fragment can stay recognizable:
+
+```yaml
+actor_rollout_ref:
+  model: {path: Qwen/Qwen3-0.6B}
+  rollout: {name: vllm, n: 1}
+distillation:
+  teacher_models:
+    teacher_model:
+      model_path: Qwen/Qwen3-1.7B
+      inference: {name: vllm}
+```
+
+miniVERL does not launch vLLM here. The compiler classifies both engine names
+as local reinterpretations and runs local Hugging Face generation and teacher
+scoring sequentially. The source value, local meaning and risk are preserved in
+the compatibility report.
+
+## Data mapping
+
+`data.train_files`, `data.val_files`, `data.prompt_key`, prompt and response
+bounds, shuffle and seed feed the native Parquet source directly. Each prompt
+row preserves its structured messages and source metadata. Run
+`miniverl data sample --out prompts.parquet` for a valid small file, or use
+`miniverl convert-dataset` when crossing the native trajectory boundary.
+
+The compiler never substitutes a calculator environment for missing Parquet
+data. A missing file is an actionable error when execution begins. Dataset
+bytes and schema are copied into export provenance.
+
+## Actor, teacher and reference roles
+
+The actor is the trainable PEFT policy. The teacher produces top-k plus tail
+targets on actor-generated tokens. Pure GKD in this profile has no reference
+policy, critic, task reward or policy-gradient term. Local runtime strategies
+may keep roles resident, swap them, or share a compatible backbone, but role
+identities never collapse in provenance.
+
+## Export boundary
+
+```bash
+miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout
+miniverl bridge doctor scaleout --json
+```
+
+The v0.8.1 bundle carries PEFT, Parquet, config and provenance artifacts, but is
+reported as `launchable: false` until exact base snapshots are materialized.
+Upstream parse/load smoke, artifact completeness, launchability and distributed
+execution are separate statuses. miniVERL never reports a distributed job as
+tested.
+
+## Common errors
+
+- **Unknown field:** capture a resolved config and remove fields outside the
+  documented profile; inspect-only compilation can still explain known
+  unsupported values.
+- **Algorithm field rejected:** PG OPD, rewards, KL penalties, `n>1`, multiple
+  teachers and distributed counts are intentionally unsupported.
+- **Interpolation rejected:** resolve Hydra/OmegaConf in your trusted verl
+  environment first. miniVERL will not execute `${...}`.
+- **Prompt schema mismatch:** validate the Parquet `prompt` column as structured
+  role/content messages, or convert it explicitly.
+- **Tokenizer mismatch:** actor and teacher scoring require structural identity
+  for the shared token space; a legacy behavioral fingerprint is not proof.
+- **CUDA out of memory:** reduce context, response length or physical batches;
+  keep logical update semantics unchanged. See [single-GPU planning](single-gpu-guide.md).
+- **Bundle not launchable:** this is expected before exact model snapshots are
+  present. Read the [bridge boundary](verl-bridge.md).
+
+Next: follow the [OPD quickstart](opd-quickstart.md), inspect the
+[compatibility policy](compatibility.md), or review [all limitations](limitations.md).

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -6,7 +6,8 @@ after the exact release commit and its remote checks are green.
 
 ## v0.8.1 development
 
-- [ ] Define the focused v0.8.1 scope before changing runtime semantics.
+- [x] Keep the release to product positioning, migration documentation and an
+      explicit vocabulary correction; no algorithm or long GPU workload changed.
 - [ ] Preserve v0.8.0 tags, public artifacts and frozen benchmark bytes.
 - [ ] Complete the full release, compatibility and public-distribution gates.
 

--- a/docs/verl-local-runtime-mobile.svg
+++ b/docs/verl-local-runtime-mobile.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 390 930" role="img" aria-labelledby="title desc">
+  <title id="title">miniVERL local OPD product flow, mobile layout</title>
+  <desc id="desc">A vertical view of typed verl-shaped inputs, local one-GPU OPD phases, inspectable artifacts and the bounded export to pinned verl. Distributed execution is outside miniVERL.</desc>
+  <defs><linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#050816"/><stop offset="1" stop-color="#111b38"/></linearGradient><marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0 0l10 5-10 5z" fill="#67e8f9"/></marker></defs>
+  <rect width="390" height="930" rx="20" fill="url(#bg)"/><rect x="1" y="1" width="388" height="928" rx="19" fill="none" stroke="#475569"/>
+  <g font-family="Inter,DejaVu Sans,Segoe UI,sans-serif">
+    <text x="24" y="42" fill="#f8fafc" font-size="20" font-weight="750">One-GPU OPD workflow</text><text x="24" y="68" fill="#94a3b8" font-size="14">typed · inspectable · fail-closed</text>
+    <g fill="#0f2740" stroke="#38bdf8"><rect x="24" y="96" width="342" height="94" rx="14"/><rect x="24" y="226" width="342" height="104" rx="14"/><rect x="24" y="366" width="342" height="218" rx="14"/></g>
+    <text x="44" y="126" fill="#67e8f9" font-size="13" font-weight="700">INPUTS</text><text x="44" y="154" fill="#f8fafc" font-size="17" font-weight="700">verl-shaped YAML + overrides</text><text x="44" y="177" fill="#cbd5e1" font-size="15">Parquet prompt data</text>
+    <path d="M195 190v28M195 330v28M195 584v28M195 728v28" stroke="#67e8f9" stroke-width="3" marker-end="url(#a)"/>
+    <text x="44" y="256" fill="#67e8f9" font-size="13" font-weight="700">TYPED COMPILER</text><text x="44" y="286" fill="#f8fafc" font-size="17" font-weight="700">Compatibility report</text><text x="44" y="311" fill="#cbd5e1" font-size="15">exact · reinterpreted · rejected</text>
+    <text x="44" y="398" fill="#67e8f9" font-size="13" font-weight="700">LOCAL SCHEDULER · 1× CUDA GPU</text>
+    <g fill="#172554" stroke="#818cf8"><rect x="44" y="423" width="302" height="42" rx="10"/><rect x="44" y="477" width="302" height="42" rx="10"/><rect x="44" y="531" width="302" height="42" rx="10"/></g>
+    <text x="195" y="450" text-anchor="middle" fill="#e0e7ff" font-size="16" font-weight="650">actor rollout</text><text x="195" y="504" text-anchor="middle" fill="#e0e7ff" font-size="16" font-weight="650">teacher scoring</text><text x="195" y="558" text-anchor="middle" fill="#e0e7ff" font-size="16" font-weight="650">actor update</text>
+    <rect x="24" y="620" width="342" height="108" rx="14" fill="#18213c" stroke="#a78bfa"/><text x="44" y="651" fill="#c4b5fd" font-size="13" font-weight="700">INSPECTABLE OUTPUTS</text><text x="44" y="680" fill="#f8fafc" font-size="16" font-weight="650">checkpoint · PEFT · targets</text><text x="44" y="704" fill="#cbd5e1" font-size="15">trajectories · metrics · provenance</text>
+    <rect x="24" y="764" width="342" height="70" rx="14" fill="#12313a" stroke="#2dd4bf"/><text x="195" y="793" text-anchor="middle" fill="#ccfbf1" font-size="15" font-weight="700">materialized export bundle</text><text x="195" y="817" text-anchor="middle" fill="#ccfbf1" font-size="15">→ pinned verl v0.8.0</text>
+    <rect x="24" y="852" width="342" height="54" rx="14" fill="#34151b" stroke="#fb7185" stroke-dasharray="7 5"/><text x="195" y="875" text-anchor="middle" fill="#fecdd3" font-size="13" font-weight="750">OUTSIDE miniVERL</text><text x="195" y="896" text-anchor="middle" fill="#fff1f2" font-size="15">distributed execution</text>
+  </g>
+</svg>

--- a/docs/verl-local-runtime.svg
+++ b/docs/verl-local-runtime.svg
@@ -36,7 +36,8 @@
 
     <rect x="342" y="306" width="730" height="84" rx="16" fill="#18213c" stroke="#a78bfa"/>
     <text x="364" y="338" fill="#c4b5fd" font-size="14" font-weight="700">INSPECTABLE OUTPUTS</text>
-    <text x="364" y="369" fill="#f8fafc" font-size="17" font-weight="650">checkpoint · PEFT adapter · teacher targets · trajectories · metrics · provenance</text>
+    <text x="364" y="362" fill="#f8fafc" font-size="16" font-weight="650">checkpoint · PEFT adapter · teacher targets · trajectories</text>
+    <text x="364" y="382" fill="#cbd5e1" font-size="15">metrics · provenance · source and compatibility records</text>
     <path d="M707 390v42" stroke="#67e8f9" stroke-width="3" marker-end="url(#arrow)"/>
 
     <rect x="342" y="440" width="468" height="38" rx="12" fill="#12313a" stroke="#2dd4bf"/>

--- a/docs/verl-local-runtime.svg
+++ b/docs/verl-local-runtime.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 500" role="img" aria-labelledby="title desc">
+  <title id="title">miniVERL local OPD product flow</title>
+  <desc id="desc">verl-shaped configuration and Parquet prompts enter a typed compiler, then one GPU runs actor rollout, teacher scoring, and actor update. Inspectable artifacts can be exported to pinned verl; distributed execution remains outside miniVERL.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#050816"/><stop offset="1" stop-color="#111b38"/></linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0"><stop stop-color="#22d3ee"/><stop offset="1" stop-color="#a78bfa"/></linearGradient>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0l10 5-10 5z" fill="#67e8f9"/></marker>
+  </defs>
+  <rect width="1120" height="500" rx="24" fill="url(#bg)"/>
+  <rect x="1" y="1" width="1118" height="498" rx="23" fill="none" stroke="#475569"/>
+  <g font-family="Inter,DejaVu Sans,Segoe UI,sans-serif">
+    <text x="48" y="54" fill="#f8fafc" font-size="25" font-weight="750">One-GPU OPD, from familiar inputs to portable artifacts</text>
+    <text x="48" y="82" fill="#94a3b8" font-size="16">Every boundary is typed, recorded, and fail-closed.</text>
+
+    <g fill="#0f2740" stroke="#38bdf8">
+      <rect x="48" y="124" width="244" height="124" rx="16"/>
+      <rect x="342" y="124" width="244" height="124" rx="16"/>
+      <rect x="636" y="124" width="436" height="124" rx="16"/>
+    </g>
+    <text x="70" y="158" fill="#67e8f9" font-size="14" font-weight="700">INPUTS</text>
+    <text x="70" y="190" fill="#f8fafc" font-size="18" font-weight="700">verl-shaped YAML</text>
+    <text x="70" y="216" fill="#cbd5e1" font-size="16">overrides · Parquet prompts</text>
+    <text x="364" y="158" fill="#67e8f9" font-size="14" font-weight="700">COMPILER</text>
+    <text x="364" y="190" fill="#f8fafc" font-size="18" font-weight="700">Typed compatibility</text>
+    <text x="364" y="216" fill="#cbd5e1" font-size="16">exact · reinterpreted · rejected</text>
+    <text x="658" y="158" fill="#67e8f9" font-size="14" font-weight="700">LOCAL ROLE SCHEDULER · 1× CUDA GPU</text>
+    <g fill="#172554" stroke="#818cf8">
+      <rect x="658" y="177" width="116" height="48" rx="12"/><rect x="795" y="177" width="116" height="48" rx="12"/><rect x="932" y="177" width="116" height="48" rx="12"/>
+    </g>
+    <text x="716" y="207" text-anchor="middle" fill="#e0e7ff" font-size="15" font-weight="650">actor rollout</text>
+    <text x="853" y="196" text-anchor="middle" fill="#e0e7ff" font-size="15" font-weight="650">teacher</text><text x="853" y="220" text-anchor="middle" fill="#e0e7ff" font-size="15">scoring</text>
+    <text x="990" y="196" text-anchor="middle" fill="#e0e7ff" font-size="15" font-weight="650">actor</text><text x="990" y="220" text-anchor="middle" fill="#e0e7ff" font-size="15">update</text>
+
+    <path d="M292 186h42M586 186h42" stroke="#67e8f9" stroke-width="3" marker-end="url(#arrow)"/>
+    <path d="M716 248v48" stroke="#67e8f9" stroke-width="3" marker-end="url(#arrow)"/>
+
+    <rect x="342" y="306" width="730" height="84" rx="16" fill="#18213c" stroke="#a78bfa"/>
+    <text x="364" y="338" fill="#c4b5fd" font-size="14" font-weight="700">INSPECTABLE OUTPUTS</text>
+    <text x="364" y="369" fill="#f8fafc" font-size="17" font-weight="650">checkpoint · PEFT adapter · teacher targets · trajectories · metrics · provenance</text>
+    <path d="M707 390v42" stroke="#67e8f9" stroke-width="3" marker-end="url(#arrow)"/>
+
+    <rect x="342" y="440" width="468" height="38" rx="12" fill="#12313a" stroke="#2dd4bf"/>
+    <text x="576" y="465" text-anchor="middle" fill="#ccfbf1" font-size="16" font-weight="700">materialized export bundle → pinned verl v0.8.0</text>
+    <rect x="830" y="432" width="242" height="54" rx="12" fill="#34151b" stroke="#fb7185" stroke-dasharray="7 5"/>
+    <text x="951" y="454" text-anchor="middle" fill="#fecdd3" font-size="14" font-weight="750">OUTSIDE miniVERL</text>
+    <text x="951" y="475" text-anchor="middle" fill="#fff1f2" font-size="15">distributed execution</text>
+  </g>
+</svg>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: miniVERL
-site_description: Auditable single-GPU post-training with a bounded verl artifact bridge
+site_description: Run a documented subset of verl-style OPD on one consumer GPU
 site_url: https://daoyuanli2816.github.io/mini-verl/
 repo_url: https://github.com/DaoyuanLi2816/mini-verl
 repo_name: DaoyuanLi2816/mini-verl
@@ -39,6 +39,7 @@ plugins:
   - search
 nav:
   - Home: index.md
+  - For verl users: for-verl-users.md
   - Run verl-style OPD: opd-quickstart.md
   - Start on one GPU: single-gpu-guide.md
   - Align:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "miniverl"
 dynamic = ["version"]
-description = "Auditable single-GPU alignment and distillation with a bounded verl artifact bridge."
+description = "Run a documented subset of verl-style OPD on one consumer GPU."
 readme = "PYPI.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
@@ -23,6 +23,9 @@ keywords = [
   "qwen",
   "llm-agents",
   "verl",
+  "gkd",
+  "parquet",
+  "peft",
 ]
 classifiers = [
   "Development Status :: 4 - Beta",

--- a/scripts/build_pypi_readme.py
+++ b/scripts/build_pypi_readme.py
@@ -18,7 +18,7 @@ _LINKED_IMAGE = re.compile(
 )
 _MARKDOWN_LINK = re.compile(r"(!?\[[^\]]*])\(([^)\s]+)([^)]*)\)")
 _ANY_MARKDOWN_TARGET = re.compile(r"]\((?P<target>[^)\s]+)[^)]*\)")
-_HTML_TARGET = re.compile(r'(?P<prefix>\b(?:src|href)=")(?P<target>[^"]+)(?P<suffix>")')
+_HTML_TARGET = re.compile(r'(?P<prefix>\b(?:src|srcset|href)=")(?P<target>[^"]+)(?P<suffix>")')
 _VERSION = re.compile(r'^__version__\s*=\s*"(?P<version>[^"]+)"\s*$', re.MULTILINE)
 
 
@@ -102,7 +102,7 @@ def build_pypi_readme(root: Path, *, version: str | None = None) -> str:
 
     def replace_html(match: re.Match[str]) -> str:
         target = match.group("target")
-        image = match.group("prefix").startswith('src="')
+        image = match.group("prefix").startswith(("src=", "srcset="))
         converted = _project_target(target, ref=ref, image=image)
         return f"{match.group('prefix')}{converted}{match.group('suffix')}"
 

--- a/scripts/check_docs_visual.py
+++ b/scripts/check_docs_visual.py
@@ -31,6 +31,7 @@ from typing import Any
 VIEWPORTS = ((1440, 900), (1024, 768), (820, 1000), (390, 844))
 PAGES = (
     "/",
+    "/for-verl-users/",
     "/alignment-lab/alignment-lab-v1/",
     "/alignment-external/alignment-external-v1/",
     "/consumer-runtime/",

--- a/src/miniverl/cli.py
+++ b/src/miniverl/cli.py
@@ -30,9 +30,9 @@ from miniverl.utils.runs import make_run_id
 app = typer.Typer(
     name="miniverl",
     help=(
-        "Auditable single-GPU alignment and distillation runtime.\n\n"
-        "Run native local workflows, inspect every artifact, and exchange standard "
-        "HF/PEFT/Parquet artifacts through a bounded verl artifact bridge."
+        "Run a documented subset of verl-style OPD on one consumer GPU.\n\n"
+        "Compile typed verl-shaped config, reuse Parquet prompts, execute actor rollout, "
+        "teacher scoring and actor update locally, then export inspectable PEFT artifacts."
     ),
     add_completion=False,
     no_args_is_help=True,
@@ -139,7 +139,7 @@ def main(
         envvar="MINIVERL_LOG_LEVEL",
     ),
 ) -> None:
-    """miniVERL: an auditable single-GPU alignment and distillation runtime."""
+    """miniVERL: the bounded local runtime for verl-style OPD on one GPU."""
     from miniverl.utils.logging import configure_logging
 
     configure_logging(log_level)

--- a/src/miniverl/resources/qwen3_0_6b_1_7b_opd.yaml
+++ b/src/miniverl/resources/qwen3_0_6b_1_7b_opd.yaml
@@ -25,7 +25,9 @@ actor_rollout_ref:
     ppo_max_token_len_per_gpu: 512
     use_dynamic_bsz: true
   rollout:
-    name: local_hf
+    # Upstream-shaped vocabulary. The compatibility report records that
+    # miniVERL executes this with its local HF rollout runtime, not vLLM.
+    name: vllm
     n: 1
     temperature: 0.0
     top_p: 1.0
@@ -45,7 +47,8 @@ distillation:
       model_path: Qwen/Qwen3-1.7B
       num_replicas: 1
       inference:
-        name: local_hf
+        # Likewise compiled into the sequential local teacher-scoring phase.
+        name: vllm
         dtype: bfloat16
         tensor_model_parallel_size: 1
         data_parallel_size: 1

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -232,9 +232,10 @@ def test_root_help_describes_the_current_product_without_promising_v08() -> None
 
     assert result.exit_code == 0
     collapsed = _collapse(result.stdout)
-    assert "single-GPU alignment and distillation runtime" in collapsed
-    assert "bounded verl artifact bridge" in collapsed
-    assert "documented subset of verl-style OPD" not in collapsed
+    assert "documented subset of verl-style OPD on one consumer GPU" in collapsed
+    assert "teacher scoring and actor update locally" in collapsed
+    assert "inspectable PEFT artifacts" in collapsed
+    assert "distributed verl execution" not in collapsed
 
 
 def test_command_set_matches_the_documented_set() -> None:

--- a/tests/unit/test_opd_runtime_plan.py
+++ b/tests/unit/test_opd_runtime_plan.py
@@ -14,6 +14,18 @@ def test_builtin_plan_is_weight_free_truthful_and_executable() -> None:
     plan = build_system_plan(compiled)
 
     assert plan.executable is True
+    assert compiled.source.actor_rollout_ref.rollout.name == "vllm"
+    assert compiled.source.distillation.teacher_models.teacher_model.inference.name == "vllm"
+    engine_rules = {
+        item.upstream_field: item
+        for item in compiled.compatibility
+        if item.upstream_field.endswith("name")
+    }
+    assert engine_rules["actor_rollout_ref.rollout.name"].classification == "locally_reinterpreted"
+    assert (
+        engine_rules["distillation.teacher_models.teacher_model.inference.name"].classification
+        == "locally_reinterpreted"
+    )
     assert plan.upstream["commit"] == "7aed6b230776f963fa09509c10d9c3a767d1102c"
     assert plan.student["revision"] == "c1899de289a04d12100db370d81485cdf75e47ca"
     assert plan.teacher["revision"] == "70d244cc86ccca08cf5af4e1e306ecf908b1ad5e"

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -401,7 +401,9 @@ def test_single_gpu_visual_identity_and_pypi_link_are_prominent() -> None:
     assert "1× CUDA GPU" in banner
     assert "BF16 / FP16 auto" in banner
     assert "typed provenance" in banner
-    assert "Alignment · utility · queries · GPU time" in banner
+    assert "Run verl-style OPD on one consumer GPU" in banner
+    assert "actor rollout · teacher score · actor update" in banner
+    assert "PEFT · Parquet · targets · metrics · provenance" in banner
     assert 'pip install "miniverl[train,cuda]"' not in banner
     assert "the GPU you have" not in banner
     assert "16 GB first" not in banner
@@ -446,15 +448,14 @@ def test_generated_pypi_readme_is_byte_bound_and_has_only_navigable_project_link
     assert "C:\\Users\\" not in committed
     assert "/home/" not in committed
     assert not re.search(r"!?\[[^]]*]\((?!https?://|#|mailto:)[^)]+\)", committed)
-    assert not re.search(r'(?:src|href)="(?!https?://|#|mailto:)[^"]+"', committed)
+    assert not re.search(r'(?:src|srcset|href)="(?!https?://|#|mailto:)[^"]+"', committed)
     assert relative_project_targets(committed) == []
     assert f"https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/{ref}/docs/banner.svg" in (
         committed
     )
     for path in (
         "docs/single-gpu-guide.md",
-        "recipes/qwen_consumer_gpu_calc.yaml",
-        "benchmarks/results/gpu-calc-hard-equal-update-v2.json",
+        "docs/for-verl-users.md",
         "CHANGELOG.md",
         "CITATION.cff",
         "LICENSE",
@@ -462,6 +463,10 @@ def test_generated_pypi_readme_is_byte_bound_and_has_only_navigable_project_link
         "SECURITY.md",
     ):
         assert f"https://github.com/DaoyuanLi2816/mini-verl/blob/{ref}/{path}" in committed
+    for path in ("docs/verl-local-runtime.svg", "docs/verl-local-runtime-mobile.svg"):
+        assert (
+            f"https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/{ref}/{path}" in committed
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed

- reframes the English, Chinese and PyPI landing pages around the bounded one-GPU verl OPD workflow;
- adds responsive desktop/mobile architecture diagrams and a dedicated migration guide for verl users;
- uses upstream-shaped `vllm` vocabulary in the packaged Qwen3 profile while retaining explicit local-HF reinterpretation classifications;
- aligns banner, package metadata, CLI help, MkDocs navigation and citation wording;
- expands the browser visual gate to the new migration page and teaches the PyPI README generator about responsive `srcset` assets.

## Why

v0.8.0 shipped the executable profile, but the public surface still read primarily like a collection of research studies. This release makes the supported product journey discoverable without changing its algorithmic or distributed boundary. The research record remains public and is compressed to four direct links on the landing page.

## Compatibility boundary

The supported profile remains `verl-opd-v0.8-single-gpu-v1`, pinned to verl v0.8.0 at `7aed6b230776f963fa09509c10d9c3a767d1102c`. Local execution remains sequential HF phases. No distributed job or new scientific comparison was run.

## Validation

- Ruff check and format: passed
- mypy over `src/miniverl` and `scripts`: passed
- non-GPU/non-network: 2,178 passed, 9 skipped, 85.06% branch coverage
- GPU: 8 passed on one RTX 4080
- network: 15 passed
- strict MkDocs + Playwright: 40 SVG instances across 1440/1024/820/390 viewports
- package build and Twine check: passed
- Markdown, text integrity, release state, generated artifact and actionlint checks: passed
- calculator JSON SHA-256 remains `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`