### PR TITLE
Advance development to 0.9.0.dev0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to miniVERL are recorded here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- Made the PyPI release verifier require the durable product, project and
+  policy links that the long description actually promises, instead of two
+  historical research links intentionally removed from the v0.8.1 landing
+  page. Every remaining repository link must still be release-pinned and
+  reachable.
+
 ## [0.8.1] - 2026-08-12
 
 ### Product surface

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -6,9 +6,16 @@ and what it printed.
 
 Last updated: 2026-08-12.
 
-Canonical release state: releasing `v0.8.1`.
+Canonical release state: stable `v0.8.1` (`77a570721ec587e50f9b927b4c72a6fab8a73ca6`), development `0.9.0.dev0`.
 Every public version claim is generated from `release-state.yaml` and gated by
 `python scripts/release_state.py --check`.
+
+## v0.9.0 productization
+
+Development is now focused on making the bounded single-GPU verl-style OPD
+path easier to configure, inspect, reproduce and materialize. The v0.8.1
+release remains the stable product surface; no frozen research result is being
+reinterpreted as v0.9 evidence.
 
 ## v0.8.1 product surface
 

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.8.1/docs/banner.svg" alt="miniVERL — run verl-style OPD on one consumer GPU" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — run verl-style OPD on one consumer GPU" width="880">
 </p>
 
 <div align="center">
@@ -8,7 +8,7 @@
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE)
 
 </div>
 
@@ -16,7 +16,7 @@
   <a href="https://pypi.org/project/miniverl/"><strong>PyPI</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/"><strong>Stable docs</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/dev/">Development docs</a> ·
-  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/README.zh-CN.md">中文</a>
+  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/main/README.zh-CN.md">中文</a>
 </p>
 
 **Run a documented subset of verl-style on-policy distillation on one consumer
@@ -52,14 +52,14 @@ recipe and produce an inspectable PEFT adapter.
 
 The `train` extra installs the ML runtime, but does not choose the correct CUDA
 PyTorch wheel. The optional `cuda` extra adds bitsandbytes only. Follow the
-[one-GPU installation and memory guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/single-gpu-guide.md) before a real
+[one-GPU installation and memory guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) before a real
 run.
 
 ## Architecture
 
 <picture>
-  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.8.1/docs/verl-local-runtime-mobile.svg">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.8.1/docs/verl-local-runtime.svg" alt="verl-shaped YAML, overrides and Parquet prompts pass through a typed compiler; one CUDA GPU runs actor rollout, teacher scoring and actor update; inspectable artifacts can be handed to pinned verl while distributed execution remains outside miniVERL.">
+  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime-mobile.svg">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime.svg" alt="verl-shaped YAML, overrides and Parquet prompts pass through a typed compiler; one CUDA GPU runs actor rollout, teacher scoring and actor update; inspectable artifacts can be handed to pinned verl while distributed execution remains outside miniVERL.">
 </picture>
 
 miniVERL uses one ordinary process and schedules model roles in phases. It does
@@ -115,7 +115,7 @@ miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml \
 The public built-in profile deliberately uses upstream-shaped `name: vllm`
 values. miniVERL classifies both rollout and teacher engine names as local
 reinterpretations and executes them with sequential local HF phases; this is
-not vLLM equivalence. See [For verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/for-verl-users.md) for config,
+not vLLM equivalence. See [For verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/for-verl-users.md) for config,
 data, role and error mappings.
 
 ## Tested profile boundary
@@ -150,7 +150,7 @@ This is deliberately a runtime and artifact proof. It is not a throughput
 benchmark, an alignment-quality endpoint, or evidence that OPD beats SFT, DPO
 or KD. Other NVIDIA GPUs use the same device-name-agnostic CUDA path, but model
 fit depends on VRAM, context length, quantization and installed kernels. Read
-the [exact smoke record and limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/opd-quickstart.md).
+the [exact smoke record and limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/opd-quickstart.md).
 
 ### Choose a path by hardware, not GPU branding
 
@@ -191,7 +191,7 @@ OPD overrides, but reports `launchable: false` until exact base snapshots are
 materialized. Artifact completeness, upstream parse/load smoke, launchability,
 algorithm semantics and distributed execution are separate statuses. A
 successful bridge check never means that a distributed verl job ran. Review
-the [bridge contract](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/verl-bridge.md) and [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/compatibility.md).
+the [bridge contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md) and [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md).
 
 The intended operating loop is **plan → inspect → run → inspect → export**.
 Direct execution remains convenient for experiments, but the JSON plan and
@@ -206,15 +206,15 @@ source intent.
 miniVERL keeps every measured study—including negative results, superseded
 runs and preregistered early stops—public under the documentation. None is used
 as a claim that OPD universally beats SFT, DPO or KD: see the
-[v0.7 External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/alignment-external/alignment-external-v1.md),
-[Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/alignment-lab/alignment-lab-v1.md),
-[RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/recoverybench/recoverybench-v1.md), and the
-[calculator study](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/benchmarking.md).
+[v0.7 External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-external/alignment-external-v1.md),
+[Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md),
+[RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md), and the
+[calculator study](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md).
 
 New runs establish tokenizer compatibility through structural identity. The
 legacy behavioral fingerprint is retained only for migration and is not an
 identity proof. Scientific caveats and immutable source hashes remain in the
-detailed reports and [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/limitations.md).
+detailed reports and [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md).
 
 ## Development, security and license
 
@@ -227,6 +227,6 @@ pytest -q -m "not gpu and not network"
 
 Contributions should keep the one-GPU boundary explicit and include tests for
 new failure modes. Report vulnerabilities privately through
-[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/SECURITY.md). See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/CONTRIBUTING.md), the
-[changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/CHANGELOG.md), [citation metadata](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/CITATION.cff),
-[reproducibility guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/docs/reproducibility.md), and [Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.8.1/LICENSE).
+[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md). See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md), the
+[changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md), [citation metadata](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff),
+[reproducibility guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/reproducibility.md), and [Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE).

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "release": "0.8.1",
-  "status": "candidate",
+  "status": "released",
   "quality_floor": "2,000+ tests and 85%+ branch coverage at v0.8.1",
   "local_validation": {
     "scope": "the maintainer's workstation, where the GPU and Windows-specific paths actually run",
@@ -27,16 +27,23 @@
     }
   },
   "release_validation": {
-    "scope": "the exact product merge, validated by CI before release metadata",
-    "commit": "8d3ebb269c4d2cea8f51b4e2ce86c81630eb4b8e",
+    "scope": "the exact immutable v0.8.1 release commit",
+    "commit": "77a570721ec587e50f9b927b4c72a6fab8a73ca6",
     "workflows": {
       "ci": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31665123940",
       "build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31665123949",
       "docs": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31665123951",
       "pinned_verl_bridge": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31665123941",
-      "release": "pending tag workflow"
+      "release": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31666095069"
     },
     "conclusion": "success",
-    "gpu_coverage": "none; no GPU runner is configured for this repository, so the GPU counts above exist only from the local measurement"
+    "gpu_coverage": "none; no GPU runner is configured for this repository, so the GPU counts above exist only from the local measurement",
+    "publication": {
+      "pypi": "https://pypi.org/project/miniverl/0.8.1/",
+      "github_release": "https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.8.1",
+      "wheel_sha256": "7c2a58f900cbab71689f7b229a46b5710b4aa2cbabc42af7526e2da04d9ba93e",
+      "sdist_sha256": "f4bf486b2427d1f37edc7b0afe0c4a4f17ad9da7fbd221b010d4c7d792698789",
+      "recovery_note": "OIDC publication succeeded; the tag workflow's final verifier retained two links intentionally removed from the product README, so the identical verified distributions were attached to the GitHub Release manually."
+    }
   }
 }

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  <div class="docs-channel" data-stable-version="0.8.1" data-dev-version="0.8.1">
+  <div class="docs-channel" data-stable-version="0.8.1" data-dev-version="0.9.0.dev0">
     <strong id="docs-channel-label">Stable documentation</strong>
     <label for="docs-version-selector">Version</label>
     <select id="docs-version-selector" aria-label="Documentation version">
       <option value="stable">Stable 0.8.1</option>
-      <option value="dev">Development 0.8.1</option>
+      <option value="dev">Development 0.9.0.dev0</option>
     </select>
   </div>
 {% endblock %}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -20,6 +20,17 @@ Playwright viewports. PR #65 then passed every required Python 3.10-3.13,
 training dependency, Transformers boundary, wheel-install, browser and pinned
 verl check before squash merge `8d3ebb2`.
 
+## v0.9.0 productization
+
+- [ ] Add upstream-shaped override UX with complete source and precedence
+      provenance while preserving the repeatable `--set` interface.
+- [ ] Bind execution to an immutable plan artifact and fail closed when its
+      config, data, model, tokenizer or compatibility acceptance has drifted.
+- [ ] Add a bounded hardware probe, transactional model materialization and a
+      realistic one-GPU quickstart without widening the documented algorithm.
+- [ ] Preserve every frozen scientific artifact and keep distributed verl,
+      policy-gradient OPD and unsupported objective semantics fail-closed.
+
 ## v0.8.0 single-GPU verl OPD pivot
 
 - [x] Implement and validate the documented `verl-opd-v0.8-single-gpu-v1`
@@ -132,6 +143,23 @@ unauthorized after checkpoint-selection failure**.
       generated-artifact, visual, package and attribution gates before merge.
 
 ## After the tag
+
+- [x] v0.8.1 OIDC publication run
+      [`31666095069`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31666095069)
+      uploaded both exact distributions and exposed one PyPI integrity
+      attestation per file. Its final verifier correctly checked hashes and
+      attestations but then failed on two historical README links that the
+      product-surface change had intentionally removed.
+- [x] Independently download and byte-compare the workflow artifacts and both
+      public PyPI files, verify a clean public core install and attach those
+      same files to the
+      [v0.8.1 GitHub Release](https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.8.1).
+      Wheel SHA-256 is
+      `7c2a58f900cbab71689f7b229a46b5710b4aa2cbabc42af7526e2da04d9ba93e`;
+      sdist SHA-256 is
+      `f4bf486b2427d1f37edc7b0afe0c4a4f17ad9da7fbd221b010d4c7d792698789`.
+- [x] Advance development to `0.9.0.dev0` in this separate state-sync PR and
+      remove the verifier's stale dependency on historical research links.
 
 - [x] Verify the exact v0.8.0 merge-commit release workflow, OIDC publication,
       PyPI attestations, public clean install and GitHub Release.

--- a/release-state.yaml
+++ b/release-state.yaml
@@ -17,13 +17,13 @@
 # such distinction, which is how its tag shipped a docs selector still
 # advertising "Stable 0.6.1 / Development 0.6.2.dev0".
 schema_version: 1
-phase: release
+phase: development
 
 stable:
   version: "0.8.1"
   tag: "v0.8.1"
-  release_commit: "pending"
+  release_commit: "77a570721ec587e50f9b927b4c72a6fab8a73ca6"
   released_at: "2026-08-12"
 
 development:
-  version: "0.8.1"
+  version: "0.9.0.dev0"

--- a/scripts/verify_pypi_release.py
+++ b/scripts/verify_pypi_release.py
@@ -148,8 +148,6 @@ def _verify_long_description_links(
     raw = github.replace("https://github.com/", "https://raw.githubusercontent.com/")
     required_paths = (
         "docs/single-gpu-guide.md",
-        "recipes/qwen_consumer_gpu_calc.yaml",
-        "benchmarks/results/gpu-calc-hard-equal-update-v2.json",
         "CHANGELOG.md",
         "CITATION.cff",
         "LICENSE",

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.8.1"
+__version__ = "0.9.0.dev0"
 
 __all__ = ["__version__"]

--- a/tests/unit/test_pypi_release_verifier.py
+++ b/tests/unit/test_pypi_release_verifier.py
@@ -131,8 +131,6 @@ def test_long_description_requires_tag_pinned_links_on_the_rendered_page(monkeyp
     tag = "v0.2.4"
     paths = (
         "docs/single-gpu-guide.md",
-        "recipes/qwen_consumer_gpu_calc.yaml",
-        "benchmarks/results/gpu-calc-hard-equal-update-v2.json",
         "CHANGELOG.md",
         "CITATION.cff",
         "LICENSE",
@@ -174,8 +172,6 @@ def test_long_description_retries_a_pypi_client_challenge(monkeypatch) -> None:
     tag = "v0.2.4"
     paths = (
         "docs/single-gpu-guide.md",
-        "recipes/qwen_consumer_gpu_calc.yaml",
-        "benchmarks/results/gpu-calc-hard-equal-update-v2.json",
         "CHANGELOG.md",
         "CITATION.cff",
         "LICENSE",
@@ -217,8 +213,6 @@ def test_long_description_can_defer_a_client_challenge_to_browser_inspection(
     tag = "v0.2.4"
     paths = (
         "docs/single-gpu-guide.md",
-        "recipes/qwen_consumer_gpu_calc.yaml",
-        "benchmarks/results/gpu-calc-hard-equal-update-v2.json",
         "CHANGELOG.md",
         "CITATION.cff",
         "LICENSE",


### PR DESCRIPTION
## Summary

- record the verified v0.8.1 PyPI and GitHub Release artifacts and advance main to `0.9.0.dev0`
- document the release-workflow recovery without changing the immutable v0.8.1 tag
- stop requiring two historical research links that the v0.8.1 product README intentionally removed, while retaining release-pinned and reachability checks for every remaining repository link

## Validation

- `pytest -q tests/unit/test_pypi_release_verifier.py tests/unit/test_release_state.py tests/unit/test_packaging.py::test_release_quality_has_one_version_bound_machine_readable_record` (25 passed)
- `ruff check .`
- `ruff format --check .`
- `mypy src/miniverl`
- `python scripts/build_pypi_readme.py --check`
- `python scripts/release_state.py --check`
- `python scripts/check_markdown_links.py`
- `git diff --check`
- frozen calculator SHA-256 remains `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`

## Publication record

PyPI and workflow artifacts are byte-identical. Wheel SHA-256 is `7c2a58f900cbab71689f7b229a46b5710b4aa2cbabc42af7526e2da04d9ba93e`; sdist SHA-256 is `f4bf486b2427d1f37edc7b0afe0c4a4f17ad9da7fbd221b010d4c7d792698789`. Both PyPI integrity records expose a Trusted Publisher attestation, and a clean public core install reports `miniverl 0.8.1` with a passing core doctor.