### PR TITLE
Add verl-style override workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           python scripts/publish_alignment_lab_artifacts.py --check
           python scripts/publish_verl_bridge_diagrams.py --check
+          python scripts/publish_verl_opd_compatibility.py --check
       - name: Build complete development site strictly
         run: mkdocs build --strict
       - name: Install deterministic Chromium

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to miniVERL are recorded here. The format follows
 
 ## [Unreleased]
 
+### Verl config UX
+
+- Added safe trailing Hydra-style overrides and repeatable plain/JSON
+  `--overrides-file` inputs with deterministic base → files → `--set` →
+  trailing precedence. The compiled report preserves every duplicate, source,
+  prior value and final effective value without evaluating shell text or
+  interpolation.
+- Added value-bound approval metadata for the packaged profile. External
+  configs, or packaged profiles whose high-risk values drift, require explicit
+  `--accept-local-reinterpretations` before `run`; unsupported algorithm and
+  distributed fields still fail closed.
+- Classified all 82 leaves in an Apache-2.0-provenanced fixture derived from
+  the pinned official verl v0.8.0 Qwen3 OPD example. Harmless logging and
+  compile hints are informational, while policy-gradient and enabled FSDP
+  offload semantics remain unsupported.
+
 ### Fixed
 
 - Made the PyPI release verifier require the durable product, project and

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -17,6 +17,16 @@ path easier to configure, inspect, reproduce and materialize. The v0.8.1
 release remains the stable product surface; no frozen research result is being
 reinterpreted as v0.9 evidence.
 
+The first v0.9 slice accepts safe trailing dotted overrides, repeatable plain
+files and JSON argv arrays with base → files → `--set` → trailing precedence.
+Every duplicate retains its source, prior value and final effective value.
+External configs require explicit acceptance of the displayed high-risk local
+reinterpretations; the packaged Qwen profile's approval is value-bound and
+fails closed if one of those values drifts. A generated report classifies all
+82 leaves in the pinned official-example field fixture: 23 exact, 16
+semantically conformant, 22 locally reinterpreted, 18 informational and 3
+unsupported. No algorithm or distributed boundary widened.
+
 ## v0.8.1 product surface
 
 The landing pages now lead with the documented one-GPU verl-style OPD journey,

--- a/PYPI.md
+++ b/PYPI.md
@@ -92,7 +92,7 @@ without reconstructing intent from console text.
 
 | What you do in verl | miniVERL equivalent |
 | --- | --- |
-| pass Hydra overrides | repeat `--set key=value` in v0.8.1 |
+| pass Hydra-style overrides | repeat `--set`; v0.9 development also accepts `--overrides-file` and tokens after `--` |
 | inspect the resolved config | `miniverl plan --json` |
 | execute pure OPD | `miniverl run` |
 | reuse prompt Parquet | point `data.train_files` at it directly |
@@ -111,6 +111,11 @@ distillation.teacher_models.teacher_model.model_path=Qwen/Qwen3-1.7B
 miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml \
   --set actor_rollout_ref.actor.optim.lr=1e-5
 ```
+
+External YAML must explicitly accept the high-risk local mappings printed by
+`plan` before `run`; the packaged profile carries a value-bound reviewed
+manifest. [Override precedence and safe input forms](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/config-overrides.md)
+are documented without executing Hydra interpolation or shell text.
 
 The public built-in profile deliberately uses upstream-shaped `name: vllm`
 values. miniVERL classifies both rollout and teacher engine names as local

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ without reconstructing intent from console text.
 
 | What you do in verl | miniVERL equivalent |
 | --- | --- |
-| pass Hydra overrides | repeat `--set key=value` in v0.8.1 |
+| pass Hydra-style overrides | repeat `--set`; v0.9 development also accepts `--overrides-file` and tokens after `--` |
 | inspect the resolved config | `miniverl plan --json` |
 | execute pure OPD | `miniverl run` |
 | reuse prompt Parquet | point `data.train_files` at it directly |
@@ -111,6 +111,11 @@ distillation.teacher_models.teacher_model.model_path=Qwen/Qwen3-1.7B
 miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml \
   --set actor_rollout_ref.actor.optim.lr=1e-5
 ```
+
+External YAML must explicitly accept the high-risk local mappings printed by
+`plan` before `run`; the packaged profile carries a value-bound reviewed
+manifest. [Override precedence and safe input forms](docs/config-overrides.md)
+are documented without executing Hydra interpolation or shell text.
 
 The public built-in profile deliberately uses upstream-shaped `name: vllm`
 values. miniVERL classifies both rollout and teacher engine names as local

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -79,7 +79,7 @@ target 以无 pickle 格式校验，checkpoint 事务化发布，最终 adapter 
 
 | verl 中的动作 | miniVERL 对应方式 |
 | --- | --- |
-| 传入 Hydra override | v0.8.1 中重复使用 `--set key=value` |
+| 传入 Hydra 风格 override | 重复使用 `--set`；v0.9 开发版也接受 `--overrides-file` 与 `--` 后的参数 |
 | 检查 resolved config | `miniverl plan --json` |
 | 执行纯 OPD | `miniverl run` |
 | 复用 prompt Parquet | 直接设置 `data.train_files` |
@@ -94,6 +94,10 @@ distillation.teacher_models.teacher_model.model_path=Qwen/Qwen3-1.7B
 miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml \
   --set actor_rollout_ref.actor.optim.lr=1e-5
 ```
+
+外部 YAML 在 `run` 前必须显式接受 `plan` 列出的高风险本地重解释；内置
+profile 使用与具体值绑定的审核清单。详见[覆盖优先级与安全输入格式](docs/config-overrides.md)，
+miniVERL 不执行 Hydra interpolation 或 shell 文本。
 
 公开内置 profile 刻意使用上游形状的 `name: vllm`。miniVERL 会把 rollout 与 teacher
 engine 名分类为本地重解释，再通过顺序本地 HF 阶段执行；这不等于 vLLM 语义。完整

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -10,11 +10,13 @@ No source code from another repository has been copied, vendored or adapted.
 This matters for two projects in particular, because miniVERL is positioned next
 to them:
 
-* **verl** (`https://github.com/verl-project/verl`, Apache-2.0). No verl code,
-  configuration schema, documentation wording, logo or visual identity is used
-  here. miniVERL is an independent implementation of a much narrower scope and
-  is not compatible with, derived from, or endorsed by verl. The name is a nod to
-  the problem space only.
+* **verl** (`https://github.com/volcengine/verl`, Apache-2.0). No verl runtime
+  code, documentation wording, logo or visual identity is used here. The
+  reduced test fixture
+  `tests/fixtures/verl/opd-v0.8-official-example-fields.yaml` is derived from
+  the field surface of the pinned v0.8.0 Qwen3 OPD example and retains source,
+  commit and license provenance. miniVERL is an independent implementation of
+  a much narrower scope and is not endorsed by verl.
 * **OPSD** (`https://github.com/HJSang/OPSD_OnPolicyDistillation`). This
   repository has no LICENSE file and is therefore all-rights-reserved; nothing
   from it has been copied. It is cited in `docs/comparisons.md` and

--- a/docs/config-overrides.md
+++ b/docs/config-overrides.md
@@ -1,0 +1,76 @@
+# Config overrides
+
+miniVERL accepts one resolved YAML mapping plus familiar dotted `key=value`
+tokens. It does not execute a verl launcher, shell command, Hydra resolver or
+OmegaConf interpolation. Resolve composition inside the trusted verl workflow,
+then pass either the YAML, an argv JSON array, or a plain override file.
+
+```bash
+miniverl plan \
+  --config verl-opd.yaml \
+  --overrides-file site.overrides \
+  --set actor_rollout_ref.actor.optim.lr=1e-5 \
+  -- \
+  'data.train_files=["data/train.parquet"]' \
+  distillation.distillation_loss.topk=64
+```
+
+Precedence is deterministic:
+
+1. base YAML;
+2. each `--overrides-file`, in command order;
+3. each `--set`, in command order;
+4. tokens after `--`, in command order.
+
+Every occurrence remains in the compiled report with its source, order,
+previous value, previous source, final value and whether it is the effective
+occurrence. Duplicate fields are therefore visible rather than silently
+collapsed.
+
+## Safe input forms
+
+A plain file contains one expression per line. Empty lines and lines beginning
+with `#` are ignored:
+
+```text
+data.train_batch_size=8
+actor_rollout_ref.rollout.name=vllm
+```
+
+A `.json` file must contain an array of strings, suitable for argv captured by
+a trusted launcher:
+
+```json
+[
+  "data.train_batch_size=8",
+  "actor_rollout_ref.rollout.name=vllm"
+]
+```
+
+Values use safe YAML scalar/list/dict parsing. `${...}`, non-finite numbers,
+unknown fields, YAML object constructors, Hydra `+`/`~` operators and shell
+scripts fail closed. No input string is evaluated as code.
+
+## High-risk local reinterpretations
+
+`miniverl plan` always lists fields whose upstream meaning is replaced by a
+materially different one-GPU meaning—for example a PPO mini-batch becoming a
+logical direct-GKD update batch, or `vllm` selecting the sequential local HF
+runtime. The packaged profile carries a reviewed approval manifest. Running an
+external YAML requires:
+
+```bash
+miniverl run --config verl-opd.yaml --accept-local-reinterpretations
+```
+
+This flag accepts only the high-risk mappings printed in that compiled report.
+It never enables an unsupported algorithm, multi-GPU field, FSDP behavior or
+policy-gradient objective.
+
+## Official-example field coverage
+
+The generated [coverage report](generated/verl-opd-v08-official-fields.json)
+classifies every leaf in a reduced field-surface fixture derived from verl
+v0.8.0's Apache-2.0 Qwen3 FSDP OPD example. It intentionally retains fields
+that are rejected, so coverage means “explained deterministically,” not
+“supported.”

--- a/docs/for-verl-users.md
+++ b/docs/for-verl-users.md
@@ -20,7 +20,7 @@ the mapping is explicit and does not imply endorsement or full compatibility.
   `distillation.teacher_models.teacher_model.model_path`, response bounds,
   learning rate and LoRA configuration.
 
-What is not reusable: arbitrary Hydra composition, shell launch scripts,
+What is not reusable: arbitrary Hydra composition inside miniVERL, shell launch scripts,
 resource pools, Ray actors, FSDP/Megatron checkpoints, PPO/GRPO, critics,
 policy-gradient OPD, task-reward mixtures, multiple teachers and multimodal
 workers. Unsupported semantics fail closed instead of falling back silently.
@@ -30,7 +30,7 @@ workers. Unsupported semantics fail closed instead of falling back silently.
 | verl action | miniVERL action |
 | --- | --- |
 | compose or capture a resolved config | provide resolved YAML to `--config` |
-| add a Hydra override | repeat `--set key=value` |
+| add a Hydra-style override | repeat `--set`, use `--overrides-file`, or place tokens after `--` |
 | inspect resolved intent | `miniverl plan --json` |
 | launch OPD | `miniverl run` |
 | read prompt Parquet | use the file directly |
@@ -46,8 +46,9 @@ miniverl plan --profile verl-opd-v0.8-single-gpu-v1 \
 ```
 
 Planning is weight-free and offline. Use `--json` to retain the complete field
-matrix. v0.8.1 accepts only repeated `--set`; it does not execute `${...}`
-interpolations or shell text.
+matrix. The development CLI records repeated `--set`, override files and
+trailing tokens with deterministic precedence; it does not execute `${...}`
+interpolations or shell text. See [Config overrides](config-overrides.md).
 
 ## Same fields, different placement
 
@@ -111,6 +112,9 @@ tested.
   teachers and distributed counts are intentionally unsupported.
 - **Interpolation rejected:** resolve Hydra/OmegaConf in your trusted verl
   environment first. miniVERL will not execute `${...}`.
+- **High-risk reinterpretation not accepted:** inspect `miniverl plan`, then
+  pass `--accept-local-reinterpretations` for an external config. Packaged
+  profiles carry reviewed acceptance metadata.
 - **Prompt schema mismatch:** validate the Parquet `prompt` column as structured
   role/content messages, or convert it explicitly.
 - **Tokenizer mismatch:** actor and teacher scoring require structural identity

--- a/docs/generated/verl-opd-v0.8-compatibility.json
+++ b/docs/generated/verl-opd-v0.8-compatibility.json
@@ -5,7 +5,7 @@
     "locally_reinterpreted": 22,
     "semantically_conformant": 15
   },
-  "compiled_digest": "44d9392a43fd1c166217d2ff992a4b4202070df08d32f03a767a59c15793a7ce",
+  "compiled_digest": "d9458fba483548bedbff9b112d8e192e48055baec24a389f151323417d3072ea",
   "executable": true,
   "field_count": 72,
   "fields": [
@@ -67,7 +67,7 @@
       "semantic_risk": "high",
       "source_value": 8,
       "upstream_field": "actor_rollout_ref.actor.ppo_mini_batch_size",
-      "user_confirmation_required": false
+      "user_confirmation_required": true
     },
     {
       "classification": "locally_reinterpreted",
@@ -160,7 +160,7 @@
       "semantic_risk": "high",
       "source_value": 0.5,
       "upstream_field": "actor_rollout_ref.rollout.gpu_memory_utilization",
-      "user_confirmation_required": false
+      "user_confirmation_required": true
     },
     {
       "classification": "semantically_conformant",
@@ -210,7 +210,7 @@
       "semantic_risk": "high",
       "source_value": "vllm",
       "upstream_field": "actor_rollout_ref.rollout.name",
-      "user_confirmation_required": false
+      "user_confirmation_required": true
     },
     {
       "classification": "exact",
@@ -230,7 +230,7 @@
       "semantic_risk": "high",
       "source_value": 1,
       "upstream_field": "actor_rollout_ref.rollout.tensor_model_parallel_size",
-      "user_confirmation_required": false
+      "user_confirmation_required": true
     },
     {
       "classification": "exact",
@@ -444,7 +444,7 @@
       "semantic_risk": "high",
       "source_value": 1,
       "upstream_field": "distillation.n_gpus_per_node",
-      "user_confirmation_required": false
+      "user_confirmation_required": true
     },
     {
       "classification": "locally_reinterpreted",
@@ -454,7 +454,7 @@
       "semantic_risk": "high",
       "source_value": 1,
       "upstream_field": "distillation.nnodes",
-      "user_confirmation_required": false
+      "user_confirmation_required": true
     },
     {
       "classification": "informational_only",
@@ -474,7 +474,7 @@
       "semantic_risk": "high",
       "source_value": 1,
       "upstream_field": "distillation.teacher_models.teacher_model.inference.data_parallel_size",
-      "user_confirmation_required": false
+      "user_confirmation_required": true
     },
     {
       "classification": "semantically_conformant",
@@ -494,7 +494,7 @@
       "semantic_risk": "high",
       "source_value": 0.5,
       "upstream_field": "distillation.teacher_models.teacher_model.inference.gpu_memory_utilization",
-      "user_confirmation_required": false
+      "user_confirmation_required": true
     },
     {
       "classification": "semantically_conformant",
@@ -514,7 +514,7 @@
       "semantic_risk": "high",
       "source_value": "vllm",
       "upstream_field": "distillation.teacher_models.teacher_model.inference.name",
-      "user_confirmation_required": false
+      "user_confirmation_required": true
     },
     {
       "classification": "locally_reinterpreted",
@@ -524,7 +524,7 @@
       "semantic_risk": "high",
       "source_value": 1,
       "upstream_field": "distillation.teacher_models.teacher_model.inference.pipeline_model_parallel_size",
-      "user_confirmation_required": false
+      "user_confirmation_required": true
     },
     {
       "classification": "locally_reinterpreted",
@@ -534,7 +534,7 @@
       "semantic_risk": "high",
       "source_value": 1,
       "upstream_field": "distillation.teacher_models.teacher_model.inference.tensor_model_parallel_size",
-      "user_confirmation_required": false
+      "user_confirmation_required": true
     },
     {
       "classification": "exact",
@@ -554,7 +554,7 @@
       "semantic_risk": "high",
       "source_value": 1,
       "upstream_field": "distillation.teacher_models.teacher_model.num_replicas",
-      "user_confirmation_required": false
+      "user_confirmation_required": true
     },
     {
       "classification": "informational_only",
@@ -674,7 +674,7 @@
       "semantic_risk": "high",
       "source_value": 1,
       "upstream_field": "trainer.n_gpus_per_node",
-      "user_confirmation_required": false
+      "user_confirmation_required": true
     },
     {
       "classification": "locally_reinterpreted",
@@ -684,7 +684,7 @@
       "semantic_risk": "high",
       "source_value": 1,
       "upstream_field": "trainer.nnodes",
-      "user_confirmation_required": false
+      "user_confirmation_required": true
     },
     {
       "classification": "exact",
@@ -738,7 +738,30 @@
     }
   ],
   "profile": "verl-opd-v0.8-single-gpu-v1",
-  "schema_version": 1,
+  "reinterpretation_acceptance": {
+    "accepted": false,
+    "required_fields": [
+      "actor_rollout_ref.actor.ppo_mini_batch_size",
+      "actor_rollout_ref.rollout.gpu_memory_utilization",
+      "actor_rollout_ref.rollout.name",
+      "actor_rollout_ref.rollout.tensor_model_parallel_size",
+      "distillation.n_gpus_per_node",
+      "distillation.nnodes",
+      "distillation.teacher_models.teacher_model.inference.data_parallel_size",
+      "distillation.teacher_models.teacher_model.inference.gpu_memory_utilization",
+      "distillation.teacher_models.teacher_model.inference.name",
+      "distillation.teacher_models.teacher_model.inference.pipeline_model_parallel_size",
+      "distillation.teacher_models.teacher_model.inference.tensor_model_parallel_size",
+      "distillation.teacher_models.teacher_model.num_replicas",
+      "trainer.n_gpus_per_node",
+      "trainer.nnodes",
+      "trainer.save_freq",
+      "trainer.test_freq",
+      "trainer.total_epochs"
+    ],
+    "source": "not_accepted"
+  },
+  "schema_version": 2,
   "scope": "config conformance for one documented local pure-OPD profile; not full verl compatibility or distributed execution",
   "source_fixture": "examples/verl-opd-v0.8-single-gpu.yaml",
   "source_sha256": "085805d904136ae271db7629b4810340f54d6aba7c2ed08e7a88d8ac01511b4f",

--- a/docs/generated/verl-opd-v08-official-fields.json
+++ b/docs/generated/verl-opd-v08-official-fields.json
@@ -1,0 +1,28 @@
+{
+  "claim": "Every fixture leaf is classified; coverage does not imply that policy-gradient, FSDP, or distributed execution is supported.",
+  "classifications": {
+    "derived": 0,
+    "exact": 23,
+    "informational_only": 18,
+    "locally_reinterpreted": 22,
+    "semantically_conformant": 16,
+    "unsupported": 3
+  },
+  "executable": false,
+  "official_example_fields_total": 82,
+  "profile": "verl-opd-v0.8-single-gpu-v1",
+  "provenance": {
+    "commit": "7aed6b230776f963fa09509c10d9c3a767d1102c",
+    "fixture": "tests/fixtures/verl/opd-v0.8-official-example-fields.yaml",
+    "license": "Apache-2.0",
+    "repository": "https://github.com/verl-project/verl",
+    "source_path": "examples/on_policy_distillation_trainer/run_qwen3_8b_fsdp.sh",
+    "tag": "v0.8.0"
+  },
+  "schema_version": 1,
+  "unsupported_fields": [
+    "actor_rollout_ref.actor.fsdp_config.optimizer_offload",
+    "actor_rollout_ref.actor.fsdp_config.param_offload",
+    "algorithm.adv_estimator"
+  ]
+}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -22,7 +22,7 @@ verl check before squash merge `8d3ebb2`.
 
 ## v0.9.0 productization
 
-- [ ] Add upstream-shaped override UX with complete source and precedence
+- [x] Add upstream-shaped override UX with complete source and precedence
       provenance while preserving the repeatable `--set` interface.
 - [ ] Bind execution to an immutable plan artifact and fail closed when its
       config, data, model, tokenizer or compatibility acceptance has drifted.
@@ -30,6 +30,17 @@ verl check before squash merge `8d3ebb2`.
       realistic one-GPU quickstart without widening the documented algorithm.
 - [ ] Preserve every frozen scientific artifact and keep distributed verl,
       policy-gradient OPD and unsupported objective semantics fail-closed.
+
+The config-UX candidate accepts ordered override files, repeatable `--set`
+values and trailing verl-style assignments while retaining every duplicate in
+the machine-readable provenance. The reduced official-field fixture classifies
+82 fields (23 exact, 16 semantically conformant, 22 locally reinterpreted,
+18 informational-only and 3 unsupported); unsupported objective and FSDP
+offload semantics still fail closed. The candidate passed 2,188 local
+non-GPU/non-network tests at 85.03% branch coverage, 8 RTX 4080 GPU tests,
+13 network tests with 2 environment-dependent skips, strict MkDocs, all 40
+rendered SVG instances across four Playwright viewports, package/Twine checks
+and the pinned-verl compatibility tests available in the training environment.
 
 ## v0.8.0 single-GPU verl OPD pivot
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ plugins:
 nav:
   - Home: index.md
   - For verl users: for-verl-users.md
+  - Config overrides: config-overrides.md
   - Run verl-style OPD: opd-quickstart.md
   - Start on one GPU: single-gpu-guide.md
   - Align:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ core-metadata-version = "2.4"
 "benchmarks/preregistration/alignment-external-v1.yaml" = "miniverl/evidence/data/alignment-external-v1/preregistration.yaml"
 "benchmarks/evidence/alignment-external-v1/jsonnav-selection-records.jsonl" = "miniverl/evidence/data/alignment-external-v1/task-evidence.jsonl"
 "src/miniverl/resources/qwen3_0_6b_1_7b_opd.yaml" = "miniverl/resources/qwen3_0_6b_1_7b_opd.yaml"
+"src/miniverl/resources/qwen3_0_6b_1_7b_opd_approval.json" = "miniverl/resources/qwen3_0_6b_1_7b_opd_approval.json"
 
 [tool.hatch.build.targets.sdist]
 core-metadata-version = "2.4"

--- a/scripts/check_docs_visual.py
+++ b/scripts/check_docs_visual.py
@@ -32,6 +32,7 @@ VIEWPORTS = ((1440, 900), (1024, 768), (820, 1000), (390, 844))
 PAGES = (
     "/",
     "/for-verl-users/",
+    "/config-overrides/",
     "/alignment-lab/alignment-lab-v1/",
     "/alignment-external/alignment-external-v1/",
     "/consumer-runtime/",

--- a/scripts/publish_verl_opd_compatibility.py
+++ b/scripts/publish_verl_opd_compatibility.py
@@ -1,13 +1,15 @@
-"""Publish the pinned OPD field matrix from the typed compiler."""
+"""Publish compiler-bound compatibility reports for the pinned OPD profile."""
 
 from __future__ import annotations
 
 import argparse
 import hashlib
+import json
 from collections import Counter
 from pathlib import Path
 from typing import Any
 
+from miniverl.bridge.contract import VERL_COMMIT, VERL_REPOSITORY, VERL_TAG
 from miniverl.bridge.opd_v08 import load_verl_opd_v08
 from miniverl.utils.runs import canonical_json
 
@@ -16,7 +18,7 @@ def build_matrix(source: Path) -> dict[str, Any]:
     compiled = load_verl_opd_v08(source)
     fields = [item.model_dump(mode="json") for item in compiled.compatibility]
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "profile": compiled.profile,
         "upstream": compiled.upstream,
         "source_fixture": source.as_posix(),
@@ -27,6 +29,7 @@ def build_matrix(source: Path) -> dict[str, Any]:
         "classification_counts": dict(
             sorted(Counter(item["classification"] for item in fields).items())
         ),
+        "reinterpretation_acceptance": compiled.reinterpretation_acceptance,
         "fields": fields,
         "scope": (
             "config conformance for one documented local pure-OPD profile; "
@@ -35,21 +38,79 @@ def build_matrix(source: Path) -> dict[str, Any]:
     }
 
 
+def build_official_report(root: Path) -> dict[str, object]:
+    fixture = root / "tests/fixtures/verl/opd-v0.8-official-example-fields.yaml"
+    plan = load_verl_opd_v08(fixture, require_executable=False)
+    counts = Counter(item.classification for item in plan.compatibility)
+    return {
+        "schema_version": 1,
+        "profile": plan.profile,
+        "provenance": {
+            "repository": VERL_REPOSITORY,
+            "tag": VERL_TAG,
+            "commit": VERL_COMMIT,
+            "source_path": "examples/on_policy_distillation_trainer/run_qwen3_8b_fsdp.sh",
+            "license": "Apache-2.0",
+            "fixture": fixture.relative_to(root).as_posix(),
+        },
+        "official_example_fields_total": len(plan.compatibility),
+        "classifications": {
+            name: counts.get(name, 0)
+            for name in (
+                "exact",
+                "semantically_conformant",
+                "locally_reinterpreted",
+                "derived",
+                "informational_only",
+                "unsupported",
+            )
+        },
+        "executable": plan.executable,
+        "unsupported_fields": [
+            item.upstream_field
+            for item in plan.compatibility
+            if item.classification == "unsupported"
+        ],
+        "claim": (
+            "Every fixture leaf is classified; coverage does not imply that "
+            "policy-gradient, FSDP, or distributed execution is supported."
+        ),
+    }
+
+
+def render_official_report(root: Path) -> str:
+    return json.dumps(build_official_report(root), indent=2, sort_keys=True) + "\n"
+
+
 def main() -> int:
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--source", type=Path, default=Path("examples/verl-opd-v0.8-single-gpu.yaml")
     )
     parser.add_argument(
         "--out", type=Path, default=Path("docs/generated/verl-opd-v0.8-compatibility.json")
     )
+    parser.add_argument(
+        "--official-out",
+        type=Path,
+        default=Path("docs/generated/verl-opd-v08-official-fields.json"),
+    )
     parser.add_argument("--check", action="store_true")
     args = parser.parse_args()
+    root = Path(__file__).resolve().parents[1]
     rendered = canonical_json(build_matrix(args.source))
+    official = render_official_report(root)
     if args.check:
-        return 0 if args.out.read_text(encoding="utf-8") == rendered else 1
+        current = args.out.is_file() and args.out.read_text(encoding="utf-8") == rendered
+        official_current = (
+            args.official_out.is_file()
+            and args.official_out.read_text(encoding="utf-8") == official
+        )
+        return 0 if current and official_current else 1
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(rendered, encoding="utf-8", newline="\n")
+    args.official_out.parent.mkdir(parents=True, exist_ok=True)
+    args.official_out.write_text(official, encoding="utf-8", newline="\n")
     return 0
 
 

--- a/src/miniverl/bridge/opd_runtime.py
+++ b/src/miniverl/bridge/opd_runtime.py
@@ -25,6 +25,9 @@ class OPDSystemPlan(BaseModel):
     upstream: dict[str, str]
     compiled_digest: str
     executable: bool
+    overrides: list[dict[str, Any]]
+    reinterpretation_acceptance: dict[str, Any]
+    acknowledgement_required_mappings: list[dict[str, Any]]
     field_classification_counts: dict[str, int]
     unsupported_fields: list[str]
     student: dict[str, Any]
@@ -111,6 +114,13 @@ def build_system_plan(compiled: CompiledLocalExecutionPlan) -> OPDSystemPlan:
         upstream=compiled.upstream,
         compiled_digest=compiled.compiled_digest,
         executable=compiled.executable,
+        overrides=[item.model_dump(mode="json") for item in compiled.overrides],
+        reinterpretation_acceptance=compiled.reinterpretation_acceptance,
+        acknowledgement_required_mappings=[
+            item.model_dump(mode="json")
+            for item in compiled.compatibility
+            if item.user_confirmation_required
+        ],
         field_classification_counts=classifications,
         unsupported_fields=[
             item.upstream_field

--- a/src/miniverl/bridge/opd_v08.py
+++ b/src/miniverl/bridge/opd_v08.py
@@ -85,6 +85,7 @@ class VerlOPDDataConfig(_StrictModel):
 
 class VerlOPDModelConfig(_StrictModel):
     path: str = Field(min_length=1)
+    use_remove_padding: bool = False
     enable_gradient_checkpointing: bool = False
     lora_rank: int = Field(default=16, ge=1)
     lora_alpha: int = Field(default=32, ge=1)
@@ -104,8 +105,15 @@ class VerlOPDOptimConfig(_StrictModel):
         return self
 
 
+class VerlOPDFSDPConfig(_StrictModel):
+    param_offload: bool = False
+    optimizer_offload: bool = False
+
+
 class VerlOPDActorConfig(_StrictModel):
     optim: VerlOPDOptimConfig
+    use_torch_compile: bool = False
+    fsdp_config: VerlOPDFSDPConfig = Field(default_factory=VerlOPDFSDPConfig)
     loss_agg_mode: str = "token-mean"
     use_kl_loss: bool = False
     ppo_mini_batch_size: int = Field(default=1, ge=1)
@@ -123,6 +131,8 @@ class VerlOPDRolloutConfig(_StrictModel):
     max_model_len: int | None = Field(default=None, ge=1)
     max_num_batched_tokens: int | None = Field(default=None, ge=1)
     max_num_seqs: int | None = Field(default=None, ge=1)
+    log_prob_use_dynamic_bsz: bool = False
+    log_prob_max_token_len_per_gpu: int | None = Field(default=None, ge=1)
 
     @model_validator(mode="after")
     def _numbers_are_finite(self) -> VerlOPDRolloutConfig:
@@ -142,6 +152,7 @@ class VerlOPDActorRolloutRefConfig(_StrictModel):
 
 
 class VerlOPDAlgorithmConfig(_StrictModel):
+    adv_estimator: str | None = None
     use_kl_in_reward: bool = False
 
 
@@ -210,6 +221,9 @@ class VerlOPDTrainerConfig(_StrictModel):
     total_training_steps: int | None = Field(default=None, ge=1)
     n_gpus_per_node: int = Field(default=1, ge=1)
     nnodes: int = Field(default=1, ge=1)
+    balance_batch: bool = False
+    logger: str | list[str] = "console"
+    val_before_train: bool = False
 
 
 class MiniVerlRuntimeExtensions(_StrictModel):
@@ -266,6 +280,13 @@ class OverrideRecord(_StrictModel):
     expression: str
     field: str
     value: Any
+    source_kind: Literal["overrides_file", "set", "trailing"] = "set"
+    source: str = "--set"
+    order: int = 0
+    previous_value: Any = None
+    previous_source: str = "base_config"
+    final_value: Any = None
+    effective: bool = False
 
 
 class CompatibilityEntry(_StrictModel):
@@ -280,7 +301,7 @@ class CompatibilityEntry(_StrictModel):
 
 
 class CompiledLocalExecutionPlan(_StrictModel):
-    schema_version: Literal[1] = 1
+    schema_version: Literal[2] = 2
     profile: Literal["verl-opd-v0.8-single-gpu-v1"] = "verl-opd-v0.8-single-gpu-v1"
     upstream: dict[str, str]
     source_digest: str
@@ -289,6 +310,7 @@ class CompiledLocalExecutionPlan(_StrictModel):
     source: VerlOPDV08Profile
     overrides: list[OverrideRecord]
     compatibility: list[CompatibilityEntry]
+    reinterpretation_acceptance: dict[str, Any]
     local_execution: dict[str, Any]
     executable: bool
 
@@ -333,6 +355,11 @@ _FIELD_RULES: dict[str, _Rule] = {
     ),
     "data.seed": _rule("source.seed", "exact", "same integer seed"),
     "actor_rollout_ref.model.path": _rule("student.model_id", "exact", "same model identity"),
+    "actor_rollout_ref.model.use_remove_padding": _rule(
+        "student.padding",
+        "semantically_conformant",
+        "the local padded runtime removes padding logically",
+    ),
     "actor_rollout_ref.model.enable_gradient_checkpointing": _rule(
         "student.gradient_checkpointing", "semantically_conformant", "same memory technique"
     ),
@@ -354,6 +381,21 @@ _FIELD_RULES: dict[str, _Rule] = {
     ),
     "actor_rollout_ref.actor.optim.lr_warmup_steps": _rule(
         "optimizer.lr_warmup_steps", "exact", "same optimizer-step count"
+    ),
+    "actor_rollout_ref.actor.use_torch_compile": _rule(
+        None,
+        "informational_only",
+        "recorded for provenance; the local runtime selects its own compilation path",
+    ),
+    "actor_rollout_ref.actor.fsdp_config.param_offload": _rule(
+        None,
+        "informational_only",
+        "false is a harmless distributed-training no-op; true is unsupported",
+    ),
+    "actor_rollout_ref.actor.fsdp_config.optimizer_offload": _rule(
+        None,
+        "informational_only",
+        "false is a harmless distributed-training no-op; true is unsupported",
     ),
     "actor_rollout_ref.actor.loss_agg_mode": _rule(
         "loss.reduction", "semantically_conformant", "token-mean is the only executable v0.8 mode"
@@ -410,6 +452,22 @@ _FIELD_RULES: dict[str, _Rule] = {
     ),
     "actor_rollout_ref.rollout.max_num_seqs": _rule(
         "batching.rollout_batch_limit", "locally_reinterpreted", "local sequence cap", "medium"
+    ),
+    "actor_rollout_ref.rollout.log_prob_use_dynamic_bsz": _rule(
+        None,
+        "informational_only",
+        "no separate rollout log-prob worker exists in direct GKD OPD",
+    ),
+    "actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu": _rule(
+        None,
+        "informational_only",
+        "no separate rollout log-prob worker exists in direct GKD OPD",
+    ),
+    "algorithm.adv_estimator": _rule(
+        None,
+        "unsupported",
+        "policy-gradient advantage estimation is outside direct GKD OPD",
+        "high",
     ),
     "algorithm.use_kl_in_reward": _rule(
         "loss.kl_in_reward", "exact", "must remain disabled; pure OPD has no reward"
@@ -517,6 +575,15 @@ _FIELD_RULES: dict[str, _Rule] = {
         "placement.device_count", "locally_reinterpreted", "always one local CUDA device", "high"
     ),
     "trainer.nnodes": _rule("placement.node_count", "locally_reinterpreted", "must be one", "high"),
+    "trainer.balance_batch": _rule(
+        None, "informational_only", "logical batches are already deterministic and locally ordered"
+    ),
+    "trainer.logger": _rule(
+        None, "informational_only", "external logger selection is not executed by miniVERL"
+    ),
+    "trainer.val_before_train": _rule(
+        None, "informational_only", "recorded; validation scheduling follows the local run contract"
+    ),
     "miniverl.runtime.mode": _rule(None, "informational_only", "miniVERL-only local extension"),
     "miniverl.student_revision": _rule(
         "student.revision", "informational_only", "miniVERL-only immutable Hub revision"
@@ -649,10 +716,61 @@ def _set_path(payload: dict[str, Any], path: str, value: Any) -> None:
     current[parts[-1]] = value
 
 
-def parse_overrides(expressions: Sequence[str]) -> list[OverrideRecord]:
+def _validate_override_value(value: Any, *, field: str) -> None:
+    if value is None or isinstance(value, (str, bool, int)):
+        return
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ConfigError(f"override {field} must be finite")
+        return
+    if isinstance(value, list):
+        for item in value:
+            _validate_override_value(item, field=field)
+        return
+    if isinstance(value, dict):
+        if any(not isinstance(key, str) for key in value):
+            raise ConfigError(f"override {field} mapping keys must be strings")
+        for item in value.values():
+            _validate_override_value(item, field=field)
+        return
+    raise ConfigError(
+        f"override {field} uses unsupported YAML value type {type(value).__name__}",
+        hint="use finite JSON/YAML strings, numbers, booleans, null, lists, or mappings",
+    )
+
+
+def _read_override_file(path: Path) -> list[str]:
+    if path.suffix.lower() in {".sh", ".bash", ".ps1", ".cmd", ".bat"}:
+        raise ConfigError(f"override file must contain data, not a shell script: {path}")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise ConfigError(f"cannot read override file {path}: {exc}") from exc
+    if path.suffix.lower() == ".json":
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ConfigError(f"override argv JSON {path} is invalid: {exc}") from exc
+        if not isinstance(payload, list) or any(not isinstance(item, str) for item in payload):
+            raise ConfigError(f"override argv JSON {path} must be an array of strings")
+        return payload
+    return [
+        line.strip()
+        for line in text.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def parse_overrides(
+    expressions: Sequence[str],
+    *,
+    source_kind: Literal["overrides_file", "set", "trailing"] = "set",
+    source: str = "--set",
+    start_order: int = 0,
+) -> list[OverrideRecord]:
     """Parse repeatable ``key=value`` overrides without Hydra or shell evaluation."""
     records: list[OverrideRecord] = []
-    for expression in expressions:
+    for offset, expression in enumerate(expressions):
         if "=" not in expression:
             raise ConfigError(f"override {expression!r} must use key=value syntax")
         field, raw = expression.split("=", 1)
@@ -667,7 +785,62 @@ def parse_overrides(expressions: Sequence[str]) -> list[OverrideRecord]:
         except yaml.YAMLError as exc:
             raise ConfigError(f"override {expression!r} has invalid YAML value: {exc}") from exc
         reject_interpolation(value, label=f"override {field}")
-        records.append(OverrideRecord(expression=expression, field=field, value=value))
+        _validate_override_value(value, field=field)
+        records.append(
+            OverrideRecord(
+                expression=expression,
+                field=field,
+                value=value,
+                source_kind=source_kind,
+                source=source,
+                order=start_order + offset,
+            )
+        )
+    return records
+
+
+def _resolve_overrides(
+    payload: dict[str, Any],
+    *,
+    override_files: Sequence[Path],
+    overrides: Sequence[str],
+    trailing_overrides: Sequence[str],
+) -> list[OverrideRecord]:
+    records: list[OverrideRecord] = []
+    order = 0
+    for path in override_files:
+        parsed = parse_overrides(
+            _read_override_file(path),
+            source_kind="overrides_file",
+            source=str(path),
+            start_order=order,
+        )
+        records.extend(parsed)
+        order += len(parsed)
+    parsed_set = parse_overrides(overrides, source_kind="set", source="--set", start_order=order)
+    records.extend(parsed_set)
+    order += len(parsed_set)
+    records.extend(
+        parse_overrides(
+            trailing_overrides,
+            source_kind="trailing",
+            source="--",
+            start_order=order,
+        )
+    )
+
+    current_sources = dict.fromkeys(_flatten(payload), "base_config")
+    for record in records:
+        before = _flatten(payload)
+        record.previous_value = before.get(record.field)
+        record.previous_source = current_sources.get(record.field, "not_present")
+        _set_path(payload, record.field, record.value)
+        current_sources[record.field] = record.source
+    final = _flatten(payload)
+    last_order = {record.field: record.order for record in records}
+    for record in records:
+        record.final_value = final.get(record.field)
+        record.effective = last_order[record.field] == record.order
     return records
 
 
@@ -721,21 +894,39 @@ def _semantic_blocker(path: str, value: Any) -> str | None:
         return "more than one local training GPU is unsupported"
     if path == "distillation.nnodes" and value not in {0, 1}:
         return "multi-node teacher execution is unsupported"
+    if path == "algorithm.adv_estimator" and value is not None:
+        return "policy-gradient advantage estimation is outside direct GKD OPD"
+    if (
+        path
+        in {
+            "actor_rollout_ref.actor.fsdp_config.param_offload",
+            "actor_rollout_ref.actor.fsdp_config.optimizer_offload",
+        }
+        and value
+    ):
+        return "FSDP offload semantics are unsupported by the one-GPU local runtime"
     return None
 
 
 def compile_verl_opd_v08(
     payload: Mapping[str, Any],
     *,
+    override_files: Sequence[Path] = (),
     overrides: Sequence[str] = (),
+    trailing_overrides: Sequence[str] = (),
+    reinterpretations_accepted: bool = True,
+    acceptance_source: str = "library_call",
     require_executable: bool = True,
 ) -> CompiledLocalExecutionPlan:
     """Compile one resolved documented profile into a deterministic local plan."""
     merged = copy.deepcopy(dict(payload))
     reject_interpolation(merged, label="verl OPD config")
-    records = parse_overrides(overrides)
-    for record in records:
-        _set_path(merged, record.field, record.value)
+    records = _resolve_overrides(
+        merged,
+        override_files=override_files,
+        overrides=overrides,
+        trailing_overrides=trailing_overrides,
+    )
     reject_interpolation(merged, label="resolved verl OPD config")
 
     teachers = (
@@ -778,6 +969,9 @@ def compile_verl_opd_v08(
             classification = rule.classification
             reason = rule.reason
             risk = rule.risk
+        confirmation_required = rule.confirmation or (
+            classification == "locally_reinterpreted" and risk == "high"
+        )
         compatibility.append(
             CompatibilityEntry(
                 upstream_field=path,
@@ -786,7 +980,7 @@ def compile_verl_opd_v08(
                 classification=classification,
                 reason=reason,
                 semantic_risk=risk,
-                user_confirmation_required=rule.confirmation,
+                user_confirmation_required=confirmation_required,
                 executable=blocker is None,
             )
         )
@@ -806,6 +1000,7 @@ def compile_verl_opd_v08(
         "task_rewards": False,
         "policy_gradient": False,
     }
+    high_risk = [item.upstream_field for item in compatibility if item.user_confirmation_required]
     common = {
         "upstream": {"repository": VERL_REPOSITORY, "tag": VERL_TAG, "commit": VERL_COMMIT},
         "source_digest": _canonical_digest(merged),
@@ -813,6 +1008,11 @@ def compile_verl_opd_v08(
         "source": source,
         "overrides": records,
         "compatibility": compatibility,
+        "reinterpretation_acceptance": {
+            "required_fields": high_risk,
+            "accepted": reinterpretations_accepted or not high_risk,
+            "source": acceptance_source if high_risk else "not_required",
+        },
         "local_execution": local_execution,
         "executable": executable,
     }
@@ -836,7 +1036,10 @@ def compile_verl_opd_v08(
 def load_verl_opd_v08(
     path: Path,
     *,
+    override_files: Sequence[Path] = (),
     overrides: Sequence[str] = (),
+    trailing_overrides: Sequence[str] = (),
+    accept_local_reinterpretations: bool = False,
     require_executable: bool = True,
 ) -> CompiledLocalExecutionPlan:
     """Load a resolved YAML mapping; scripts and interpolations are never evaluated."""
@@ -850,7 +1053,11 @@ def load_verl_opd_v08(
         raise ConfigError("verl OPD YAML must contain one mapping")
     return compile_verl_opd_v08(
         payload,
+        override_files=override_files,
         overrides=overrides,
+        trailing_overrides=trailing_overrides,
+        reinterpretations_accepted=accept_local_reinterpretations,
+        acceptance_source="cli_flag" if accept_local_reinterpretations else "not_accepted",
         require_executable=require_executable,
     )
 
@@ -858,27 +1065,68 @@ def load_verl_opd_v08(
 def load_verl_opd_v08_source(
     source: str | Path,
     *,
+    override_files: Sequence[Path] = (),
     overrides: Sequence[str] = (),
+    trailing_overrides: Sequence[str] = (),
+    accept_local_reinterpretations: bool = False,
     require_executable: bool = True,
 ) -> CompiledLocalExecutionPlan:
     """Load a path or the packaged Qwen3 quickstart profile."""
     source_text = str(source)
     if source_text != "builtin:qwen3-0.6b-1.7b-opd":
         return load_verl_opd_v08(
-            Path(source), overrides=overrides, require_executable=require_executable
+            Path(source),
+            override_files=override_files,
+            overrides=overrides,
+            trailing_overrides=trailing_overrides,
+            accept_local_reinterpretations=accept_local_reinterpretations,
+            require_executable=require_executable,
         )
     from importlib.resources import files
 
     resource = files("miniverl").joinpath("resources/qwen3_0_6b_1_7b_opd.yaml")
+    approval_resource = files("miniverl").joinpath("resources/qwen3_0_6b_1_7b_opd_approval.json")
     try:
         payload = yaml.safe_load(resource.read_text(encoding="utf-8"))
     except (OSError, UnicodeError, yaml.YAMLError) as exc:
         raise ConfigError(f"cannot read packaged OPD profile: {exc}") from exc
     if not isinstance(payload, Mapping):
         raise ConfigError("packaged OPD profile must contain one mapping")
+    unaccepted = compile_verl_opd_v08(
+        payload,
+        override_files=override_files,
+        overrides=overrides,
+        trailing_overrides=trailing_overrides,
+        reinterpretations_accepted=False,
+        acceptance_source="packaged_approval_mismatch",
+        require_executable=require_executable,
+    )
+    try:
+        approval = json.loads(approval_resource.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ConfigError(f"cannot read packaged OPD approval manifest: {exc}") from exc
+    approved_values = approval.get("approved_high_risk_values")
+    observed_values = {
+        item.upstream_field: item.source_value
+        for item in unaccepted.compatibility
+        if item.user_confirmation_required
+    }
+    manifest_matches = (
+        approval.get("schema_version") == 1
+        and approval.get("profile") == VERL_OPD_V08_PROFILE
+        and approved_values == observed_values
+    )
+    if not manifest_matches and not accept_local_reinterpretations:
+        return unaccepted
     return compile_verl_opd_v08(
         payload,
+        override_files=override_files,
         overrides=overrides,
+        trailing_overrides=trailing_overrides,
+        reinterpretations_accepted=True,
+        acceptance_source=(
+            "cli_flag" if accept_local_reinterpretations else "packaged_approval_manifest"
+        ),
         require_executable=require_executable,
     )
 
@@ -910,7 +1158,11 @@ def publish_imported_verl_opd_v08(
     # Prove the exact bytes about to be published remain executable without
     # relying on the first in-memory model instance.
     reparsed = yaml.safe_load(rendered)
-    validated = compile_verl_opd_v08(reparsed)
+    validated = compile_verl_opd_v08(
+        reparsed,
+        reinterpretations_accepted=bool(compiled.reinterpretation_acceptance["accepted"]),
+        acceptance_source=str(compiled.reinterpretation_acceptance["source"]),
+    )
     report = {
         "schema_version": 1,
         "status": "accepted",

--- a/src/miniverl/cli.py
+++ b/src/miniverl/cli.py
@@ -908,13 +908,22 @@ def align(
 # ---------------------------------------------------------- verl-shaped plan/run
 
 
-@app.command("plan")
+@app.command(
+    "plan",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
 def plan_command(
+    ctx: typer.Context,
     config: str = typer.Option(..., "--config", help="Resolved YAML path or builtin profile."),
     profile: str = typer.Option(
         "verl-opd-v0.8-single-gpu-v1", "--profile", help="Pinned compatibility profile."
     ),
     overrides: list[str] = typer.Option([], "--set", help="Repeatable dotted key=value override."),
+    override_files: list[Path] = typer.Option(
+        [],
+        "--overrides-file",
+        help="Repeatable plain key=value file or JSON argv array.",
+    ),
     as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
     offline: bool = typer.Option(False, "--offline", help="Do not access the network."),
     probe: bool = typer.Option(
@@ -939,7 +948,12 @@ def plan_command(
                 "--probe is not implemented in v0.8.0",
                 hint="run without --probe for the weight-free estimate",
             )
-        compiled = load_verl_opd_v08_source(config, overrides=overrides)
+        compiled = load_verl_opd_v08_source(
+            config,
+            override_files=override_files,
+            overrides=overrides,
+            trailing_overrides=ctx.args,
+        )
         plan = build_system_plan(compiled)
         payload = plan.model_dump(mode="json")
     except MiniVerlError as exc:
@@ -966,15 +980,39 @@ def plan_command(
         console.print(f"    {_esc(key)}: {_esc(value)}")
     console.print("  time to first update: unknown (not measured by plan)")
     console.print(f"  plan sha256 {_esc(plan.compiled_digest)}")
+    required = plan.reinterpretation_acceptance["required_fields"]
+    if required:
+        console.print("  high-risk local reinterpretations")
+        for mapping in plan.acknowledgement_required_mappings:
+            console.print(
+                f"    - {_esc(mapping['upstream_field'])}: "
+                f"{_esc(mapping['source_value'])} -> {_esc(mapping['local_target'])}"
+            )
+            console.print(f"      {_esc(mapping['reason'])}")
+        console.print(f"  acceptance: {_esc(plan.reinterpretation_acceptance['source'])}")
 
 
-@app.command("run")
+@app.command(
+    "run",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
 def verl_run_command(
+    ctx: typer.Context,
     config: str = typer.Option(..., "--config", help="Resolved YAML path or builtin profile."),
     profile: str = typer.Option(
         "verl-opd-v0.8-single-gpu-v1", "--profile", help="Pinned compatibility profile."
     ),
     overrides: list[str] = typer.Option([], "--set", help="Repeatable dotted key=value override."),
+    override_files: list[Path] = typer.Option(
+        [],
+        "--overrides-file",
+        help="Repeatable plain key=value file or JSON argv array.",
+    ),
+    accept_local_reinterpretations: bool = typer.Option(
+        False,
+        "--accept-local-reinterpretations",
+        help="Accept the reported high-risk one-GPU semantic reinterpretations.",
+    ),
     output: Optional[Path] = typer.Option(None, "--output", help="Parent run directory."),
     run_id: Optional[str] = typer.Option(None, "--run-id", help="Explicit run id."),
     resume: Optional[Path] = typer.Option(None, "--resume", help="Resume an existing run."),
@@ -994,7 +1032,21 @@ def verl_run_command(
             raise ConfigError(
                 f"unsupported OPD profile {profile!r}", hint=f"use --profile {VERL_OPD_V08_PROFILE}"
             )
-        compiled = load_verl_opd_v08_source(config, overrides=overrides)
+        compiled = load_verl_opd_v08_source(
+            config,
+            override_files=override_files,
+            overrides=overrides,
+            trailing_overrides=ctx.args,
+            accept_local_reinterpretations=accept_local_reinterpretations,
+        )
+        acceptance = compiled.reinterpretation_acceptance
+        if acceptance["required_fields"] and not acceptance["accepted"]:
+            raise ConfigError(
+                "external config has high-risk local reinterpretations that were not accepted",
+                hint=(
+                    "inspect them with miniverl plan, then pass --accept-local-reinterpretations"
+                ),
+            )
         system_plan = build_system_plan(compiled)
         native = compile_native_run_config(compiled, system_plan=system_plan)
         from miniverl.config.models import VerlParquetSourceConfig
@@ -1682,8 +1734,12 @@ def bridge_doctor_command(
         raise typer.Exit(1)
 
 
-@bridge_app.command("compile-opd")
+@bridge_app.command(
+    "compile-opd",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
 def bridge_compile_opd_command(
+    ctx: typer.Context,
     config: str = typer.Option(..., "--config", help="Resolved YAML path or builtin profile."),
     profile: str = typer.Option(
         "verl-opd-v0.8-single-gpu-v1",
@@ -1694,6 +1750,11 @@ def bridge_compile_opd_command(
         [],
         "--set",
         help="Repeatable dotted key=value override. No Hydra or shell evaluation.",
+    ),
+    override_files: list[Path] = typer.Option(
+        [],
+        "--overrides-file",
+        help="Repeatable plain key=value file or JSON argv array.",
     ),
     out: Optional[Path] = typer.Option(
         None,
@@ -1718,7 +1779,9 @@ def bridge_compile_opd_command(
             )
         plan = load_verl_opd_v08_source(
             config,
+            override_files=override_files,
             overrides=overrides,
+            trailing_overrides=ctx.args,
             require_executable=not inspect_unsupported,
         )
         payload = plan.model_dump(mode="json")

--- a/src/miniverl/resources/qwen3_0_6b_1_7b_opd_approval.json
+++ b/src/miniverl/resources/qwen3_0_6b_1_7b_opd_approval.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "profile": "verl-opd-v0.8-single-gpu-v1",
+  "approved_high_risk_values": {
+    "actor_rollout_ref.actor.ppo_mini_batch_size": 2,
+    "actor_rollout_ref.rollout.gpu_memory_utilization": 0.5,
+    "actor_rollout_ref.rollout.name": "vllm",
+    "actor_rollout_ref.rollout.tensor_model_parallel_size": 1,
+    "distillation.n_gpus_per_node": 1,
+    "distillation.nnodes": 1,
+    "distillation.teacher_models.teacher_model.inference.data_parallel_size": 1,
+    "distillation.teacher_models.teacher_model.inference.gpu_memory_utilization": 0.5,
+    "distillation.teacher_models.teacher_model.inference.name": "vllm",
+    "distillation.teacher_models.teacher_model.inference.pipeline_model_parallel_size": 1,
+    "distillation.teacher_models.teacher_model.inference.tensor_model_parallel_size": 1,
+    "distillation.teacher_models.teacher_model.num_replicas": 1,
+    "trainer.n_gpus_per_node": 1,
+    "trainer.nnodes": 1,
+    "trainer.save_freq": 1,
+    "trainer.test_freq": -1,
+    "trainer.total_epochs": 1
+  }
+}

--- a/tests/cli/test_opd_product_cli.py
+++ b/tests/cli/test_opd_product_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
@@ -47,6 +48,103 @@ def test_run_dry_compiles_a_valid_native_recipe() -> None:
     payload = json.loads(result.stdout)
     assert payload["resolved_native_config"]["source"]["kind"] == "verl_parquet"
     assert payload["resolved_native_config"]["loss"]["mode"] == "forward_kl_topk"
+
+
+def test_plan_accepts_trailing_hydra_style_overrides_and_override_files(tmp_path) -> None:
+    override_file = tmp_path / "plan.overrides"
+    override_file.write_text(
+        "distillation.distillation_loss.topk=16\n",
+        encoding="utf-8",
+    )
+    result = runner.invoke(
+        app,
+        [
+            "plan",
+            "--profile",
+            "verl-opd-v0.8-single-gpu-v1",
+            "--config",
+            "builtin:qwen3-0.6b-1.7b-opd",
+            "--overrides-file",
+            str(override_file),
+            "--set",
+            "distillation.distillation_loss.topk=32",
+            "--json",
+            "--",
+            "distillation.distillation_loss.topk=64",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["loss"]["top_k"] == 64
+    assert [item["source_kind"] for item in payload["overrides"]] == [
+        "overrides_file",
+        "set",
+        "trailing",
+    ]
+    assert payload["reinterpretation_acceptance"]["accepted"] is True
+
+
+def test_external_run_requires_explicit_high_risk_reinterpretation_acceptance() -> None:
+    config = Path(__file__).resolve().parents[2] / "examples/verl-opd-v0.8-single-gpu.yaml"
+    refused = runner.invoke(
+        app,
+        ["run", "--config", str(config), "--dry-run", "--offline"],
+    )
+    assert refused.exit_code == 1
+    assert "--accept-local-reinterpretations" in refused.output
+
+    accepted = runner.invoke(
+        app,
+        [
+            "run",
+            "--config",
+            str(config),
+            "--dry-run",
+            "--offline",
+            "--accept-local-reinterpretations",
+            "--json",
+        ],
+    )
+    assert accepted.exit_code == 0, accepted.output
+    payload = json.loads(accepted.stdout)
+    acceptance = payload["compatibility"]["reinterpretation_acceptance"]
+    assert acceptance["accepted"] is True
+    assert acceptance["source"] == "cli_flag"
+    assert "actor_rollout_ref.actor.ppo_mini_batch_size" in acceptance["required_fields"]
+
+
+def test_builtin_approval_is_value_bound_and_does_not_approve_semantic_drift() -> None:
+    approved = runner.invoke(
+        app,
+        [
+            "run",
+            "--config",
+            "builtin:qwen3-0.6b-1.7b-opd",
+            "--dry-run",
+            "--offline",
+            "--json",
+        ],
+    )
+    assert approved.exit_code == 0, approved.output
+    assert (
+        json.loads(approved.stdout)["compatibility"]["reinterpretation_acceptance"]["source"]
+        == "packaged_approval_manifest"
+    )
+
+    drifted = runner.invoke(
+        app,
+        [
+            "run",
+            "--config",
+            "builtin:qwen3-0.6b-1.7b-opd",
+            "--set",
+            "actor_rollout_ref.actor.ppo_mini_batch_size=4",
+            "--dry-run",
+            "--offline",
+        ],
+    )
+    assert drifted.exit_code == 1
+    assert "--accept-local-reinterpretations" in drifted.output
 
 
 def test_data_sample_writes_portable_message_rows(tmp_path) -> None:

--- a/tests/fixtures/verl/opd-v0.8-official-example-fields.yaml
+++ b/tests/fixtures/verl/opd-v0.8-official-example-fields.yaml
@@ -1,0 +1,101 @@
+# Field-surface fixture derived from volcengine/verl's Apache-2.0 example:
+# examples/on_policy_distillation_trainer/run_qwen3_8b_fsdp.sh
+# tag v0.8.0, commit 7aed6b230776f963fa09509c10d9c3a767d1102c.
+# Values are reduced for offline classification; this fixture is intentionally
+# non-executable because it retains the official PG/FSDP field surface.
+data:
+  train_files: [data/train.parquet]
+  val_files: [data/val.parquet]
+  prompt_key: prompt
+  train_batch_size: 8
+  max_prompt_length: 256
+  max_response_length: 64
+  filter_overlong_prompts: true
+  truncation: error
+  shuffle: false
+  seed: 17
+actor_rollout_ref:
+  model:
+    path: Qwen/Qwen3-0.6B
+    use_remove_padding: true
+    enable_gradient_checkpointing: true
+    lora_rank: 16
+    lora_alpha: 32
+    target_modules: [q_proj, v_proj]
+    lora_adapter_path: null
+  actor:
+    use_torch_compile: true
+    optim:
+      lr: 1e-5
+      weight_decay: 0.01
+      lr_warmup_steps: 0
+    loss_agg_mode: token-mean
+    use_kl_loss: false
+    ppo_mini_batch_size: 8
+    ppo_max_token_len_per_gpu: 2048
+    use_dynamic_bsz: true
+    fsdp_config:
+      param_offload: true
+      optimizer_offload: true
+  rollout:
+    name: vllm
+    n: 1
+    temperature: 1.0
+    top_p: 0.95
+    tensor_model_parallel_size: 1
+    gpu_memory_utilization: 0.5
+    max_model_len: 320
+    max_num_batched_tokens: 2048
+    max_num_seqs: 8
+    log_prob_use_dynamic_bsz: true
+    log_prob_max_token_len_per_gpu: 2048
+algorithm:
+  adv_estimator: grpo
+  use_kl_in_reward: false
+distillation:
+  enabled: true
+  teacher_key: data_source
+  n_gpus_per_node: 1
+  nnodes: 1
+  teacher_models:
+    teacher_model:
+      model_path: Qwen/Qwen3-1.7B
+      num_replicas: 1
+      inference:
+        name: vllm
+        dtype: bfloat16
+        tensor_model_parallel_size: 1
+        data_parallel_size: 1
+        pipeline_model_parallel_size: 1
+        gpu_memory_utilization: 0.5
+        max_model_len: 321
+  distillation_loss:
+    loss_mode: forward_kl_topk
+    topk: 32
+    use_task_rewards: false
+    distillation_loss_coef: 1.0
+    loss_max_clamp: 10.0
+    log_prob_min_clamp: -10.0
+    use_policy_gradient: false
+trainer:
+  balance_batch: true
+  logger: [console, wandb]
+  val_before_train: false
+  project_name: mini-verl
+  experiment_name: official-field-surface
+  save_freq: 10
+  test_freq: 10
+  total_epochs: 1
+  total_training_steps: 2
+  n_gpus_per_node: 1
+  nnodes: 1
+miniverl:
+  student_revision: c1899de289a04d12100db370d81485cdf75e47ca
+  teacher_revision: 70d244cc86ccca08cf5af4e1e306ecf908b1ad5e
+  runtime: {mode: auto}
+  memory: {vram_limit_gib: 16, headroom_gib: 1.5}
+  batching:
+    rollout_batch_size: 2
+    teacher_score_batch_size: 2
+    update_trajectory_batch_size: 2
+  teacher_adapter: {path: null, revision: null}

--- a/tests/unit/test_opd_runtime_plan.py
+++ b/tests/unit/test_opd_runtime_plan.py
@@ -34,6 +34,10 @@ def test_builtin_plan_is_weight_free_truthful_and_executable() -> None:
     assert plan.time_to_first_update == {"status": "unknown", "seconds": None}
     assert plan.local_execution["distributed_execution"] is False
     assert plan.unsupported_fields == []
+    assert plan.acknowledgement_required_mappings
+    assert all(
+        item["reason"] and item["local_target"] for item in plan.acknowledgement_required_mappings
+    )
 
 
 def test_native_compilation_preserves_pure_opd_semantics() -> None:

--- a/tests/unit/test_verl_opd_compatibility_publish.py
+++ b/tests/unit/test_verl_opd_compatibility_publish.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.publish_verl_opd_compatibility import render_official_report
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_official_example_coverage_report_is_generated_and_self_consistent() -> None:
+    target = ROOT / "docs/generated/verl-opd-v08-official-fields.json"
+    assert target.read_text(encoding="utf-8") == render_official_report(ROOT)
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert sum(payload["classifications"].values()) == payload["official_example_fields_total"]
+    assert payload["executable"] is False
+    assert "algorithm.adv_estimator" in payload["unsupported_fields"]

--- a/tests/unit/test_verl_opd_v08_config.py
+++ b/tests/unit/test_verl_opd_v08_config.py
@@ -154,6 +154,119 @@ def test_override_precedence_and_scientific_notation_are_safe() -> None:
     ]
 
 
+def test_override_sources_preserve_precedence_duplicates_and_effective_values(
+    tmp_path: Path,
+) -> None:
+    from miniverl.bridge.opd_v08 import load_verl_opd_v08
+
+    source = tmp_path / "profile.yaml"
+    source.write_text(
+        Path(__file__)
+        .resolve()
+        .parents[2]
+        .joinpath("examples/verl-opd-v0.8-single-gpu.yaml")
+        .read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    first = tmp_path / "first.overrides"
+    first.write_text(
+        "# comments and blank lines are ignored\n\ndistillation.distillation_loss.topk=16\n",
+        encoding="utf-8",
+    )
+    second = tmp_path / "second.json"
+    second.write_text(
+        json.dumps(
+            [
+                "distillation.distillation_loss.topk=32",
+                "actor_rollout_ref.actor.optim.lr=2e-5",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    plan = load_verl_opd_v08(
+        source,
+        override_files=(first, second),
+        overrides=(
+            "distillation.distillation_loss.topk=64",
+            "distillation.distillation_loss.topk=48",
+        ),
+        trailing_overrides=("distillation.distillation_loss.topk=40",),
+    )
+
+    topk = [item for item in plan.overrides if item.field.endswith(".topk")]
+    assert [item.source_kind for item in topk] == [
+        "overrides_file",
+        "overrides_file",
+        "set",
+        "set",
+        "trailing",
+    ]
+    assert [item.previous_value for item in topk] == [32, 16, 32, 64, 48]
+    assert [item.previous_source for item in topk] == [
+        "base_config",
+        str(first),
+        str(second),
+        "--set",
+        "--set",
+    ]
+    assert all(item.final_value == 40 for item in topk)
+    assert [item.effective for item in topk] == [False, False, False, False, True]
+    assert plan.source.distillation.distillation_loss.topk == 40
+    assert plan.source.actor_rollout_ref.actor.optim.lr == pytest.approx(2e-5)
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "actor_rollout_ref.model.path=${oc.env:MODEL}",
+        "actor_rollout_ref.actor.optim.lr=.nan",
+        "actor_rollout_ref.model.path=2026-08-12",
+        "actor_rollout_ref.model.path=!!python/object/apply:os.system ['never']",
+    ],
+)
+def test_override_files_reject_interpolation_non_finite_and_yaml_objects(
+    tmp_path: Path, line: str
+) -> None:
+    from miniverl.bridge.opd_v08 import load_verl_opd_v08
+
+    overrides = tmp_path / "unsafe.overrides"
+    overrides.write_text(line + "\n", encoding="utf-8")
+    source = Path(__file__).resolve().parents[2] / "examples/verl-opd-v0.8-single-gpu.yaml"
+    with pytest.raises(ConfigError):
+        load_verl_opd_v08(source, override_files=(overrides,))
+
+
+def test_official_example_field_fixture_is_fully_classified() -> None:
+    from miniverl.bridge.opd_v08 import load_verl_opd_v08
+
+    root = Path(__file__).resolve().parents[2]
+    plan = load_verl_opd_v08(
+        root / "tests/fixtures/verl/opd-v0.8-official-example-fields.yaml",
+        require_executable=False,
+    )
+    fields = {item.upstream_field: item for item in plan.compatibility}
+    expected = {
+        "algorithm.adv_estimator",
+        "actor_rollout_ref.model.use_remove_padding",
+        "actor_rollout_ref.actor.use_torch_compile",
+        "actor_rollout_ref.actor.fsdp_config.param_offload",
+        "actor_rollout_ref.actor.fsdp_config.optimizer_offload",
+        "actor_rollout_ref.rollout.log_prob_use_dynamic_bsz",
+        "actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu",
+        "trainer.balance_batch",
+        "trainer.logger",
+        "trainer.val_before_train",
+    }
+    assert expected <= fields.keys()
+    assert set(plan.source_leaf_fields) == fields.keys()
+    assert fields["trainer.logger"].classification == "informational_only"
+    assert fields["actor_rollout_ref.actor.fsdp_config.param_offload"].classification == (
+        "unsupported"
+    )
+    assert plan.executable is False
+
+
 @pytest.mark.parametrize(
     ("path", "value"),
     [


### PR DESCRIPTION
﻿## Summary

- accept ordered override files, repeatable `--set` values, and trailing verl-style `key=value` assignments without Hydra or shell evaluation
- preserve duplicate/precedence provenance and require value-bound acceptance for acknowledgement-required one-GPU reinterpretations
- publish a reduced, attributed official-field compatibility fixture/report and document the supported config workflow in English and Chinese

## Compatibility evidence

- reduced official profile subset: 82 fields
- exact: 23
- semantically conformant: 16
- locally reinterpreted: 22
- informational only: 18
- unsupported: 3
- unsupported advantage-estimator and FSDP-offload semantics remain fail-closed

## Validation

- `pytest -q -m "not gpu and not network" --cov=miniverl`: 2,188 passed, 9 skipped, 21 deselected; 85.03% branch coverage
- `pytest -q -m gpu`: 8 passed on RTX 4080
- `pytest -q -m network`: 13 passed, 2 skipped
- focused config/product tests: 42 passed, 1 skipped
- Ruff check/format, mypy, actionlint, strict MkDocs, generated artifacts, Markdown/link checks, Playwright at 1440/1024/820/390 px, build/Twine and package-resource checks passed
- frozen calculator result SHA-256 remains `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`

This PR does not add an algorithm, change a scientific result, or claim distributed verl compatibility.
