### PR TITLE
Bind runs to immutable execution plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to miniVERL are recorded here. The format follows
 
 ## [Unreleased]
 
+### Immutable plan/run workflow
+
+- Added deterministic `plan --out plan.json` artifacts that bind the source
+  YAML, ordered overrides, accepted compatibility matrix, immutable model
+  revisions, scanned Parquet hashes/schema/rows, exact native config and
+  weight-free physical recommendations.
+- Added `run --plan` with fail-closed plan, source, data and minor-version
+  validation. The plan digest is carried by run manifests, teacher caches and
+  checkpoints; direct `run --config` remains supported.
+
 ### Verl config UX
 
 - Added safe trailing Hydra-style overrides and repeatable plain/JSON

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -27,6 +27,14 @@ fails closed if one of those values drifts. A generated report classifies all
 semantically conformant, 22 locally reinterpreted, 18 informational and 3
 unsupported. No algorithm or distributed boundary widened.
 
+The second slice adds deterministic immutable OPD plans. `plan --out` hashes
+the source config and every Parquet file, scans schema/content/row identity,
+requires immutable model commits and seals the accepted compatibility result,
+native config and weight-free recommendations. `run --plan` revalidates those
+bytes without recompiling; the canonical plan digest propagates into the run
+manifest, teacher cache and every checkpoint. Tokenizer structural identity is
+truthfully deferred until tokenizers are loaded by the later bounded probe.
+
 ## v0.8.1 product surface
 
 The landing pages now lead with the documented one-GPU verl-style OPD journey,

--- a/PYPI.md
+++ b/PYPI.md
@@ -38,10 +38,9 @@ python -m pip install "miniverl[train]"
 miniverl data sample --format verl-parquet --out prompts.parquet
 miniverl plan --profile verl-opd-v0.8-single-gpu-v1 \
   --config builtin:qwen3-0.6b-1.7b-opd \
-  --set 'data.train_files=["prompts.parquet"]'
+  --set 'data.train_files=["prompts.parquet"]' --out plan.json
 miniverl run --profile verl-opd-v0.8-single-gpu-v1 \
-  --config builtin:qwen3-0.6b-1.7b-opd \
-  --set 'data.train_files=["prompts.parquet"]' --dry-run
+  --plan plan.json --dry-run
 ```
 
 These commands need no Git checkout. `data sample` creates a real structured
@@ -199,12 +198,11 @@ successful bridge check never means that a distributed verl job ran. Review
 the [bridge contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md) and [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md).
 
 The intended operating loop is **plan → inspect → run → inspect → export**.
-Direct execution remains convenient for experiments, but the JSON plan and
-compatibility report are the durable review surfaces: they expose model pins,
-data paths, loss details, physical batches, unsupported fields, estimated
-memory and every local reinterpretation before weights are allocated. Run
-artifacts then add measurements and hashes without rewriting the original
-source intent.
+`plan --out` byte-binds the YAML, ordered overrides and scanned Parquet inputs
+to the exact native config; `run --plan` rejects drift before loading weights.
+Its digest follows the run manifest, teacher cache and checkpoints. Direct
+`run --config` remains available for experiments. See [immutable execution
+plans](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/immutable-plans.md).
 
 ## Research and validation
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,9 @@ python -m pip install "miniverl[train]"
 miniverl data sample --format verl-parquet --out prompts.parquet
 miniverl plan --profile verl-opd-v0.8-single-gpu-v1 \
   --config builtin:qwen3-0.6b-1.7b-opd \
-  --set 'data.train_files=["prompts.parquet"]'
+  --set 'data.train_files=["prompts.parquet"]' --out plan.json
 miniverl run --profile verl-opd-v0.8-single-gpu-v1 \
-  --config builtin:qwen3-0.6b-1.7b-opd \
-  --set 'data.train_files=["prompts.parquet"]' --dry-run
+  --plan plan.json --dry-run
 ```
 
 These commands need no Git checkout. `data sample` creates a real structured
@@ -199,12 +198,11 @@ successful bridge check never means that a distributed verl job ran. Review
 the [bridge contract](docs/verl-bridge.md) and [compatibility policy](docs/compatibility.md).
 
 The intended operating loop is **plan → inspect → run → inspect → export**.
-Direct execution remains convenient for experiments, but the JSON plan and
-compatibility report are the durable review surfaces: they expose model pins,
-data paths, loss details, physical batches, unsupported fields, estimated
-memory and every local reinterpretation before weights are allocated. Run
-artifacts then add measurements and hashes without rewriting the original
-source intent.
+`plan --out` byte-binds the YAML, ordered overrides and scanned Parquet inputs
+to the exact native config; `run --plan` rejects drift before loading weights.
+Its digest follows the run manifest, teacher cache and checkpoints. Direct
+`run --config` remains available for experiments. See [immutable execution
+plans](docs/immutable-plans.md).
 
 ## Research and validation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,10 +35,9 @@ python -m pip install "miniverl[train]"
 miniverl data sample --format verl-parquet --out prompts.parquet
 miniverl plan --profile verl-opd-v0.8-single-gpu-v1 \
   --config builtin:qwen3-0.6b-1.7b-opd \
-  --set 'data.train_files=["prompts.parquet"]'
+  --set 'data.train_files=["prompts.parquet"]' --out plan.json
 miniverl run --profile verl-opd-v0.8-single-gpu-v1 \
-  --config builtin:qwen3-0.6b-1.7b-opd \
-  --set 'data.train_files=["prompts.parquet"]' --dry-run
+  --plan plan.json --dry-run
 ```
 
 这些命令不需要 Git checkout。`data sample` 生成真实的结构化 Parquet；`plan` 在不加载
@@ -165,9 +164,10 @@ snapshot materialize 之前仍报告 `launchable: false`。产物完整性、上
 launchability、算法语义与 distributed execution 分开报告。bridge doctor 通过并不表示运行过
 分布式 verl。详见[桥接契约](docs/verl-bridge.md)与[兼容性政策](docs/compatibility.md)。
 
-建议操作闭环是 **plan → inspect → run → inspect → export**。JSON plan 与兼容报告在分配
-权重前明确模型 pin、数据路径、loss、physical batch、不支持字段、显存 estimate 与所有本地
-重解释；run artifact 只在其上补充 measurement 与 hash，不会改写源意图。
+建议操作闭环是 **plan → inspect → run → inspect → export**。`plan --out` 把 YAML、按顺序
+应用的 override、扫描后的 Parquet 与精确 native config 绑定；`run --plan` 在加载权重前拒绝
+任何漂移。plan digest 同时进入 run manifest、teacher cache 和 checkpoint；直接
+`run --config` 仍适合快速实验。详见[不可变执行计划](docs/immutable-plans.md)。
 
 ## 研究与验证
 

--- a/docs/config-overrides.md
+++ b/docs/config-overrides.md
@@ -67,6 +67,10 @@ This flag accepts only the high-risk mappings printed in that compiled report.
 It never enables an unsupported algorithm, multi-GPU field, FSDP behavior or
 policy-gradient objective.
 
+For a reviewed run, bind the acceptance and exact inputs once with
+`miniverl plan --out plan.json`, then use `miniverl run --plan plan.json`; see
+[Immutable execution plans](immutable-plans.md).
+
 ## Official-example field coverage
 
 The generated [coverage report](generated/verl-opd-v08-official-fields.json)

--- a/docs/for-verl-users.md
+++ b/docs/for-verl-users.md
@@ -50,6 +50,11 @@ matrix. The development CLI records repeated `--set`, override files and
 trailing tokens with deterministic precedence; it does not execute `${...}`
 interpolations or shell text. See [Config overrides](config-overrides.md).
 
+For a serious run, add `--accept-local-reinterpretations --out plan.json`,
+inspect the immutable artifact, then execute `miniverl run --plan plan.json`.
+This binds the source YAML, overrides and scanned Parquet bytes to the exact
+native config; see [Immutable execution plans](immutable-plans.md).
+
 ## Same fields, different placement
 
 An upstream-shaped fragment can stay recognizable:

--- a/docs/immutable-plans.md
+++ b/docs/immutable-plans.md
@@ -1,0 +1,41 @@
+# Immutable execution plans
+
+For a serious run, freeze the resolved config and Parquet inputs before loading
+model weights:
+
+```bash
+miniverl plan --config verl-opd.yaml \
+  --accept-local-reinterpretations \
+  --out plan.json --offline
+miniverl run --plan plan.json --offline
+```
+
+`plan --out` is still weight-free. It scans the actual Parquet source and
+atomically writes a deterministic JSON artifact containing:
+
+- the source YAML byte digest and every ordered override;
+- the full compatibility report and explicit reinterpretation acceptance;
+- immutable student and teacher revisions;
+- every Parquet file hash plus schema, content and row-count identities;
+- the exact validated native `RunConfig`, loss semantics and physical
+  recommendations;
+- declared tokenizer revisions. Structural tokenizer identities remain
+  `declared_not_loaded` until the bounded hardware probe loads them.
+
+The plan's canonical digest excludes only its own digest fields. `run --plan`
+validates the schema and miniVERL minor-version boundary, recomputes that digest,
+rechecks the YAML and every Parquet byte, rescans the data manifest, and consumes
+the sealed native config. It never recompiles with new defaults. Model
+construction starts only after all checks pass.
+
+The same plan digest is recorded in the run manifest, teacher-cache index,
+checkpoint state and checkpoint identity. A cache or checkpoint from another
+plan is refused. Direct `run --config` remains available for quick experiments,
+but `--plan` is mutually exclusive with config and override options.
+
+## Deliberate limits
+
+An immutable plan does not download or hash model snapshots, allocate CUDA, or
+claim measured memory. Those identities become measured only through the
+explicit probe/materialization stages. Moving model revisions, unsupported verl
+semantics and unaccepted local reinterpretations prevent plan publication.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -24,7 +24,7 @@ verl check before squash merge `8d3ebb2`.
 
 - [x] Add upstream-shaped override UX with complete source and precedence
       provenance while preserving the repeatable `--set` interface.
-- [ ] Bind execution to an immutable plan artifact and fail closed when its
+- [x] Bind execution to an immutable plan artifact and fail closed when its
       config, data, model, tokenizer or compatibility acceptance has drifted.
 - [ ] Add a bounded hardware probe, transactional model materialization and a
       realistic one-GPU quickstart without widening the documented algorithm.
@@ -41,6 +41,13 @@ non-GPU/non-network tests at 85.03% branch coverage, 8 RTX 4080 GPU tests,
 13 network tests with 2 environment-dependent skips, strict MkDocs, all 40
 rendered SVG instances across four Playwright viewports, package/Twine checks
 and the pinned-verl compatibility tests available in the training environment.
+
+The immutable-plan candidate passed 2,196 local non-GPU/non-network tests at
+85.01% branch coverage, 8 RTX 4080 GPU tests, and 13 network tests with 2
+environment-dependent skips. Determinism and tamper tests cover plan bytes,
+source YAML, Parquet files, acceptance, native config, cache identity and
+checkpoint identity. Ruff, mypy, actionlint, strict MkDocs, package/Twine,
+generated-description, link/text and all four Playwright viewports also pass.
 
 ## v0.8.0 single-GPU verl OPD pivot
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
   - Home: index.md
   - For verl users: for-verl-users.md
   - Config overrides: config-overrides.md
+  - Immutable plans: immutable-plans.md
   - Run verl-style OPD: opd-quickstart.md
   - Start on one GPU: single-gpu-guide.md
   - Align:

--- a/scripts/check_docs_visual.py
+++ b/scripts/check_docs_visual.py
@@ -33,6 +33,7 @@ PAGES = (
     "/",
     "/for-verl-users/",
     "/config-overrides/",
+    "/immutable-plans/",
     "/alignment-lab/alignment-lab-v1/",
     "/alignment-external/alignment-external-v1/",
     "/consumer-runtime/",

--- a/src/miniverl/bridge/opd_plan.py
+++ b/src/miniverl/bridge/opd_plan.py
@@ -1,0 +1,289 @@
+"""Immutable, data-bound execution plans for the pinned verl OPD profile."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from importlib.resources import files
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from miniverl import __version__
+from miniverl.bridge.opd_runtime import OPDSystemPlan, build_system_plan, compile_native_run_config
+from miniverl.bridge.opd_v08 import CompiledLocalExecutionPlan
+from miniverl.config.models import RunConfig, VerlParquetSourceConfig
+from miniverl.data.verl_parquet import VerlParquetDataset
+from miniverl.errors import ConfigError
+from miniverl.utils.runs import canonical_json, write_json_atomic
+
+__all__ = [
+    "ImmutableOPDPlan",
+    "build_immutable_opd_plan",
+    "load_and_verify_immutable_opd_plan",
+]
+
+_COMMIT = re.compile(r"^[0-9a-f]{40}$")
+_BUILTIN = "builtin:qwen3-0.6b-1.7b-opd"
+
+
+class ImmutableOPDPlan(BaseModel):
+    """Complete local execution input whose digest excludes only its self-references."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = 1
+    artifact_type: Literal["miniverl_immutable_opd_plan"] = "miniverl_immutable_opd_plan"
+    miniverl_version: str
+    profile: str
+    pinned_verl: dict[str, str]
+    source_config: dict[str, Any]
+    overrides: list[dict[str, Any]]
+    compatibility: list[dict[str, Any]]
+    compatibility_acceptance: dict[str, Any]
+    compiled_plan: dict[str, Any]
+    system_plan: dict[str, Any]
+    resolved_native_config: dict[str, Any]
+    data: dict[str, Any]
+    models: dict[str, Any]
+    tokenizers: dict[str, Any]
+    loss: dict[str, Any]
+    execution_recommendations: dict[str, Any]
+    plan_digest: str
+
+
+def _sha256(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+            size += len(chunk)
+    return digest.hexdigest(), size
+
+
+def _source_identity(source: str | Path) -> tuple[dict[str, Any], Path]:
+    text = str(source)
+    if text == _BUILTIN:
+        resource = files("miniverl").joinpath("resources/qwen3_0_6b_1_7b_opd.yaml")
+        payload = resource.read_bytes()
+        return (
+            {
+                "kind": "packaged_builtin",
+                "locator": _BUILTIN,
+                "path": None,
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "bytes": len(payload),
+            },
+            Path.cwd(),
+        )
+    path = Path(source).resolve()
+    if not path.is_file() or path.is_symlink():
+        raise ConfigError(f"source config is not a regular file: {path}")
+    digest, size = _sha256(path)
+    return (
+        {
+            "kind": "resolved_yaml",
+            "locator": str(source),
+            "path": str(path),
+            "sha256": digest,
+            "bytes": size,
+        },
+        path.parent,
+    )
+
+
+def _revision(identity: str, revision: str | None, *, role: str) -> dict[str, Any]:
+    if revision is None or _COMMIT.fullmatch(revision) is None:
+        raise ConfigError(
+            f"immutable plan requires a 40-hex commit revision for the {role} model",
+            hint=f"resolve {identity} to an immutable Hub commit before planning",
+        )
+    return {"model_id": identity, "revision": revision, "revision_kind": "immutable_commit"}
+
+
+def _resolve_data_paths(native: RunConfig, base: Path) -> None:
+    if not isinstance(native.source, VerlParquetSourceConfig):
+        raise ConfigError("immutable OPD plan requires a verl Parquet source")
+
+    def resolved(values: list[str]) -> list[str]:
+        return [
+            str((path if path.is_absolute() else base / path).resolve())
+            for path in map(Path, values)
+        ]
+
+    native.source.train_files = resolved(native.source.train_files)
+    native.source.val_files = resolved(native.source.val_files)
+
+
+def _data_identity(native: RunConfig) -> dict[str, Any]:
+    assert isinstance(native.source, VerlParquetSourceConfig)
+    manifest = VerlParquetDataset(native.source).inspect()
+    records: list[dict[str, Any]] = []
+    for split, names in (("train", native.source.train_files), ("val", native.source.val_files)):
+        for name in names:
+            path = Path(name)
+            if not path.is_file() or path.is_symlink():
+                raise ConfigError(f"{split} data is not a regular file: {path}")
+            digest, size = _sha256(path)
+            records.append(
+                {"split": split, "path": str(path.resolve()), "sha256": digest, "bytes": size}
+            )
+    return {
+        "manifest": {
+            "rows": manifest.rows,
+            "schema_digest": manifest.schema_digest,
+            "content_digest": manifest.content_digest,
+            "files": list(manifest.files),
+        },
+        "files": records,
+    }
+
+
+def _digest_payload(payload: dict[str, Any]) -> str:
+    normalized = json.loads(json.dumps(payload))
+    normalized.pop("plan_digest", None)
+    run = normalized.get("resolved_native_config", {}).get("run")
+    if isinstance(run, dict):
+        run["execution_plan_digest"] = None
+    return hashlib.sha256(canonical_json(normalized).encode("utf-8")).hexdigest()
+
+
+def build_immutable_opd_plan(
+    compiled: CompiledLocalExecutionPlan,
+    *,
+    source: str | Path,
+    system_plan: OPDSystemPlan | None = None,
+) -> ImmutableOPDPlan:
+    """Scan local inputs and build a deterministic, weight-free execution artifact."""
+    acceptance = compiled.reinterpretation_acceptance
+    if acceptance["required_fields"] and not acceptance["accepted"]:
+        raise ConfigError(
+            "cannot publish an execution plan with unaccepted local reinterpretations",
+            hint="inspect the mappings, then pass --accept-local-reinterpretations",
+        )
+    source_identity, base = _source_identity(source)
+    system = system_plan or build_system_plan(compiled)
+    native = compile_native_run_config(compiled, system_plan=system)
+    _resolve_data_paths(native, base)
+    student = _revision(
+        native.models.student.model_id,
+        native.models.student.revision,
+        role="student",
+    )
+    teacher = _revision(
+        native.models.teacher.model_id,
+        native.models.teacher.revision,
+        role="teacher",
+    )
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "artifact_type": "miniverl_immutable_opd_plan",
+        "miniverl_version": __version__,
+        "profile": compiled.profile,
+        "pinned_verl": compiled.upstream,
+        "source_config": source_identity,
+        "overrides": [item.model_dump(mode="json") for item in compiled.overrides],
+        "compatibility": [item.model_dump(mode="json") for item in compiled.compatibility],
+        "compatibility_acceptance": acceptance,
+        "compiled_plan": compiled.model_dump(mode="json"),
+        "system_plan": system.model_dump(mode="json"),
+        "resolved_native_config": native.model_dump(mode="json"),
+        "data": _data_identity(native),
+        "models": {
+            "student": student,
+            "teacher": teacher,
+            "teacher_adapter": compiled.source.miniverl.teacher_adapter.model_dump(mode="json"),
+        },
+        "tokenizers": {
+            "status": "declared_not_loaded",
+            "student": {"model_id": student["model_id"], "revision": student["revision"]},
+            "teacher": {"model_id": teacher["model_id"], "revision": teacher["revision"]},
+            "structural_identity": None,
+            "behavioral_fingerprint": None,
+        },
+        "loss": system.loss,
+        "execution_recommendations": {
+            "local_execution": system.local_execution,
+            "memory": system.memory,
+            "batching": system.batching,
+            "disk": system.disk,
+            "time_to_first_update": system.time_to_first_update,
+            "evidence_status": "estimated_or_unknown_not_measured",
+        },
+        "plan_digest": "0" * 64,
+    }
+    digest = _digest_payload(payload)
+    payload["plan_digest"] = digest
+    payload["resolved_native_config"]["run"]["execution_plan_digest"] = digest
+    return ImmutableOPDPlan.model_validate(payload)
+
+
+def _verify_version(plan: ImmutableOPDPlan) -> None:
+    def release_line(value: str) -> tuple[str, str]:
+        match = re.match(r"^(\d+)\.(\d+)", value)
+        if match is None:
+            raise ConfigError(f"invalid miniVERL version in execution plan: {value!r}")
+        return match.group(1), match.group(2)
+
+    if release_line(plan.miniverl_version) != release_line(__version__):
+        raise ConfigError(
+            f"execution plan targets miniVERL {plan.miniverl_version}, current is {__version__}",
+            hint="rebuild the plan with this miniVERL minor release",
+        )
+
+
+def _verify_source(identity: dict[str, Any]) -> None:
+    locator = identity.get("locator")
+    if identity.get("kind") == "packaged_builtin":
+        current, _ = _source_identity(str(locator))
+    else:
+        current, _ = _source_identity(Path(str(identity.get("path"))))
+    if current["sha256"] != identity.get("sha256") or current["bytes"] != identity.get("bytes"):
+        raise ConfigError("source config changed after the execution plan was written")
+
+
+def load_and_verify_immutable_opd_plan(path: str | Path) -> tuple[ImmutableOPDPlan, RunConfig]:
+    """Validate artifact, source, data and exact native config before model construction."""
+    target = Path(path)
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+        plan = ImmutableOPDPlan.model_validate(payload)
+    except (OSError, UnicodeError, json.JSONDecodeError, ValidationError) as exc:
+        raise ConfigError(f"cannot read immutable execution plan {target}: {exc}") from exc
+    actual = _digest_payload(plan.model_dump(mode="json"))
+    if actual != plan.plan_digest:
+        raise ConfigError(
+            f"execution plan digest mismatch: recorded {plan.plan_digest}, calculated {actual}",
+            hint="do not edit plan.json; rebuild it from the source config",
+        )
+    _verify_version(plan)
+    if plan.compatibility_acceptance.get(
+        "required_fields"
+    ) and not plan.compatibility_acceptance.get("accepted"):
+        raise ConfigError("execution plan does not accept its required local reinterpretations")
+    _verify_source(plan.source_config)
+    for record in plan.data.get("files", []):
+        data_path = Path(str(record.get("path")))
+        if not data_path.is_file() or data_path.is_symlink():
+            raise ConfigError(f"planned data file changed or disappeared: {data_path}")
+        digest, size = _sha256(data_path)
+        if digest != record.get("sha256") or size != record.get("bytes"):
+            raise ConfigError(f"planned data file changed after planning: {data_path}")
+    try:
+        native = RunConfig.model_validate(plan.resolved_native_config)
+    except ValidationError as exc:
+        raise ConfigError(f"execution plan contains an invalid native config: {exc}") from exc
+    observed_data = _data_identity(native)
+    if observed_data != plan.data:
+        raise ConfigError("planned data schema, rows, or content changed after planning")
+    if native.run.execution_plan_digest != plan.plan_digest:
+        raise ConfigError("native config is not bound to the execution plan digest")
+    return plan, native
+
+
+def write_immutable_opd_plan(path: str | Path, plan: ImmutableOPDPlan) -> None:
+    """Atomically publish a canonical plan artifact."""
+    write_json_atomic(Path(path), plan.model_dump(mode="json"))

--- a/src/miniverl/cache/store.py
+++ b/src/miniverl/cache/store.py
@@ -179,6 +179,7 @@ class TeacherCache:
         temperature: float,
         loss_mode: str,
         score_implementation_version: str | None = None,
+        execution_plan_digest: str | None = None,
         dtype: str = "float32",
         entries_per_shard: int = 32,
         overwrite: bool = False,
@@ -219,6 +220,7 @@ class TeacherCache:
             temperature=temperature,
             loss_mode=loss_mode,
             score_implementation_version=score_implementation_version,
+            execution_plan_digest=execution_plan_digest,
             dtype=dtype,
             entries_per_shard=entries_per_shard,
         )
@@ -271,6 +273,7 @@ class TeacherCache:
         temperature: float,
         loss_mode: str,
         score_implementation_version: str | None = None,
+        execution_plan_digest: str | None = None,
         dtype: str,
     ) -> None:
         """Reject reuse when any objective or teacher identity component changed."""
@@ -280,6 +283,8 @@ class TeacherCache:
                 unverified.append("structural tokenizer identity")
             if teacher_adapter_provenance is not None:
                 unverified.append("teacher adapter provenance")
+            if execution_plan_digest is not None:
+                unverified.append("immutable execution plan identity")
             if unverified:
                 raise StaleCacheError(
                     "schema-v1 teacher cache cannot verify " + " or ".join(unverified),
@@ -303,6 +308,7 @@ class TeacherCache:
             expected["teacher_adapter_provenance"] = (
                 dict(teacher_adapter_provenance) if teacher_adapter_provenance is not None else None
             )
+            expected["execution_plan_digest"] = execution_plan_digest
         mismatches = {
             key: (getattr(self.index, key), value)
             for key, value in expected.items()

--- a/src/miniverl/cli.py
+++ b/src/miniverl/cli.py
@@ -924,6 +924,16 @@ def plan_command(
         "--overrides-file",
         help="Repeatable plain key=value file or JSON argv array.",
     ),
+    accept_local_reinterpretations: bool = typer.Option(
+        False,
+        "--accept-local-reinterpretations",
+        help="Accept the reported acknowledgement-required one-GPU reinterpretations.",
+    ),
+    out: Optional[Path] = typer.Option(
+        None,
+        "--out",
+        help="Atomically write a data-bound immutable execution plan.",
+    ),
     as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
     offline: bool = typer.Option(False, "--offline", help="Do not access the network."),
     probe: bool = typer.Option(
@@ -953,9 +963,20 @@ def plan_command(
             override_files=override_files,
             overrides=overrides,
             trailing_overrides=ctx.args,
+            accept_local_reinterpretations=accept_local_reinterpretations,
         )
         plan = build_system_plan(compiled)
         payload = plan.model_dump(mode="json")
+        artifact = None
+        if out is not None:
+            from miniverl.bridge.opd_plan import (
+                build_immutable_opd_plan,
+                write_immutable_opd_plan,
+            )
+
+            artifact = build_immutable_opd_plan(compiled, source=config, system_plan=plan)
+            write_immutable_opd_plan(out, artifact)
+            payload = artifact.model_dump(mode="json")
     except MiniVerlError as exc:
         _fail(exc)
         return
@@ -979,7 +1000,8 @@ def plan_command(
     for key, value in plan.memory.items():
         console.print(f"    {_esc(key)}: {_esc(value)}")
     console.print("  time to first update: unknown (not measured by plan)")
-    console.print(f"  plan sha256 {_esc(plan.compiled_digest)}")
+    plan_digest = artifact.plan_digest if artifact is not None else plan.compiled_digest
+    console.print(f"  plan sha256 {_esc(plan_digest)}")
     required = plan.reinterpretation_acceptance["required_fields"]
     if required:
         console.print("  high-risk local reinterpretations")
@@ -990,6 +1012,8 @@ def plan_command(
             )
             console.print(f"      {_esc(mapping['reason'])}")
         console.print(f"  acceptance: {_esc(plan.reinterpretation_acceptance['source'])}")
+    if out is not None:
+        console.print(f"  immutable plan: {_esc(out)}")
 
 
 @app.command(
@@ -998,7 +1022,12 @@ def plan_command(
 )
 def verl_run_command(
     ctx: typer.Context,
-    config: str = typer.Option(..., "--config", help="Resolved YAML path or builtin profile."),
+    config: Optional[str] = typer.Option(
+        None, "--config", help="Resolved YAML path or builtin profile."
+    ),
+    plan_path: Optional[Path] = typer.Option(
+        None, "--plan", help="Validated immutable plan.json from `miniverl plan --out`."
+    ),
     profile: str = typer.Option(
         "verl-opd-v0.8-single-gpu-v1", "--profile", help="Pinned compatibility profile."
     ),
@@ -1032,23 +1061,48 @@ def verl_run_command(
             raise ConfigError(
                 f"unsupported OPD profile {profile!r}", hint=f"use --profile {VERL_OPD_V08_PROFILE}"
             )
-        compiled = load_verl_opd_v08_source(
-            config,
-            override_files=override_files,
-            overrides=overrides,
-            trailing_overrides=ctx.args,
-            accept_local_reinterpretations=accept_local_reinterpretations,
-        )
-        acceptance = compiled.reinterpretation_acceptance
-        if acceptance["required_fields"] and not acceptance["accepted"]:
+        if plan_path is not None and config is not None:
+            raise ConfigError("--plan and --config are mutually exclusive")
+        if plan_path is not None and (
+            overrides or override_files or ctx.args or accept_local_reinterpretations
+        ):
             raise ConfigError(
-                "external config has high-risk local reinterpretations that were not accepted",
-                hint=(
-                    "inspect them with miniverl plan, then pass --accept-local-reinterpretations"
-                ),
+                "--plan cannot be combined with config overrides or reinterpretation flags",
+                hint="rebuild the immutable plan with the desired inputs",
             )
-        system_plan = build_system_plan(compiled)
-        native = compile_native_run_config(compiled, system_plan=system_plan)
+        execution_plan_digest: str | None = None
+        if plan_path is not None:
+            from miniverl.bridge.opd_plan import load_and_verify_immutable_opd_plan
+            from miniverl.bridge.opd_v08 import CompiledLocalExecutionPlan
+
+            artifact, native = load_and_verify_immutable_opd_plan(plan_path)
+            compiled = CompiledLocalExecutionPlan.model_validate(artifact.compiled_plan)
+            system_plan = build_system_plan(compiled)
+            if system_plan.model_dump(mode="json") != artifact.system_plan:
+                raise ConfigError(
+                    "immutable plan's system recommendations do not match its compiler input"
+                )
+            execution_plan_digest = artifact.plan_digest
+        else:
+            if config is None:
+                raise ConfigError("one of --config or --plan is required")
+            compiled = load_verl_opd_v08_source(
+                config,
+                override_files=override_files,
+                overrides=overrides,
+                trailing_overrides=ctx.args,
+                accept_local_reinterpretations=accept_local_reinterpretations,
+            )
+            acceptance = compiled.reinterpretation_acceptance
+            if acceptance["required_fields"] and not acceptance["accepted"]:
+                raise ConfigError(
+                    "external config has high-risk local reinterpretations that were not accepted",
+                    hint=(
+                        "inspect them with miniverl plan, then pass --accept-local-reinterpretations"
+                    ),
+                )
+            system_plan = build_system_plan(compiled)
+            native = compile_native_run_config(compiled, system_plan=system_plan)
         from miniverl.config.models import VerlParquetSourceConfig
 
         if not isinstance(native.source, VerlParquetSourceConfig):  # pragma: no cover
@@ -1056,6 +1110,7 @@ def verl_run_command(
         if dry_run:
             payload = {
                 "dry_run": True,
+                "execution_plan_digest": execution_plan_digest,
                 "compatibility": compiled.model_dump(mode="json"),
                 "system_plan": system_plan.model_dump(mode="json"),
                 "resolved_native_config": native.model_dump(mode="json"),
@@ -1103,7 +1158,11 @@ def verl_run_command(
             )
             write_json_atomic(
                 trainer.paths.root / "local-execution-plan.json",
-                system_plan.model_dump(mode="json"),
+                (
+                    artifact.model_dump(mode="json")
+                    if plan_path is not None
+                    else system_plan.model_dump(mode="json")
+                ),
             )
             result = trainer.train()
             paths = trainer.paths
@@ -1175,6 +1234,7 @@ def verl_run_command(
                 ),
                 "runtime_correctness_only": True,
                 "alignment_quality_claim": False,
+                "execution_plan_digest": execution_plan_digest,
             }
             if resume is None:
                 measurements = fresh_measurements
@@ -1203,7 +1263,12 @@ def verl_run_command(
     except (MiniVerlError, ModuleNotFoundError, ValidationError) as exc:
         _fail(exc)
         return
-    payload = {**result.to_dict(), "run_dir": str(paths.root), "measurements": measurements}
+    payload = {
+        **result.to_dict(),
+        "run_dir": str(paths.root),
+        "execution_plan_digest": execution_plan_digest,
+        "measurements": measurements,
+    }
     if as_json:
         _emit_json(payload)
     else:

--- a/src/miniverl/config/models.py
+++ b/src/miniverl/config/models.py
@@ -726,6 +726,7 @@ class RunMeta(_Base):
     deterministic: bool = True
     notes: str = ""
     tags: list[str] = Field(default_factory=list)
+    execution_plan_digest: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")
 
 
 class RunConfig(_Base):
@@ -1124,6 +1125,12 @@ class RunConfig(_Base):
     def to_yaml(self) -> str:
         """Serialize to canonical YAML (enums as their string values)."""
         payload = self.model_dump(mode="json")
+        return yaml.safe_dump(payload, sort_keys=False, allow_unicode=True, width=100)
+
+    def training_identity_yaml(self) -> str:
+        """Serialize training semantics without the orthogonal plan binding."""
+        payload = self.model_dump(mode="json")
+        payload["run"].pop("execution_plan_digest", None)
         return yaml.safe_dump(payload, sort_keys=False, allow_unicode=True, width=100)
 
     def write_yaml(self, path: str | Path) -> Path:

--- a/src/miniverl/schemas/cache.py
+++ b/src/miniverl/schemas/cache.py
@@ -78,6 +78,7 @@ class CacheIndex(BaseModel):
     temperature: float = Field(gt=0.0)
     loss_mode: str
     score_implementation_version: str | None = None
+    execution_plan_digest: str | None = None
     dtype: str = "float32"
     entries_per_shard: int = Field(default=32, ge=1, le=4096)
     entries: dict[str, CacheEntryMeta] = Field(default_factory=dict)

--- a/src/miniverl/training/checkpoint.py
+++ b/src/miniverl/training/checkpoint.py
@@ -63,12 +63,13 @@ class CheckpointState:
     rng: dict[str, Any] = field(default_factory=dict)
     config_digest: str = ""
     resolved_config_digest: str = ""
+    execution_plan_digest: str = ""
     offline_dataset_digest: str = ""
     metrics: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-friendly view."""
-        return {
+        payload = {
             "schema_version": self.schema_version,
             "miniverl_version": self.miniverl_version,
             "global_step": self.global_step,
@@ -97,6 +98,9 @@ class CheckpointState:
             "offline_dataset_digest": self.offline_dataset_digest,
             "metrics": self.metrics,
         }
+        if self.execution_plan_digest:
+            payload["execution_plan_digest"] = self.execution_plan_digest
+        return payload
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> CheckpointState:
@@ -316,6 +320,8 @@ def save_checkpoint(
                 identity=checkpoint_identity,
             ),
         }
+        if state.execution_plan_digest:
+            manifest["execution_plan_digest"] = state.execution_plan_digest
         try:
             manifest_json = json.dumps(manifest, indent=2, sort_keys=True, allow_nan=False) + "\n"
         except (OverflowError, RecursionError, TypeError, ValueError) as exc:

--- a/src/miniverl/training/trainer.py
+++ b/src/miniverl/training/trainer.py
@@ -902,6 +902,7 @@ class OPDTrainer:
             }
         return {
             "miniverl_version": __version__,
+            "execution_plan_digest": config.run.execution_plan_digest,
             "run_id": self.run_id,
             "run_name": config.run.name,
             "created_at": self._started_at,
@@ -1292,6 +1293,7 @@ class OPDTrainer:
                     if self.config.loss.mode is LossMode.VERL_FORWARD_KL_TOPK
                     else "miniverl-native-v1"
                 ),
+                "execution_plan_digest": self.config.run.execution_plan_digest,
                 "dtype": self.config.cache.dtype,
             }
             if (path / "index.json").is_file():
@@ -2890,7 +2892,7 @@ class OPDTrainer:
     # -- checkpointing -----------------------------------------------------------
 
     def _config_digest(self) -> str:
-        return hashlib.sha256(self.config.to_yaml().encode("utf-8")).hexdigest()
+        return hashlib.sha256(self.config.training_identity_yaml().encode("utf-8")).hexdigest()
 
     def _resolved_config_digest(self) -> str:
         if self.paths.config_resolved.is_file():
@@ -2906,6 +2908,7 @@ class OPDTrainer:
             "tokenizer_identity": student.tokenizer_id or student.model_id,
             "tokenizer_revision": student.tokenizer_revision or student.revision,
             "lora": student.lora.model_dump(mode="json"),
+            "execution_plan_digest": self.config.run.execution_plan_digest,
         }
 
     def save_checkpoint(self, *, name: str | None = None) -> Path:
@@ -2948,6 +2951,7 @@ class OPDTrainer:
             scheduler=self.schedule.state_dict(),
             config_digest=self._config_digest(),
             resolved_config_digest=self._resolved_config_digest(),
+            execution_plan_digest=self.config.run.execution_plan_digest or "",
             offline_dataset_digest=self.offline_dataset_digest,
         )
         save_checkpoint(
@@ -2983,6 +2987,12 @@ class OPDTrainer:
 
         validated = validate_checkpoint(directory)
         digest = self._config_digest()
+        expected_plan_digest = self.config.run.execution_plan_digest or ""
+        if validated.state.execution_plan_digest != expected_plan_digest:
+            raise ConfigError(
+                "the checkpoint was written by a different immutable execution plan",
+                hint="resume using the exact plan.json recorded by the original run",
+            )
         if validated.state.config_digest and validated.state.config_digest != digest:
             raise ConfigError(
                 "the checkpoint was written by a different configuration",

--- a/tests/integration/test_checkpoint_integrity.py
+++ b/tests/integration/test_checkpoint_integrity.py
@@ -63,6 +63,17 @@ def test_latest_checkpoint_prefers_final_when_it_is_the_highest_step(tmp_path: P
     assert latest_checkpoint(root) == root / "final"
 
 
+def test_empty_execution_plan_identity_preserves_legacy_checkpoint_shape(tmp_path: Path) -> None:
+    from miniverl.training.checkpoint import validate_checkpoint
+
+    checkpoint = _write_checkpoint(tmp_path / "legacy-compatible", step=2)
+    state = (checkpoint / "state.json").read_text(encoding="utf-8")
+    manifest = (checkpoint / "checkpoint.json").read_text(encoding="utf-8")
+    assert "execution_plan_digest" not in state
+    assert "execution_plan_digest" not in manifest
+    assert validate_checkpoint(checkpoint).state.execution_plan_digest == ""
+
+
 def test_latest_checkpoint_uses_state_step_instead_of_lexicographic_name(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/test_prompt_opd_pipeline.py
+++ b/tests/integration/test_prompt_opd_pipeline.py
@@ -45,6 +45,7 @@ def test_prompt_opd_trains_without_an_environment_or_reward(tmp_path) -> None:
                 "mode": "opd",
                 "seed": 9,
                 "output_dir": str(tmp_path / "runs"),
+                "execution_plan_digest": "a" * 64,
             },
             "models": {
                 "backend": "toy",
@@ -121,7 +122,16 @@ def test_prompt_opd_trains_without_an_environment_or_reward(tmp_path) -> None:
     assert result.policy_version == 1
     manifest = json.loads((result.run_dir / "manifest.json").read_text(encoding="utf-8"))
     assert manifest["source"]["kind"] == "verl_parquet"
+    assert manifest["execution_plan_digest"] == "a" * 64
     assert manifest["source"]["rows"] == {"train": 2, "val": 0}
+    cache_index = json.loads(
+        (result.run_dir / "teacher-cache" / "index.json").read_text(encoding="utf-8")
+    )
+    assert cache_index["execution_plan_digest"] == "a" * 64
+    checkpoint_state = json.loads(
+        (result.run_dir / "checkpoints" / "final" / "state.json").read_text(encoding="utf-8")
+    )
+    assert checkpoint_state["execution_plan_digest"] == "a" * 64
     rows = [
         json.loads(line)
         for line in (result.run_dir / "trajectories.jsonl").read_text(encoding="utf-8").splitlines()

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -67,6 +67,37 @@ def _cache(path: Path, *, dtype: str = "float32", entries_per_shard: int = 2) ->
     )
 
 
+def test_execution_plan_digest_is_persisted_and_required_for_reuse(tmp_path: Path) -> None:
+    cache = TeacherCache.create(
+        tmp_path / "tc-plan",
+        miniverl_version="0.9.0.dev0",
+        teacher_model_id="toy-teacher",
+        teacher_model_revision="rev-abc",
+        tokenizer_fingerprint="fp-1234",
+        vocab_size=VOCAB,
+        top_k=TOP_K,
+        temperature=1.0,
+        loss_mode="bucketed_topk_tail",
+        execution_plan_digest="a" * 64,
+    )
+    reopened = TeacherCache.open(cache.path)
+    common = {
+        "teacher_model_id": "toy-teacher",
+        "teacher_model_revision": "rev-abc",
+        "tokenizer_fingerprint": "fp-1234",
+        "tokenizer_identity": {},
+        "teacher_adapter_provenance": None,
+        "vocab_size": VOCAB,
+        "top_k": TOP_K,
+        "temperature": 1.0,
+        "loss_mode": "bucketed_topk_tail",
+        "dtype": "float32",
+    }
+    reopened.assert_compatible(**common, execution_plan_digest="a" * 64)
+    with pytest.raises(StaleCacheError, match="execution_plan_digest"):
+        reopened.assert_compatible(**common, execution_plan_digest=None)
+
+
 # ----------------------------------------------------------- round trip
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -871,6 +871,14 @@ def test_to_yaml_serializes_enums_as_their_string_values() -> None:
     assert raw["models"]["backend"] == "toy"
 
 
+def test_plan_binding_is_orthogonal_to_the_training_config_identity() -> None:
+    config = RunConfig.from_yaml(RECIPES_DIR / "toy_cpu.yaml")
+    baseline = config.training_identity_yaml()
+    config.run.execution_plan_digest = "a" * 64
+    assert config.training_identity_yaml() == baseline
+    assert "execution_plan_digest" in config.to_yaml()
+
+
 def test_write_yaml_creates_missing_parents_and_can_be_read_back(tmp_path: Path) -> None:
     original = RunConfig.from_yaml(RECIPES_DIR / "toy_cpu.yaml")
     target = tmp_path / "nested" / "deeper" / "config.resolved.yaml"

--- a/tests/unit/test_opd_immutable_plan.py
+++ b/tests/unit/test_opd_immutable_plan.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from miniverl.cli import app
+
+runner = CliRunner()
+
+
+def _external_profile(tmp_path: Path) -> tuple[Path, Path]:
+    pytest.importorskip("pyarrow")
+    data = tmp_path / "prompts.parquet"
+    sampled = runner.invoke(
+        app,
+        ["data", "sample", "--format", "verl-parquet", "--out", str(data)],
+    )
+    assert sampled.exit_code == 0, sampled.output
+
+    from miniverl.bridge.opd_v08 import load_verl_opd_v08_source
+
+    payload = load_verl_opd_v08_source("builtin:qwen3-0.6b-1.7b-opd").source.model_dump(
+        mode="python"
+    )
+    payload["data"]["train_files"] = [str(data)]
+    profile = tmp_path / "opd.yaml"
+    profile.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return profile, data
+
+
+def _write_plan(tmp_path: Path) -> tuple[Path, Path, Path, dict[str, object]]:
+    profile, data = _external_profile(tmp_path)
+    plan = tmp_path / "plan.json"
+    result = runner.invoke(
+        app,
+        [
+            "plan",
+            "--config",
+            str(profile),
+            "--accept-local-reinterpretations",
+            "--out",
+            str(plan),
+            "--offline",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    return plan, profile, data, json.loads(plan.read_text(encoding="utf-8"))
+
+
+def test_plan_out_binds_source_data_models_and_exact_native_config(tmp_path: Path) -> None:
+    plan, profile, data, payload = _write_plan(tmp_path)
+
+    assert payload["schema_version"] == 1
+    assert payload["artifact_type"] == "miniverl_immutable_opd_plan"
+    assert len(payload["plan_digest"]) == 64
+    assert payload["source_config"]["path"] == str(profile.resolve())
+    assert len(payload["source_config"]["sha256"]) == 64
+    assert payload["data"]["manifest"]["rows"]["train"] == 4
+    assert payload["data"]["files"][0]["path"] == str(data.resolve())
+    assert payload["models"]["student"]["revision_kind"] == "immutable_commit"
+    assert payload["models"]["teacher"]["revision_kind"] == "immutable_commit"
+    assert payload["tokenizers"]["status"] == "declared_not_loaded"
+    assert payload["compatibility_acceptance"]["accepted"] is True
+    assert (
+        payload["resolved_native_config"]["run"]["execution_plan_digest"] == payload["plan_digest"]
+    )
+    assert plan.read_bytes().endswith(b"\n")
+
+
+def test_plan_bytes_are_deterministic_for_unchanged_inputs(tmp_path: Path) -> None:
+    first, profile, _, _ = _write_plan(tmp_path)
+    second = tmp_path / "second-plan.json"
+    result = runner.invoke(
+        app,
+        [
+            "plan",
+            "--config",
+            str(profile),
+            "--accept-local-reinterpretations",
+            "--out",
+            str(second),
+            "--offline",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert first.read_bytes() == second.read_bytes()
+
+
+def test_run_from_plan_does_not_recompile_and_rejects_plan_tampering(tmp_path: Path) -> None:
+    plan, _, _, payload = _write_plan(tmp_path)
+    accepted = runner.invoke(
+        app,
+        ["run", "--plan", str(plan), "--dry-run", "--offline", "--json"],
+    )
+    assert accepted.exit_code == 0, accepted.output
+    dry = json.loads(accepted.stdout)
+    assert dry["execution_plan_digest"] == payload["plan_digest"]
+    assert dry["resolved_native_config"] == payload["resolved_native_config"]
+
+    tampered = dict(payload)
+    tampered["system_plan"] = {**tampered["system_plan"], "executable": False}
+    plan.write_text(json.dumps(tampered), encoding="utf-8")
+    refused = runner.invoke(app, ["run", "--plan", str(plan), "--dry-run", "--offline"])
+    assert refused.exit_code == 1
+    assert "plan digest" in refused.output.lower()
+
+
+@pytest.mark.parametrize("target", ["source", "data"])
+def test_run_from_plan_rejects_source_or_data_drift(tmp_path: Path, target: str) -> None:
+    plan, profile, data, _ = _write_plan(tmp_path)
+    if target == "source":
+        profile.write_bytes(profile.read_bytes() + b"\n# changed\n")
+    else:
+        data.write_bytes(data.read_bytes() + b"changed")
+
+    refused = runner.invoke(app, ["run", "--plan", str(plan), "--dry-run", "--offline"])
+    assert refused.exit_code == 1
+    assert target in refused.output.lower()
+    assert "changed" in refused.output.lower()
+
+
+def test_run_plan_is_mutually_exclusive_with_config_and_overrides(tmp_path: Path) -> None:
+    plan, profile, _, _ = _write_plan(tmp_path)
+    refused = runner.invoke(
+        app,
+        ["run", "--plan", str(plan), "--config", str(profile), "--dry-run"],
+    )
+    assert refused.exit_code == 1
+    assert "mutually exclusive" in refused.output.lower()
+
+    refused = runner.invoke(
+        app,
+        ["run", "--plan", str(plan), "--set", "trainer.total_training_steps=3", "--dry-run"],
+    )
+    assert refused.exit_code == 1
+    assert "override" in refused.output.lower()
+
+
+def test_external_plan_requires_acceptance_before_publication(tmp_path: Path) -> None:
+    profile, _ = _external_profile(tmp_path)
+    target = tmp_path / "refused.json"
+    refused = runner.invoke(
+        app,
+        ["plan", "--config", str(profile), "--out", str(target), "--offline"],
+    )
+    assert refused.exit_code == 1
+    assert "--accept-local-reinterpretations" in refused.output
+    assert not target.exists()


### PR DESCRIPTION
﻿## Summary

- add deterministic `miniverl plan --out plan.json` artifacts binding source YAML bytes, ordered overrides, accepted compatibility mappings, immutable model revisions, scanned Parquet hashes/schema/rows, exact native config and weight-free recommendations
- add `miniverl run --plan plan.json`, which validates plan integrity, version compatibility, source/data bytes and the sealed native config before model construction without recompiling defaults
- propagate the plan digest through run manifests, teacher-cache identity and checkpoints while preserving legacy checkpoint digest compatibility when no plan is present

## Validation

- non-GPU/non-network: 2,196 passed, 9 skipped, 21 deselected; 85.01% branch coverage
- RTX 4080 GPU: 8 passed
- network: 13 passed, 2 environment-dependent skips
- focused plan/cache/checkpoint/config/runtime: 211 passed
- Ruff check/format, mypy, actionlint, strict MkDocs, text/link/release-state/generated-description gates passed
- Playwright: 40 rendered SVG instances across 1440/1024/820/390 px
- wheel and sdist passed build/Twine
- dev wheel SHA-256: `ddafdd5275e5b77b38a58ec700cce4c20f86a06e5b3c8de0aaac373c998d181d`
- dev sdist SHA-256: `28effafac6da0ccf4bb62f72567a664ae60daae0aa2d89534f4ef30afeeb8e6f`
- frozen calculator SHA-256 remains `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`

This remains one-GPU pure forward-top-k GKD. It does not add a scientific comparison or claim distributed verl execution.
