### PR TITLE
Release miniVERL v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to miniVERL are recorded here. The format follows
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-08-12
+
 ### Product surface
 
 - Reframed the English, Chinese and PyPI landing pages around the bounded
@@ -858,7 +860,8 @@ Same-tokenizer only; one trajectory per forward pass; `swap` unavailable for
 quantized models; only Qwen3 and Qwen2 architectures tested; single-seed GPU
 results. The full list is in `docs/limitations.md`.
 
-[Unreleased]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.6.3...v0.7.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 title: "miniVERL: A bounded single-GPU runtime for verl-style OPD"
 message: "If you use miniVERL in your work, please cite it as below."
 type: software
-version: 0.8.0
+version: 0.8.1
 date-released: 2026-08-12
 license: Apache-2.0
 repository-code: "https://github.com/DaoyuanLi2816/mini-verl"

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -6,7 +6,7 @@ and what it printed.
 
 Last updated: 2026-08-12.
 
-Canonical release state: stable `v0.8.0` (`657f774ce15ad85052b8a88919f774d700264595`), development `0.8.1.dev0`.
+Canonical release state: releasing `v0.8.1`.
 Every public version claim is generated from `release-state.yaml` and gated by
 `python scripts/release_state.py --check`.
 

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — run verl-style OPD on one consumer GPU" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.8.1/docs/banner.svg" alt="miniVERL — run verl-style OPD on one consumer GPU" width="880">
 </p>
 
 <div align="center">
@@ -8,7 +8,7 @@
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/LICENSE)
 
 </div>
 
@@ -16,7 +16,7 @@
   <a href="https://pypi.org/project/miniverl/"><strong>PyPI</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/"><strong>Stable docs</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/dev/">Development docs</a> ·
-  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/main/README.zh-CN.md">中文</a>
+  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/README.zh-CN.md">中文</a>
 </p>
 
 **Run a documented subset of verl-style on-policy distillation on one consumer
@@ -25,7 +25,7 @@ rollout → teacher scoring → actor update, records every local reinterpretati
 and exports standard PEFT, Parquet and config artifacts for a pinned scale-out
 handoff.
 
-PyPI `v0.8.0` is stable; `main` is development. miniVERL is an independent
+PyPI `v0.8.1` is stable; `main` is development. miniVERL is an independent
 project with no upstream endorsement. It does not execute arbitrary verl YAML,
 launch distributed jobs, or claim full algorithmic compatibility.
 
@@ -52,14 +52,14 @@ recipe and produce an inspectable PEFT adapter.
 
 The `train` extra installs the ML runtime, but does not choose the correct CUDA
 PyTorch wheel. The optional `cuda` extra adds bitsandbytes only. Follow the
-[one-GPU installation and memory guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) before a real
+[one-GPU installation and memory guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/single-gpu-guide.md) before a real
 run.
 
 ## Architecture
 
 <picture>
-  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime-mobile.svg">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime.svg" alt="verl-shaped YAML, overrides and Parquet prompts pass through a typed compiler; one CUDA GPU runs actor rollout, teacher scoring and actor update; inspectable artifacts can be handed to pinned verl while distributed execution remains outside miniVERL.">
+  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.8.1/docs/verl-local-runtime-mobile.svg">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.8.1/docs/verl-local-runtime.svg" alt="verl-shaped YAML, overrides and Parquet prompts pass through a typed compiler; one CUDA GPU runs actor rollout, teacher scoring and actor update; inspectable artifacts can be handed to pinned verl while distributed execution remains outside miniVERL.">
 </picture>
 
 miniVERL uses one ordinary process and schedules model roles in phases. It does
@@ -115,7 +115,7 @@ miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml \
 The public built-in profile deliberately uses upstream-shaped `name: vllm`
 values. miniVERL classifies both rollout and teacher engine names as local
 reinterpretations and executes them with sequential local HF phases; this is
-not vLLM equivalence. See [For verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/for-verl-users.md) for config,
+not vLLM equivalence. See [For verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/for-verl-users.md) for config,
 data, role and error mappings.
 
 ## Tested profile boundary
@@ -150,7 +150,7 @@ This is deliberately a runtime and artifact proof. It is not a throughput
 benchmark, an alignment-quality endpoint, or evidence that OPD beats SFT, DPO
 or KD. Other NVIDIA GPUs use the same device-name-agnostic CUDA path, but model
 fit depends on VRAM, context length, quantization and installed kernels. Read
-the [exact smoke record and limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/opd-quickstart.md).
+the [exact smoke record and limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/opd-quickstart.md).
 
 ### Choose a path by hardware, not GPU branding
 
@@ -191,7 +191,7 @@ OPD overrides, but reports `launchable: false` until exact base snapshots are
 materialized. Artifact completeness, upstream parse/load smoke, launchability,
 algorithm semantics and distributed execution are separate statuses. A
 successful bridge check never means that a distributed verl job ran. Review
-the [bridge contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md) and [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md).
+the [bridge contract](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/verl-bridge.md) and [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/compatibility.md).
 
 The intended operating loop is **plan → inspect → run → inspect → export**.
 Direct execution remains convenient for experiments, but the JSON plan and
@@ -206,15 +206,15 @@ source intent.
 miniVERL keeps every measured study—including negative results, superseded
 runs and preregistered early stops—public under the documentation. None is used
 as a claim that OPD universally beats SFT, DPO or KD: see the
-[v0.7 External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-external/alignment-external-v1.md),
-[Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md),
-[RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md), and the
-[calculator study](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md).
+[v0.7 External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/alignment-external/alignment-external-v1.md),
+[Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/alignment-lab/alignment-lab-v1.md),
+[RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/recoverybench/recoverybench-v1.md), and the
+[calculator study](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/benchmarking.md).
 
 New runs establish tokenizer compatibility through structural identity. The
 legacy behavioral fingerprint is retained only for migration and is not an
 identity proof. Scientific caveats and immutable source hashes remain in the
-detailed reports and [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md).
+detailed reports and [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/limitations.md).
 
 ## Development, security and license
 
@@ -227,6 +227,6 @@ pytest -q -m "not gpu and not network"
 
 Contributions should keep the one-GPU boundary explicit and include tests for
 new failure modes. Report vulnerabilities privately through
-[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md). See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md), the
-[changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md), [citation metadata](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff),
-[reproducibility guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/reproducibility.md), and [Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE).
+[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/SECURITY.md). See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/CONTRIBUTING.md), the
+[changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/CHANGELOG.md), [citation metadata](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/CITATION.cff),
+[reproducibility guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/reproducibility.md), and [Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/LICENSE).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ rollout → teacher scoring → actor update, records every local reinterpretati
 and exports standard PEFT, Parquet and config artifacts for a pinned scale-out
 handoff.
 
-PyPI `v0.8.0` is stable; `main` is development. miniVERL is an independent
+PyPI `v0.8.1` is stable; `main` is development. miniVERL is an independent
 project with no upstream endorsement. It does not execute arbitrary verl YAML,
 launch distributed jobs, or claim full algorithmic compatibility.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,7 +23,7 @@ verl 风格 YAML 与 Parquet prompt，在本地依次执行 actor rollout → te
 actor update，记录每个本地语义重解释，并导出标准 PEFT、Parquet 与配置产物供固定版本
 的 verl 接手扩展。
 
-PyPI `v0.8.0` 是稳定版；`main` 是开发版。miniVERL 是独立项目，不代表上游背书；它
+PyPI `v0.8.1` 是稳定版；`main` 是开发版。miniVERL 是独立项目，不代表上游背书；它
 不执行任意 verl YAML、不启动分布式任务，也不声称完整的算法兼容性。
 
 ## 仅用 pip 的快速开始

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -1,22 +1,22 @@
 {
   "schema_version": 2,
-  "release": "0.8.0",
-  "status": "released",
-  "quality_floor": "2,000+ tests and 85%+ branch coverage at v0.8.0",
+  "release": "0.8.1",
+  "status": "candidate",
+  "quality_floor": "2,000+ tests and 85%+ branch coverage at v0.8.1",
   "local_validation": {
     "scope": "the maintainer's workstation, where the GPU and Windows-specific paths actually run",
-    "commit": "4fe229ebd87d2c6ea2e6007033f4fe0cb7877c98",
-    "commit_relationship": "exact implementation commit plus following validation-record-only updates; the final pull-request head is validated by CI",
-    "measured_at": "2026-08-12T01:18:27-07:00",
-    "platform": "Windows 11 Pro 10.0.22631",
-    "python": "CPython 3.12",
+    "commit": "ec0ffe9d8b75880487dde0d8ee022d82090c685f",
+    "commit_relationship": "exact product branch head; squash merge 8d3ebb2 carries the same tree and passed the full required CI matrix",
+    "measured_at": "2026-08-12T20:55:24-07:00",
+    "platform": "Windows 11",
+    "python": "CPython 3.10 for coverage; CPython 3.12 for CUDA",
     "coverage_mode": "branch",
     "cpu_non_gpu_non_network": {
       "passed": 2178,
       "skipped": 9,
       "deselected": 21,
-      "branch_coverage_percent": 85.3,
-      "skip_reason": "six platform/privilege skips plus three pinned-verl conformance skips while the official package was intentionally absent from the general environment; the conformance tests were run separately against the pin"
+      "branch_coverage_percent": 85.06,
+      "skip_reason": "six platform/privilege skips plus three pinned-verl conformance skips while the official package was intentionally absent from the general environment; the pinned profile ran separately in CI"
     },
     "gpu": {
       "passed": 8,
@@ -27,14 +27,14 @@
     }
   },
   "release_validation": {
-    "scope": "the exact published commit, validated by CI rather than locally",
-    "commit": "657f774ce15ad85052b8a88919f774d700264595",
+    "scope": "the exact product merge, validated by CI before release metadata",
+    "commit": "8d3ebb269c4d2cea8f51b4e2ce86c81630eb4b8e",
     "workflows": {
-      "ci": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31579172119",
-      "build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31579172102",
-      "docs": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31579172137",
-      "pinned_verl_bridge": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31579172225",
-      "release": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31579635238"
+      "ci": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31665123940",
+      "build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31665123949",
+      "docs": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31665123951",
+      "pinned_verl_bridge": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31665123941",
+      "release": "pending tag workflow"
     },
     "conclusion": "success",
     "gpu_coverage": "none; no GPU runner is configured for this repository, so the GPU counts above exist only from the local measurement"

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  <div class="docs-channel" data-stable-version="0.8.0" data-dev-version="0.8.1.dev0">
+  <div class="docs-channel" data-stable-version="0.8.1" data-dev-version="0.8.1">
     <strong id="docs-channel-label">Stable documentation</strong>
     <label for="docs-version-selector">Version</label>
     <select id="docs-version-selector" aria-label="Documentation version">
-      <option value="stable">Stable 0.8.0</option>
-      <option value="dev">Development 0.8.1.dev0</option>
+      <option value="stable">Stable 0.8.1</option>
+      <option value="dev">Development 0.8.1</option>
     </select>
   </div>
 {% endblock %}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -8,8 +8,17 @@ after the exact release commit and its remote checks are green.
 
 - [x] Keep the release to product positioning, migration documentation and an
       explicit vocabulary correction; no algorithm or long GPU workload changed.
-- [ ] Preserve v0.8.0 tags, public artifacts and frozen benchmark bytes.
-- [ ] Complete the full release, compatibility and public-distribution gates.
+- [x] Preserve v0.8.0 tags, public artifacts and frozen benchmark bytes; the
+      calculator artifact remains SHA-256 `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`.
+- [x] Complete the candidate quality, compatibility, package and documentation
+      gates; public-distribution checks run after the immutable v0.8.1 tag.
+
+Product head `ec0ffe9d8b75880487dde0d8ee022d82090c685f` passed 2,178 local
+non-GPU/non-network tests at 85.06% branch coverage, 8 GPU tests on one RTX
+4080, 15 network tests, strict MkDocs and 40 rendered SVG instances across four
+Playwright viewports. PR #65 then passed every required Python 3.10-3.13,
+training dependency, Transformers boundary, wheel-install, browser and pinned
+verl check before squash merge `8d3ebb2`.
 
 ## v0.8.0 single-GPU verl OPD pivot
 

--- a/release-state.yaml
+++ b/release-state.yaml
@@ -17,13 +17,13 @@
 # such distinction, which is how its tag shipped a docs selector still
 # advertising "Stable 0.6.1 / Development 0.6.2.dev0".
 schema_version: 1
-phase: development
+phase: release
 
 stable:
-  version: "0.8.0"
-  tag: "v0.8.0"
-  release_commit: "657f774ce15ad85052b8a88919f774d700264595"
+  version: "0.8.1"
+  tag: "v0.8.1"
+  release_commit: "pending"
   released_at: "2026-08-12"
 
 development:
-  version: "0.8.1.dev0"
+  version: "0.8.1"

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.8.1.dev0"
+__version__ = "0.8.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Release scope

Finalize v0.8.1 as the product-surface correction merged in #65. This changes only release projections, changelog/checklist records and the machine-readable quality record.

## Evidence

- product head: `ec0ffe9d8b75880487dde0d8ee022d82090c685f`
- green product merge: `8d3ebb269c4d2cea8f51b4e2ce86c81630eb4b8e`
- local CPU: 2,178 passed, 9 skipped, 85.06% branch coverage
- local GPU: 8 passed on one RTX 4080
- local network: 15 passed
- strict docs/browser gate: 40 rendered SVG instances at four viewports
- package/Twine, Ruff, mypy, actionlint, Markdown, text and release-state checks: passed
- calculator artifact SHA-256 unchanged: `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`

The tag remains uncreated until this exact release PR is green and merged. Publication will use the existing OIDC workflow.