### PR TITLE
Materialize launchable verl OPD bundles

### DIFF
--- a/.github/workflows/verl-bridge.yml
+++ b/.github/workflows/verl-bridge.yml
@@ -47,7 +47,7 @@ jobs:
           changed=$(git diff --name-only "origin/$BASE_REF"...HEAD)
           echo "changed files:"
           echo "$changed"
-          if echo "$changed" | grep -Eq '^(\.github/workflows/verl-bridge\.yml|pyproject\.toml|scripts/[^/]*verl_bridge[^/]*|src/miniverl/bridge/.*|src/miniverl/losses/verl_topk\.py|tests/.*verl_bridge.*|tests/conformance/test_verl_v08_loss\.py)$'; then
+          if echo "$changed" | grep -Eq '^(\.github/workflows/verl-bridge\.yml|pyproject\.toml|scripts/[^/]*verl_bridge[^/]*|src/miniverl/bridge/.*|src/miniverl/losses/verl_topk\.py|tests/.*verl_(bridge|opd).*|tests/conformance/test_verl_v08_loss\.py)$'; then
             echo "bridge=true" >> "$GITHUB_OUTPUT"
           else
             echo "bridge=false" >> "$GITHUB_OUTPUT"
@@ -75,6 +75,10 @@ jobs:
           "git+https://github.com/verl-project/verl.git@7aed6b230776f963fa09509c10d9c3a767d1102c"
       - name: Compare forward_kl_topk values, diagnostics and gradients
         run: python -m pytest -q tests/conformance/test_verl_v08_loss.py -m verl_conformance
+      - name: Materialize and recheck a tiny launchable pure-OPD bundle
+        run: >-
+          python -m pytest -q tests/conformance/test_verl_v08_materialize.py
+          -m verl_conformance
       - name: Generate and export the standards smoke bundle
         run: |
           python scripts/prepare_verl_bridge_smoke.py --out _verl-smoke-source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ All notable changes to miniVERL are recorded here. The format follows
   tiny rollout/teacher-score/selected-position-backward phases, exact cache
   identity, zero optimizer updates and post-release CUDA-memory verification.
 
+### Transactional scale-out materialization
+
+- Added `miniverl bridge materialize` for exact local or downloaded student and
+  teacher snapshots. It rejects moving revisions and unsafe trees, validates
+  model/tokenizer/PEFT/Parquet/top-k inputs under the pinned verl commit, hashes
+  every copied or merged file, and publishes through a rollback-safe staged
+  directory replacement.
+- New pure-OPD exports correctly keep both base-model loadability flags false.
+  `launch.sh` replaces the fail-closed template only after the pinned upstream
+  config merge and bounded sequential model-load smoke pass; distributed
+  execution remains explicitly untested.
+- Teacher-adapter merging requires an explicit flag, never mutates the source
+  base, and records base, adapter, software, output and licensing provenance.
+
 ### Verl config UX
 
 - Added safe trailing Hydra-style overrides and repeatable plain/JSON

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -43,6 +43,17 @@ Probe caches bind hardware/software, model, tokenizer, quantization, token and
 plan identities; cached and fresh publication of the same measurement produces
 byte-identical immutable plans.
 
+The scale-out slice adds transactional `bridge materialize`. A fresh export
+continues to carry identity-only bases and remains non-launchable. Materialize
+accepts exact regular-file snapshots or resolves the recorded 40-character
+commits through download/cache mode, validates shard closure, tokenizer and
+model loads, student PEFT, Parquet, top-k and the exact installed verl config,
+then publishes `launch.sh` and full file hashes through a staged directory
+swap. Teacher-adapter merging is an explicit, non-mutating operation with base,
+adapter, software and output provenance. `launchable: true` means only that the
+pinned upstream entry point has complete local inputs; distributed execution
+remains `false` and algorithm parity remains unclaimed.
+
 ## v0.8.1 product surface
 
 The landing pages now lead with the documented one-GPU verl-style OPD journey,

--- a/PYPI.md
+++ b/PYPI.md
@@ -189,15 +189,16 @@ checkpoints, measurements and a PEFT adapter. Inspect before moving it:
 miniverl inspect runs/my-opd/trajectories.jsonl
 miniverl cache stats runs/my-opd/teacher-cache
 miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout
+miniverl bridge materialize scaleout --download --offline
 miniverl bridge doctor scaleout --json
 ```
 
 The v0.8.1 export preserves student/teacher identities, Parquet bytes and pure
 OPD overrides, but reports `launchable: false` until exact base snapshots are
-materialized. Artifact completeness, upstream parse/load smoke, launchability,
-algorithm semantics and distributed execution are separate statuses. A
-successful bridge check never means that a distributed verl job ran. Review
-the [bridge contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md) and [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md).
+materialized and validated against the installed pinned verl commit. Only then
+does `bridge materialize` publish a checksummed `launch.sh`; distributed
+execution remains untested. Review the [materialization contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/scaleout-materialization.md),
+[bridge contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md) and [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md).
 
 The intended operating loop is **plan → inspect → run → inspect → export**.
 `plan --out` byte-binds the YAML, ordered overrides and scanned Parquet inputs

--- a/README.md
+++ b/README.md
@@ -189,15 +189,16 @@ checkpoints, measurements and a PEFT adapter. Inspect before moving it:
 miniverl inspect runs/my-opd/trajectories.jsonl
 miniverl cache stats runs/my-opd/teacher-cache
 miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout
+miniverl bridge materialize scaleout --download --offline
 miniverl bridge doctor scaleout --json
 ```
 
 The v0.8.1 export preserves student/teacher identities, Parquet bytes and pure
 OPD overrides, but reports `launchable: false` until exact base snapshots are
-materialized. Artifact completeness, upstream parse/load smoke, launchability,
-algorithm semantics and distributed execution are separate statuses. A
-successful bridge check never means that a distributed verl job ran. Review
-the [bridge contract](docs/verl-bridge.md) and [compatibility policy](docs/compatibility.md).
+materialized and validated against the installed pinned verl commit. Only then
+does `bridge materialize` publish a checksummed `launch.sh`; distributed
+execution remains untested. Review the [materialization contract](docs/scaleout-materialization.md),
+[bridge contract](docs/verl-bridge.md) and [compatibility policy](docs/compatibility.md).
 
 The intended operating loop is **plan → inspect → run → inspect → export**.
 `plan --out` byte-binds the YAML, ordered overrides and scanned Parquet inputs

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -158,13 +158,15 @@ prompt 的 role/content 保持结构化，data source、ability 与 extra metada
 miniverl inspect runs/my-opd/trajectories.jsonl
 miniverl cache stats runs/my-opd/teacher-cache
 miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout
+miniverl bridge materialize scaleout --download --offline
 miniverl bridge doctor scaleout --json
 ```
 
-v0.8.1 export 保留 student/teacher 身份、Parquet 原始字节与纯 OPD override；精确 base
-snapshot materialize 之前仍报告 `launchable: false`。产物完整性、上游 parse/load smoke、
-launchability、算法语义与 distributed execution 分开报告。bridge doctor 通过并不表示运行过
-分布式 verl。详见[桥接契约](docs/verl-bridge.md)与[兼容性政策](docs/compatibility.md)。
+v0.8.1 export 保留 student/teacher 身份、Parquet 原始字节与纯 OPD override；在精确 base
+snapshot 被物化并通过已安装的固定 verl commit 验证前，仍报告 `launchable: false`。只有此后
+`bridge materialize` 才会发布带校验和的 `launch.sh`；分布式执行仍是未测试。详见
+[物化契约](docs/scaleout-materialization.md)、[桥接契约](docs/verl-bridge.md)与
+[兼容性政策](docs/compatibility.md)。
 
 建议操作闭环是 **plan → inspect → run → inspect → export**。`plan --out` 把 YAML、按顺序
 应用的 override、扫描后的 Parquet 与精确 native config 绑定；`run --plan` 在加载权重前拒绝

--- a/docs/for-verl-users.md
+++ b/docs/for-verl-users.md
@@ -99,11 +99,13 @@ identities never collapse in provenance.
 
 ```bash
 miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout
+miniverl bridge materialize scaleout --download --offline
 miniverl bridge doctor scaleout --json
 ```
 
 The v0.8.1 bundle carries PEFT, Parquet, config and provenance artifacts, but is
-reported as `launchable: false` until exact base snapshots are materialized.
+reported as `launchable: false` until exact base snapshots are materialized and
+the pinned upstream checks pass. Read the [materialization workflow](scaleout-materialization.md).
 Upstream parse/load smoke, artifact completeness, launchability and distributed
 execution are separate statuses. miniVERL never reports a distributed job as
 tested.
@@ -126,8 +128,8 @@ tested.
   for the shared token space; a legacy behavioral fingerprint is not proof.
 - **CUDA out of memory:** reduce context, response length or physical batches;
   keep logical update semantics unchanged. See [single-GPU planning](single-gpu-guide.md).
-- **Bundle not launchable:** this is expected before exact model snapshots are
-  present. Read the [bridge boundary](verl-bridge.md).
+- **Bundle not launchable:** materialize exact snapshots and install the pinned
+  verl commit; inspect the reported blocker. Read [scale-out materialization](scaleout-materialization.md).
 
 Next: follow the [OPD quickstart](opd-quickstart.md), inspect the
 [compatibility policy](compatibility.md), or review [all limitations](limitations.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,8 @@ FSDP, Megatron, PPO, GRPO and distributed launch are outside the runtime.
 The executable profile pins verl `v0.8.0` at `7aed6b23`: one actor, one teacher,
 `n=1`, GKD `forward_kl_topk`, token-mean and no reward/KL penalty. Unsupported
 algorithm or distributed semantics fail closed. Exports remain unlaunchable
-until exact base snapshots are materialized.
+until exact base snapshots are materialized and checked under the pinned verl
+commit. See [scale-out materialization](scaleout-materialization.md).
 
 ## Measured runtime evidence
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -452,9 +452,11 @@ job. It does not convert optimizer state, distributed RNG, native sharded
 checkpoints, Ray runtime state or teacher caches into PPO reference caches.
 Unknown and distributed-only config fields fail by default. The
 miniVERL-defined label therefore means a validated scale-out bundle, not
-runtime parity or generic verl YAML support. Current bundles are not
-launchable: the base snapshot is absent, reward logic fails closed and user
-mappings remain placeholders. See the [exact contract and evidence](verl-bridge.md).
+runtime parity or generic verl YAML support. Legacy PPO/reward-scaffold bundles
+remain non-launchable. A pure-OPD bundle can become `launchable: true` only
+after exact snapshots, the fixed upstream config merge and bounded local model
+loads pass; that status still does not say a distributed invocation succeeded.
+See the [exact contract](verl-bridge.md) and [materialization workflow](scaleout-materialization.md).
 
 `models.teacher.mode: privileged_context` works only with environments that
 implement `privileged_context()`. All three built-in environments do;

--- a/docs/opd-quickstart.md
+++ b/docs/opd-quickstart.md
@@ -54,6 +54,7 @@ miniverl import-verl --profile verl-opd-v0.8-single-gpu-v1 \
 miniverl run --profile verl-opd-v0.8-single-gpu-v1 \
   --config local-opd.yaml --output runs
 miniverl export-verl --run runs/<run-id> --target-verl v0.8.0 --out scaleout
+miniverl bridge materialize scaleout --download --offline
 miniverl bridge doctor scaleout --require-verl
 ```
 
@@ -66,4 +67,6 @@ Validation data is exported only when the source declared it; an empty
 The bundle stays `launchable: false` until the exact student and teacher base
 snapshots are materialized. A local teacher adapter adds an explicit merge
 requirement because the pinned upstream profile does not consume that adapter
-path directly. The bridge never claims a distributed verl job ran.
+path directly. Materialization requires the exact installed verl pin and emits
+`launch.sh` only after model/tokenizer/data/config checks pass. The bridge never
+claims a distributed verl job ran. See the [materialization contract](scaleout-materialization.md).

--- a/docs/scaleout-materialization.md
+++ b/docs/scaleout-materialization.md
@@ -1,0 +1,106 @@
+# Materialize a pinned verl handoff
+
+`export-verl` intentionally starts with identity-only student and teacher base
+models. Its PEFT adapter, Parquet data, pure-OPD override and provenance are
+complete, but `launchable` remains `false` until the exact model snapshots and
+the pinned upstream validation are present.
+
+## Offline-first workflow
+
+The simplest offline path copies the two exact commits from the Hugging Face
+cache into a regular-file staging tree:
+
+```bash
+miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout
+miniverl bridge materialize scaleout --download --offline
+```
+
+Hugging Face cache snapshots commonly contain symlinks. The materializer will
+not follow them from an explicitly supplied directory; download mode resolves
+cached bytes into regular staging files without network access.
+
+For a separately copied regular-file snapshot, pass both directories. Each
+path must either end in `snapshots/<40-character-commit>` or carry a
+`miniverl-snapshot.json` binding the recorded model id, revision and file
+hashes:
+
+```bash
+miniverl bridge materialize scaleout \
+  --student-snapshot /snapshots/c1899de289a04d12100db370d81485cdf75e47ca \
+  --teacher-snapshot /snapshots/70d244cc86ccca08cf5af4e1e306ecf908b1ad5e \
+  --offline
+```
+
+Remove `--offline` only when downloading the two exact recorded commits is
+intended. A branch name such as `main` or a tag is never accepted as the bundle
+identity.
+
+The command also requires official verl `v0.8.0` installed from pinned commit
+`7aed6b230776f963fa09509c10d9c3a767d1102c`. It merges the exported override
+into that exact configuration, validates Parquet and PEFT payloads, loads both
+local model/tokenizer snapshots sequentially, runs a tiny CPU forward for each
+role and verifies the top-k/tokenizer contract. It launches no Ray worker and
+performs no distributed training.
+
+## What is published
+
+Materialization stages a complete copy beside the bundle. Snapshot files must
+be regular files; model shard indexes must be closed; configs, tokenizer
+vocabularies and safetensors structure must validate. Every copied or merged
+file is SHA-256 bound in
+`provenance/materialization-manifest.json`, then the bundle-wide
+`provenance/SHA256SUMS` is regenerated. Only after all checks pass is the old
+directory replaced.
+
+Before success:
+
+```text
+recipe/launch.template.sh
+launchable: false
+```
+
+After success:
+
+```text
+recipe/verl-opd-resolved.yaml
+recipe/launch.sh
+launchable: true
+distributed_execution_tested: false
+```
+
+Here `launchable: true` means the pinned config and local artifacts are
+complete enough to invoke the documented upstream entry point. It is not a
+claim that the invocation, a distributed job or miniVERL-to-verl end-to-end
+algorithm parity was tested. Recheck the bytes and installed pin in the
+current process before use:
+
+```bash
+miniverl bridge doctor scaleout \
+  --require-verl --require-tokenizer-load --require-adapter-payload
+```
+
+## Teacher adapters
+
+If the local run used a teacher adapter that pinned verl cannot consume in the
+recorded role, export includes its standard PEFT payload when available and
+materialization remains blocked. Merging requires explicit consent:
+
+```bash
+miniverl bridge materialize scaleout --download \
+  --merge-teacher-adapter
+```
+
+The original base is never modified. The merged output is written to a new
+teacher snapshot, then reloaded and hashed. Provenance records the base and
+adapter identities and hashes, merge software versions, output hashes, and
+copied license/notice files. A missing adapter payload or identity mismatch
+fails before publication.
+
+## Failure and recovery
+
+Copy, merge, validation and provenance writes happen in a sibling staging
+directory. An ordinary exception leaves the existing bundle unchanged and
+removes staging files. Final publication uses a same-filesystem directory
+rename with in-process rollback. As with any multi-rename update, a power loss
+at the final swap is not a cross-platform filesystem transaction; preserve the
+source run and exported bundle until the materialized copy is verified.

--- a/docs/verl-bridge-launch.md
+++ b/docs/verl-bridge-launch.md
@@ -1,5 +1,12 @@
 # From one GPU to a verified scale-out handoff
 
+!!! note "Historical v0.6 article"
+
+    This page preserves the original bridge launch announcement. The current
+    pure-OPD profile can now publish `launch.sh` after the exact checks in
+    [scale-out materialization](scaleout-materialization.md); the legacy
+    PPO/reward scaffold described below remains non-launchable.
+
 miniVERL v0.6 adds a narrow, tested bridge to official verl `v0.8.0`. The goal
 is not to imitate a distributed runtime on a laptop. It is to make the boundary
 between local scientific diagnosis and later scale-out explicit, standard and

--- a/docs/verl-bridge.md
+++ b/docs/verl-bridge.md
@@ -21,13 +21,13 @@ claimed.
 
 | State | Current value | Meaning |
 | --- | --- | --- |
-| `artifact_complete` | `true` | Required PEFT, Parquet, config, identity and provenance files are present and hashed. |
+| `artifact_complete` | `false` in a new bundle | Exact student and teacher base snapshots are still required. |
 | `config_semantics_supported` | `true` for a compatible OPD run | The source is the bounded pure-GKD profile, not a PPO reinterpretation. |
-| `student_artifact_loadable` | separate check | Standard PEFT structure and payload are checked independently. |
+| `student_artifact_loadable` | `false` in a new bundle | PEFT is present, but the exact base snapshot is not yet bundled. |
 | `teacher_artifact_loadable` | `false` in a new bundle | Teacher identity is preserved; the exact snapshot is not bundled. |
 | `dataset_loadable` | separate check | Every exported Parquet footer and required column is checked. |
 | `upstream_parse_passed` | `false` in a new bundle | Set only when doctor recomputes a merge under the exact installed pin. |
-| `upstream_tiny_smoke_passed` | `false` | No model execution occurs during export or doctor. |
+| `upstream_tiny_smoke_passed` | `false` in a new bundle | Materialization performs the bounded local model/tokenizer smoke. |
 | `launchable` | `false` | Exact student/teacher snapshots are not materialized in the bundle. |
 | `distributed_execution_tested` | `false` | No distributed job ran. |
 | `algorithm_semantic_parity` | `false` | Conformance is scoped to documented config/loss behavior, not an end-to-end distributed algorithm. |
@@ -184,6 +184,7 @@ miniverl export-verl --run runs/<run-id> \
   --target-verl v0.8.0 \
   --out exports/<bundle>
 
+miniverl bridge materialize exports/<bundle> --download --offline
 miniverl bridge doctor exports/<bundle> --require-verl
 ```
 
@@ -206,11 +207,18 @@ OPD has no reward scaffold. A same-base teacher adapter is recorded but blocks
 launch until it is explicitly merged/materialized as a teacher snapshot that
 the pinned upstream can consume.
 
+`bridge materialize` resolves the two immutable model commits, copies only a
+preflighted regular-file tree, validates model/tokenizer/PEFT/data inputs under
+the exact installed verl pin and transactionally publishes a checksummed
+`launch.sh`. See [materialization](scaleout-materialization.md).
+
 `bridge doctor` verifies pins, adapter structure, tokenizer state, Parquet
 schema, pure-OPD override structure, privacy scopes and hashes. An `ok` verdict
 means those local artifact checks passed; it does not mean launchable or
 distributed-tested. `launch.template.sh` refuses to proceed without both exact
-base snapshots and never emits an unverified distributed launch command.
+base snapshots and never emits an unverified distributed launch command. On a
+materialized bundle, `doctor --require-verl` recomputes launchability in the
+current process; it does not merely trust the bundle's compatibility report.
 
 Historical `single-gpu-online-distillation-v1` runs continue to export the
 legacy PPO/reward scaffold for compatibility. That output remains explicitly

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - RecoveryBench: recoverybench/recoverybench-v1.md
   - Scale out:
       - verl bridge boundary: verl-bridge.md
+      - Materialize a handoff: scaleout-materialization.md
       - Launch requirements: verl-bridge-launch.md
       - Demo recording script: verl-bridge-demo.md
   - Community benchmarks: community-benchmarks.md

--- a/scripts/check_docs_visual.py
+++ b/scripts/check_docs_visual.py
@@ -35,6 +35,7 @@ PAGES = (
     "/config-overrides/",
     "/immutable-plans/",
     "/hardware-planning/",
+    "/scaleout-materialization/",
     "/alignment-lab/alignment-lab-v1/",
     "/alignment-external/alignment-external-v1/",
     "/consumer-runtime/",

--- a/src/miniverl/bridge/doctor.py
+++ b/src/miniverl/bridge/doctor.py
@@ -154,6 +154,39 @@ def _check_model(root: Path, *, require_payload: bool = False) -> dict[str, Any]
     }
 
 
+def _check_materialized_snapshot(root: Path, *, role: str) -> dict[str, Any]:
+    """Structurally recheck one materialized model snapshot without loading weights."""
+    relative = "model/base" if role == "student" else "teacher/base"
+    snapshot = root / relative
+    if not snapshot.is_dir():
+        return {
+            "status": "not_present",
+            "role": role,
+            "path": relative,
+            "scope": "no materialized snapshot was present",
+        }
+    try:
+        # Kept local to avoid making model-materialization dependencies part of
+        # the ordinary bridge-doctor import path.
+        from miniverl.bridge.materialize import _validate_snapshot_payload
+
+        validation = _validate_snapshot_payload(snapshot, role=role)
+    except Exception as exc:
+        return {
+            "status": "fail",
+            "role": role,
+            "path": relative,
+            "detail": f"{type(exc).__name__}: {exc}",
+        }
+    return {
+        "status": "ok",
+        "role": role,
+        "path": relative,
+        "validation": validation,
+        "scope": "config, tokenizer files, model shard closure and safetensors structure",
+    }
+
+
 def _reference_tokenizer_identity(root: Path) -> dict[str, Any]:
     """Tokenizer identity recorded by the source run, if the bundle carries one."""
     try:
@@ -1169,6 +1202,8 @@ def inspect_bridge_bundle(
         return _preflight_refusal(tree)
     target = _check_requirements(bundle)
     model = _check_model(bundle, require_payload=require_adapter_payload)
+    student_snapshot = _check_materialized_snapshot(bundle, role="student")
+    teacher_snapshot = _check_materialized_snapshot(bundle, role="teacher")
     tokenizer = _check_tokenizer(bundle, require_load=require_tokenizer_load)
     parquet = _check_parquet(bundle)
     config = _check_config(bundle)
@@ -1188,8 +1223,16 @@ def inspect_bridge_bundle(
         compatibility = json.loads(compatibility_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         compatibility = {}
-    checks = (target, model, tokenizer, parquet, config, reward, hashes, privacy)
+    snapshot_required = (
+        bool(compatibility.get("launchable")) or (bundle / "recipe/launch.sh").is_file()
+    )
+    snapshot_checks = (student_snapshot, teacher_snapshot) if snapshot_required else ()
+    checks = (target, model, tokenizer, parquet, config, reward, hashes, privacy, *snapshot_checks)
     artifact_failed = any(check.get("status") != "ok" for check in checks)
+    opd_profile = config.get("profile") == "verl-opd-v0.8-single-gpu-v1"
+    materialized_complete = not opd_profile or (
+        student_snapshot.get("status") == "ok" and teacher_snapshot.get("status") == "ok"
+    )
     upstream = _recompute_upstream_smoke(bundle, installed, enabled=require_verl)
     pinned_verl_failed = require_verl and (
         installed.get("status") != "ok" or upstream["status"] != "passed"
@@ -1213,6 +1256,8 @@ def inspect_bridge_bundle(
         "target_verl": target,
         "installed_verl": installed,
         "model_adapter_loadability": model,
+        "student_snapshot_loadability": student_snapshot,
+        "teacher_snapshot_loadability": teacher_snapshot,
         "safetensors_verification_level": model.get(
             "safetensors_verification_level", "not_present"
         ),
@@ -1232,7 +1277,7 @@ def inspect_bridge_bundle(
         "artifact_hashes": hashes,
         "privacy": privacy,
         "local_smoke_status": local_smoke,
-        "artifact_complete": not artifact_failed,
+        "artifact_complete": not artifact_failed and materialized_complete,
         "artifact_bundle_complete": not artifact_failed,
         "bundle_declared_claims": declared,
         "locally_recomputed_checks": recomputed,
@@ -1243,17 +1288,25 @@ def inspect_bridge_bundle(
         "upstream_config_parse_passed": upstream["status"] == "passed",
         "upstream_parse_passed": upstream["status"] == "passed",
         "upstream_tiny_smoke_passed": False,
-        "model_data_load_smoke_passed": config.get("profile") != "verl-opd-v0.8-single-gpu-v1"
-        and upstream["status"] == "passed"
+        "model_data_load_smoke_passed": upstream["status"] == "passed"
         and not artifact_failed
+        and materialized_complete
         and require_verl,
         "config_semantics_supported": config.get("status") == "ok",
-        "student_artifact_loadable": model.get("status") == "ok",
-        "teacher_artifact_loadable": False,
+        "student_artifact_loadable": model.get("status") == "ok"
+        and student_snapshot.get("status") == "ok",
+        "teacher_artifact_loadable": teacher_snapshot.get("status") == "ok",
         "dataset_loadable": parquet.get("status") == "ok",
         "reward_implementation_complete": bool(reward.get("implementation_complete", False)),
         "reward_required": config.get("profile") != "verl-opd-v0.8-single-gpu-v1",
-        "launchable": False,
+        "launchable": bool(
+            require_verl
+            and upstream["status"] == "passed"
+            and not artifact_failed
+            and student_snapshot.get("status") == "ok"
+            and teacher_snapshot.get("status") == "ok"
+            and (bundle / "recipe/launch.sh").is_file()
+        ),
         "distributed_execution_tested": False,
         "algorithm_semantic_parity": False,
         "distributed_execution_status": "not tested",

--- a/src/miniverl/bridge/export.py
+++ b/src/miniverl/bridge/export.py
@@ -85,6 +85,9 @@ def _copy_model(source: Path, destination: Path) -> None:
     destination.mkdir(parents=True)
     for name in _MODEL_REQUIRED:
         shutil.copy2(source / name, destination / name)
+    for path in sorted(source.iterdir()):
+        if path.is_file() and path.name.upper().startswith(("LICENSE", "NOTICE", "COPYING")):
+            shutil.copy2(path, destination / path.name)
     copied_tokenizer = False
     for name in _TOKENIZER_FILES:
         path = source / name
@@ -96,6 +99,15 @@ def _copy_model(source: Path, destination: Path) -> None:
             f"standard adapter directory {source} has no tokenizer metadata",
             hint="copy tokenizer_config.json and the tokenizer vocabulary/snapshot metadata",
         )
+
+
+def _copy_adapter_payload(source: Path, destination: Path) -> None:
+    """Copy only the standard adapter payload needed for an explicit merge."""
+    if not source.is_dir() or not all((source / name).is_file() for name in _MODEL_REQUIRED):
+        raise ConfigError(f"teacher adapter directory is incomplete: {source}")
+    destination.mkdir(parents=True)
+    for name in _MODEL_REQUIRED:
+        shutil.copy2(source / name, destination / name)
 
 
 def _adapter_contract(source: Path) -> dict[str, Any]:
@@ -455,6 +467,14 @@ def _resolve_source_file(run: Path, raw: str) -> Path:
     raise ConfigError(f"source-run Parquet file is unavailable: {raw}")
 
 
+def _resolve_source_directory(run: Path, raw: str) -> Path | None:
+    candidate = Path(raw)
+    for path in (candidate, run / candidate, run.parent / candidate):
+        if path.is_dir():
+            return path
+    return None
+
+
 def _copy_opd_data(
     run: Path, source: dict[str, Any], destination: Path
 ) -> tuple[dict[str, list[str]], dict[str, Any]]:
@@ -575,12 +595,21 @@ def _export_opd_bundle(
         raise ConfigError("compiled OPD source has no pinned teacher identity")
     teacher_adapter_path = _get(source, "miniverl.teacher_adapter.path")
     teacher_adapter_revision = _get(source, "miniverl.teacher_adapter.revision")
+    teacher_adapter_source = (
+        _resolve_source_directory(run, teacher_adapter_path)
+        if isinstance(teacher_adapter_path, str)
+        else None
+    )
     teacher = {
         "model_id": teacher_id,
         "revision": teacher_revision,
         "materialized_path": "teacher/base",
         "status": "identity only; exact snapshot is not bundled",
-        "adapter": {"path": teacher_adapter_path, "revision": teacher_adapter_revision},
+        "adapter": {
+            "path": teacher_adapter_path,
+            "revision": teacher_adapter_revision,
+            "bundled_path": "teacher/adapter" if teacher_adapter_source is not None else None,
+        },
         "upstream_materialization_required": teacher_adapter_path is not None,
     }
     blockers = [
@@ -608,6 +637,8 @@ def _export_opd_bundle(
         teacher_dir = temporary / "teacher"
         teacher_dir.mkdir()
         write_json(teacher_dir / "teacher-model.json", teacher)
+        if teacher_adapter_path is not None and teacher_adapter_source is not None:
+            _copy_adapter_payload(teacher_adapter_source, teacher_dir / "adapter")
         data_paths, data_evidence = _copy_opd_data(run, source, temporary / "data")
         overrides = _opd_overrides(source, adapter, data_paths)
         recipe = temporary / "recipe"
@@ -639,10 +670,10 @@ def _export_opd_bundle(
             },
             "miniverl_version": __version__,
             "target_semantics": "pure GKD forward_kl_topk OPD",
-            "artifact_complete": True,
+            "artifact_complete": False,
             "artifact_bundle_complete": True,
             "config_semantics_supported": True,
-            "student_artifact_loadable": True,
+            "student_artifact_loadable": False,
             "teacher_artifact_loadable": False,
             "dataset_loadable": True,
             "upstream_parse_passed": False,

--- a/src/miniverl/bridge/materialize.py
+++ b/src/miniverl/bridge/materialize.py
@@ -1,0 +1,751 @@
+"""Transactional materialization of a pure-OPD scale-out bundle.
+
+The exporter deliberately publishes identity-only base-model records.  This
+module turns those records into byte-bound local snapshots, validates the
+documented pinned verl handoff without launching distributed execution, and
+only then replaces the fail-closed launch template with ``launch.sh``.
+"""
+
+from __future__ import annotations
+
+import gc
+import hashlib
+import importlib.metadata
+import json
+import shutil
+import uuid
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from miniverl import __version__
+from miniverl.bridge.contract import VERL_COMMIT
+from miniverl.bridge.preflight import preflight_bundle_tree
+from miniverl.bridge.safetensors_check import inspect_safetensors
+from miniverl.errors import ConfigError
+from miniverl.utils.runs import read_json, write_json, write_text
+
+__all__ = ["materialize_verl_bundle"]
+
+_REVISION_LENGTH = 40
+_MAX_SNAPSHOT_FILES = 100_000
+_MAX_SNAPSHOT_BYTES = 16 * 1024 * 1024 * 1024
+_IGNORED_TOP_LEVEL = {".cache", ".git"}
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _immutable_revision(value: Any, *, role: str) -> str:
+    revision = str(value or "")
+    if len(revision) != _REVISION_LENGTH or any(
+        char not in "0123456789abcdef" for char in revision
+    ):
+        raise ConfigError(
+            f"{role} identity does not use an immutable 40-character revision",
+            hint="export again from a run pinned to an exact model commit",
+        )
+    return revision
+
+
+def _snapshot_manifest(path: Path) -> dict[str, Any]:
+    manifest = path / "miniverl-snapshot.json"
+    if not manifest.is_file():
+        return {}
+    try:
+        payload = read_json(manifest)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ConfigError(f"cannot read local snapshot identity manifest: {exc}") from exc
+    return payload if isinstance(payload, dict) else {}
+
+
+def _validate_local_revision(path: Path, *, model_id: str, revision: str, downloaded: bool) -> None:
+    if downloaded:
+        return
+    manifest = _snapshot_manifest(path)
+    manifest_files = manifest.get("files")
+    manifest_files_dict: dict[str, Any] = manifest_files if isinstance(manifest_files, dict) else {}
+    manifest_matches = (
+        manifest.get("model_id") == model_id
+        and manifest.get("revision") == revision
+        and bool(manifest_files_dict)
+    )
+    # Hugging Face's immutable cache layout ends in snapshots/<commit>.  A
+    # miniVERL manifest is the portable equivalent for copied local snapshots.
+    expected_cache_folder = "models--" + model_id.replace("/", "--")
+    cache_path_matches = (
+        path.name == revision
+        and path.parent.name == "snapshots"
+        and path.parents[1].name == expected_cache_folder
+    )
+    if not manifest_matches and not cache_path_matches:
+        raise ConfigError(
+            f"local snapshot is not bound to the expected immutable revision {revision}",
+            hint=(
+                "pass the Hugging Face cache snapshots/<commit> directory, use --download, "
+                "or provide miniverl-snapshot.json with the exact model_id and revision"
+            ),
+        )
+    if manifest_matches:
+        actual_files = {
+            item.relative_to(path).as_posix()
+            for item in path.rglob("*")
+            if item.is_file()
+            and item.name != "miniverl-snapshot.json"
+            and not (
+                item.relative_to(path).parts
+                and item.relative_to(path).parts[0] in _IGNORED_TOP_LEVEL
+            )
+        }
+        if set(manifest_files_dict) != actual_files:
+            raise ConfigError("local snapshot manifest does not enumerate every snapshot file")
+        for relative, expected in sorted(manifest_files_dict.items()):
+            if not isinstance(relative, str) or not isinstance(expected, str):
+                raise ConfigError("local snapshot manifest has an invalid file hash entry")
+            relative_path = Path(relative)
+            if relative_path.is_absolute() or ".." in relative_path.parts:
+                raise ConfigError("local snapshot manifest path escapes its snapshot")
+            candidate = path / relative_path
+            if not candidate.is_file() or _sha256(candidate) != expected:
+                raise ConfigError(f"local snapshot manifest hash mismatch: {relative}")
+
+
+def _snapshot_model_files(path: Path) -> list[Path]:
+    direct = [path / "model.safetensors", path / "pytorch_model.bin"]
+    files = [candidate for candidate in direct if candidate.is_file()]
+    for index_name in ("model.safetensors.index.json", "pytorch_model.bin.index.json"):
+        index_path = path / index_name
+        if not index_path.is_file():
+            continue
+        try:
+            index = read_json(index_path)
+            names = sorted(set(index["weight_map"].values()))
+        except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+            raise ConfigError(f"invalid model shard index {index_path.name}: {exc}") from exc
+        unsafe = [name for name in names if Path(name).is_absolute() or ".." in Path(name).parts]
+        if unsafe:
+            raise ConfigError(f"model shard index contains unsafe paths: {unsafe}")
+        missing = [name for name in names if not (path / name).is_file()]
+        if missing:
+            raise ConfigError(f"model shard index references missing files: {missing}")
+        files.extend(path / name for name in names)
+    return sorted(set(files))
+
+
+def _validate_snapshot_payload(path: Path, *, role: str) -> dict[str, Any]:
+    tree = preflight_bundle_tree(
+        path,
+        max_files=_MAX_SNAPSHOT_FILES,
+        max_nominal_bytes=_MAX_SNAPSHOT_BYTES,
+        max_depth=64,
+    )
+    if tree["status"] != "ok":
+        reasons = ", ".join(
+            f"{item['path']}: {item['reason']}" for item in tree.get("rejections", [])
+        )
+        raise ConfigError(
+            f"{role} snapshot contains a symlink, reparse point, or unsafe entry: {reasons}"
+        )
+    config_path = path / "config.json"
+    try:
+        config = read_json(config_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ConfigError(f"{role} snapshot has no valid config.json: {exc}") from exc
+    if not isinstance(config, dict):
+        raise ConfigError(f"{role} snapshot config.json must contain an object")
+    model_files = _snapshot_model_files(path)
+    if not model_files:
+        raise ConfigError(f"{role} snapshot has no model weights or complete shard index")
+    safetensors = [item for item in model_files if item.suffix == ".safetensors"]
+    for item in safetensors:
+        check = inspect_safetensors(item)
+        if check["status"] != "ok":
+            raise ConfigError(f"{role} snapshot has invalid {item.name}: {check['detail']}")
+    tokenizer_config = path / "tokenizer_config.json"
+    tokenizer_vocab = (
+        path / "tokenizer.json",
+        path / "tokenizer.model",
+        path / "vocab.json",
+        path / "vocab.txt",
+    )
+    if not tokenizer_config.is_file() or not any(item.is_file() for item in tokenizer_vocab):
+        raise ConfigError(f"{role} snapshot is missing tokenizer config or vocabulary files")
+    return {
+        "tree": tree,
+        "model_files": [item.name for item in model_files],
+        "config_sha256": _sha256(config_path),
+        "weight_format": "safetensors" if safetensors else "pytorch_bin",
+    }
+
+
+def _copy_snapshot_tree(source: Path, destination: Path, *, bundle_prefix: str) -> dict[str, str]:
+    destination.mkdir(parents=True)
+    anchor = source.resolve(strict=True)
+    files: dict[str, str] = {}
+    for item in sorted(source.rglob("*")):
+        relative = item.relative_to(source)
+        if relative.parts and relative.parts[0] in _IGNORED_TOP_LEVEL:
+            continue
+        entry_stat = item.lstat()
+        if item.is_symlink() or getattr(entry_stat, "st_file_attributes", 0) & 0x400:
+            raise ConfigError(f"snapshot changed to a symlink or reparse point: {relative}")
+        try:
+            item.resolve(strict=True).relative_to(anchor)
+        except (OSError, ValueError) as exc:
+            raise ConfigError(f"snapshot entry escapes during copy: {relative}") from exc
+        target = destination / relative
+        if item.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(item, target)
+        files[f"{bundle_prefix}/{relative.as_posix()}"] = _sha256(target)
+    return files
+
+
+def _tree_file_hashes(source: Path, *, prefix: str) -> dict[str, str]:
+    files: dict[str, str] = {}
+    for path in sorted(source.rglob("*")):
+        relative = path.relative_to(source)
+        if relative.parts and relative.parts[0] in _IGNORED_TOP_LEVEL:
+            continue
+        if path.is_file():
+            files[f"{prefix}/{relative.as_posix()}"] = _sha256(path)
+    return files
+
+
+def _copy_cached_snapshot_to_regular(source: Path, destination: Path) -> None:
+    """Dereference only links that stay inside one Hugging Face repository cache."""
+    try:
+        repository_cache = source.parents[1].resolve(strict=True)
+    except (IndexError, OSError) as exc:
+        raise ConfigError("cached snapshot does not have the expected repository layout") from exc
+    destination.mkdir(parents=True)
+    for item in sorted(source.rglob("*")):
+        relative = item.relative_to(source)
+        target = destination / relative
+        try:
+            attributes = getattr(item.lstat(), "st_file_attributes", 0)
+        except OSError as exc:
+            raise ConfigError(f"cached snapshot entry cannot be inspected: {relative}") from exc
+        if attributes & 0x400 and not item.is_symlink():
+            raise ConfigError(f"cached snapshot contains a reparse point: {relative}")
+        if item.is_dir():
+            if item.is_symlink():
+                raise ConfigError(f"cached snapshot contains a linked directory: {relative}")
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        try:
+            resolved = item.resolve(strict=True)
+            resolved.relative_to(repository_cache)
+        except (OSError, ValueError) as exc:
+            raise ConfigError(f"cached snapshot link escapes its repository: {relative}") from exc
+        if not resolved.is_file():
+            raise ConfigError(f"cached snapshot entry is not a regular file: {relative}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(resolved, target)
+
+
+def _download_snapshot(*, model_id: str, revision: str, destination: Path, offline: bool) -> Path:
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as exc:
+        raise ConfigError(
+            "snapshot download requires huggingface_hub",
+            hint="install miniverl[train] or pass exact local snapshot directories",
+        ) from exc
+    try:
+        if offline:
+            try:
+                cached = Path(
+                    snapshot_download(
+                        repo_id=model_id,
+                        revision=revision,
+                        local_files_only=True,
+                    )
+                )
+            except Exception:
+                from huggingface_hub.constants import HF_HUB_CACHE
+                from huggingface_hub.file_download import repo_folder_name
+
+                cached = (
+                    Path(HF_HUB_CACHE)
+                    / repo_folder_name(repo_id=model_id, repo_type="model")
+                    / "snapshots"
+                    / revision
+                )
+                if not cached.is_dir():
+                    raise
+            _copy_cached_snapshot_to_regular(cached, destination)
+            resolved = str(destination)
+        else:
+            resolved = snapshot_download(
+                repo_id=model_id,
+                revision=revision,
+                local_dir=destination,
+                local_files_only=False,
+            )
+    except Exception as exc:
+        mode = "offline cache resolution" if offline else "snapshot download"
+        raise ConfigError(f"{mode} failed for {model_id}@{revision}: {exc}") from exc
+    return Path(resolved)
+
+
+def _resolve_snapshot(
+    supplied: Path | None,
+    *,
+    model_id: str,
+    revision: str,
+    download: bool,
+    offline: bool,
+    destination: Path,
+    role: str,
+) -> tuple[Path, bool]:
+    if supplied is not None and download:
+        raise ConfigError(f"choose either --{role}-snapshot or --download, not both")
+    if supplied is None and not download:
+        raise ConfigError(
+            f"{role} snapshot is required",
+            hint=f"pass --{role}-snapshot snapshots/{revision} or use --download",
+        )
+    if supplied is not None:
+        return supplied.resolve(strict=True), False
+    return _download_snapshot(
+        model_id=model_id,
+        revision=revision,
+        destination=destination,
+        offline=offline,
+    ), True
+
+
+def _merge_teacher_adapter(base: Path, adapter: Path, destination: Path) -> dict[str, Any]:
+    try:
+        import peft
+        import torch
+        import transformers
+        from peft import PeftModel
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+    except ImportError as exc:
+        raise ConfigError(
+            "teacher adapter merge requires the training dependencies",
+            hint="install miniverl[train] before using --merge-teacher-adapter",
+        ) from exc
+    model = AutoModelForCausalLM.from_pretrained(
+        str(base), local_files_only=True, trust_remote_code=False, device_map="cpu"
+    )
+    merged = PeftModel.from_pretrained(model, str(adapter), is_trainable=False).merge_and_unload()
+    destination.mkdir(parents=True)
+    merged.save_pretrained(destination, safe_serialization=True)
+    tokenizer = AutoTokenizer.from_pretrained(
+        str(base), local_files_only=True, trust_remote_code=False
+    )
+    tokenizer.save_pretrained(destination)
+    for source in sorted(base.iterdir()):
+        if source.is_file() and source.name.upper().startswith(("LICENSE", "NOTICE", "COPYING")):
+            shutil.copy2(source, destination / source.name)
+    del tokenizer, merged, model
+    return {
+        "torch": torch.__version__,
+        "transformers": transformers.__version__,
+        "peft": peft.__version__,
+    }
+
+
+def _validate_teacher_adapter(
+    adapter: Path, *, teacher_id: str, teacher_revision: str, adapter_revision: str
+) -> dict[str, Any]:
+    tree = preflight_bundle_tree(adapter)
+    if tree["status"] != "ok":
+        raise ConfigError("teacher adapter tree failed structural preflight")
+    try:
+        config = read_json(adapter / "adapter_config.json")
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ConfigError(f"teacher adapter config is invalid: {exc}") from exc
+    if str(config.get("peft_type", "")).upper() != "LORA":
+        raise ConfigError("teacher adapter is not a standard LoRA PEFT adapter")
+    if config.get("base_model_name_or_path") != teacher_id:
+        raise ConfigError("teacher adapter base model differs from the recorded teacher")
+    if config.get("revision") != teacher_revision:
+        raise ConfigError("teacher adapter base revision differs from the recorded teacher")
+    payload = inspect_safetensors(adapter / "adapter_model.safetensors")
+    if payload["status"] != "ok":
+        raise ConfigError(f"teacher adapter payload is invalid: {payload['detail']}")
+    return {
+        "adapter_revision": adapter_revision,
+        "config_sha256": _sha256(adapter / "adapter_config.json"),
+        "payload_sha256": _sha256(adapter / "adapter_model.safetensors"),
+    }
+
+
+def _copy_teacher_adapter(source: Path, destination: Path) -> None:
+    required = ("adapter_config.json", "adapter_model.safetensors")
+    if not all((source / name).is_file() for name in required):
+        raise ConfigError("downloaded teacher adapter is missing standard PEFT files")
+    destination.mkdir(parents=True)
+    for name in required:
+        shutil.copy2(source / name, destination / name)
+    for path in sorted(source.iterdir()):
+        if path.is_file() and path.name.upper().startswith(("LICENSE", "NOTICE", "COPYING")):
+            shutil.copy2(path, destination / path.name)
+
+
+def _load_local_transformers_metadata(
+    path: Path, *, role: str, adapter: Path | None = None
+) -> dict[str, Any]:
+    try:
+        import torch
+        from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+    except ImportError as exc:
+        raise ConfigError(
+            "upstream materialization validation requires transformers",
+            hint="install miniverl[train,bridge]",
+        ) from exc
+    try:
+        config = AutoConfig.from_pretrained(
+            str(path), local_files_only=True, trust_remote_code=False
+        )
+        tokenizer = AutoTokenizer.from_pretrained(
+            str(path), local_files_only=True, trust_remote_code=False
+        )
+        from miniverl.models.tokenizers import tokenizer_structural_digest
+
+        tokenizer_digest = tokenizer_structural_digest(tokenizer)
+        model: Any = AutoModelForCausalLM.from_pretrained(
+            str(path),
+            local_files_only=True,
+            trust_remote_code=False,
+            low_cpu_mem_usage=True,
+            device_map="cpu",
+        )
+        if adapter is not None:
+            from peft import PeftModel
+
+            model = PeftModel.from_pretrained(model, str(adapter), is_trainable=False)
+        model.eval()
+        encoded = tokenizer("materialization smoke", return_tensors="pt")
+        with torch.no_grad():
+            output = model(**encoded, use_cache=False)
+        if output.logits.ndim != 3 or output.logits.shape[-1] != len(tokenizer):
+            raise ValueError("causal-LM logits do not match the tokenizer vocabulary")
+    except Exception as exc:
+        raise ConfigError(f"{role} local model/tokenizer smoke failed: {exc}") from exc
+    metadata = {
+        "config_class": type(config).__name__,
+        "tokenizer_class": type(tokenizer).__name__,
+        "vocab_size": len(tokenizer),
+        "tokenizer_structural_digest_v2": tokenizer_digest,
+        "parameters": sum(parameter.numel() for parameter in model.parameters()),
+        "peft_adapter_loaded": adapter is not None,
+        "tiny_forward": "passed on CPU without distributed execution",
+    }
+    del output, encoded, model, tokenizer, config
+    gc.collect()
+    return metadata
+
+
+def _validate_upstream_bundle(root: Path) -> dict[str, Any]:
+    try:
+        distribution = importlib.metadata.distribution("verl")
+    except importlib.metadata.PackageNotFoundError as exc:
+        raise ConfigError(
+            "the exact pinned verl distribution is required before launch publication",
+            hint=f"install verl from commit {VERL_COMMIT} and retry",
+        ) from exc
+    direct_text = distribution.read_text("direct_url.json")
+    try:
+        direct = json.loads(direct_text) if direct_text else {}
+    except json.JSONDecodeError as exc:
+        raise ConfigError("installed verl has invalid direct_url.json") from exc
+    actual_commit = ((direct or {}).get("vcs_info") or {}).get("commit_id")
+    if actual_commit != VERL_COMMIT:
+        raise ConfigError(
+            f"installed verl commit is {actual_commit or 'unverified'}, expected {VERL_COMMIT}"
+        )
+    try:
+        from omegaconf import OmegaConf
+    except ImportError as exc:
+        raise ConfigError("pinned upstream validation requires omegaconf") from exc
+    generated = Path(
+        str(distribution.locate_file("verl/trainer/config/_generated_ppo_trainer.yaml"))
+    )
+    if not generated.is_file():
+        raise ConfigError("installed pinned verl omits its generated PPO configuration")
+    try:
+        official = OmegaConf.load(generated)
+        override = OmegaConf.load(root / "recipe/verl-opd-overrides.yaml")
+        OmegaConf.set_struct(official, True)
+        resolved = OmegaConf.merge(official, override)
+        resolved_path = root / "recipe/verl-opd-resolved.yaml"
+        OmegaConf.save(resolved, resolved_path)
+    except Exception as exc:
+        raise ConfigError(f"pinned upstream config merge failed: {exc}") from exc
+
+    from miniverl.bridge.doctor import _check_model, _check_parquet
+
+    adapter = _check_model(root, require_payload=True)
+    parquet = _check_parquet(root)
+    if adapter["status"] != "ok":
+        raise ConfigError(f"student PEFT validation failed: {adapter.get('detail')}")
+    if parquet["status"] != "ok":
+        raise ConfigError(f"Parquet validation failed: {parquet.get('detail')}")
+    student = _load_local_transformers_metadata(
+        root / "model/base", role="student", adapter=root / "model"
+    )
+    teacher = _load_local_transformers_metadata(root / "teacher/base", role="teacher")
+    recipe = yaml.safe_load((root / "recipe/verl-opd-overrides.yaml").read_text(encoding="utf-8"))
+    topk = recipe["distillation"]["distillation_loss"].get("topk")
+    if isinstance(topk, bool) or not isinstance(topk, int) or topk < 1:
+        raise ConfigError("pure-OPD top-k must be a positive integer")
+    for role, metadata in (("student", student), ("teacher", teacher)):
+        if topk > metadata["vocab_size"]:
+            raise ConfigError(f"top-k {topk} exceeds the {role} tokenizer vocabulary")
+    if student["tokenizer_structural_digest_v2"] != teacher["tokenizer_structural_digest_v2"]:
+        raise ConfigError("student and teacher tokenizer structural identities differ")
+    return {
+        "status": "passed",
+        "resolved_config": "recipe/verl-opd-resolved.yaml",
+        "scope": (
+            "exact verl config merge, Parquet footer, PEFT payload, local model config and "
+            "tokenizer loads, sequential CPU model loads and tiny forwards, and top-k bounds; "
+            "no distributed job was run"
+        ),
+        "checks": {
+            "config_parse": "passed",
+            "parquet_schema": "passed",
+            "student_peft": "passed",
+            "student_snapshot": student,
+            "teacher_snapshot": teacher,
+            "topk_contract": "passed",
+        },
+    }
+
+
+def _launch_script() -> str:
+    return """#!/usr/bin/env bash
+set -euo pipefail
+
+BUNDLE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$BUNDLE_ROOT"
+python -m verl.trainer.main_ppo \\
+  --config-path "$BUNDLE_ROOT/recipe" \\
+  --config-name verl-opd-resolved
+"""
+
+
+def _write_hashes(root: Path) -> None:
+    checksum = root / "provenance/SHA256SUMS"
+    lines = [
+        f"{_sha256(path)}  {path.relative_to(root).as_posix()}"
+        for path in sorted(root.rglob("*"))
+        if path.is_file() and path != checksum
+    ]
+    write_text(checksum, "\n".join(lines) + "\n")
+
+
+def _replace_directory(source: Path, target: Path) -> None:
+    backup = target.parent / f".{target.name}.{uuid.uuid4().hex}.backup"
+    target.replace(backup)
+    try:
+        source.replace(target)
+    except BaseException:
+        backup.replace(target)
+        raise
+    shutil.rmtree(backup, ignore_errors=True)
+
+
+def materialize_verl_bundle(
+    bundle: str | Path,
+    *,
+    student_snapshot: str | Path | None = None,
+    teacher_snapshot: str | Path | None = None,
+    download: bool = False,
+    offline: bool = False,
+    merge_teacher_adapter: bool = False,
+) -> dict[str, Any]:
+    """Materialize exact base snapshots and publish a launchable bundle atomically."""
+    root = Path(bundle).resolve(strict=True)
+    tree = preflight_bundle_tree(root)
+    if tree["status"] != "ok":
+        raise ConfigError("bundle tree failed structural preflight")
+    compatibility_path = root / "provenance/compatibility-report.json"
+    try:
+        report = read_json(compatibility_path)
+        student_identity = read_json(root / "model/base-model.json")
+        teacher_identity = read_json(root / "teacher/teacher-model.json")
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ConfigError(f"cannot read scale-out bundle identities: {exc}") from exc
+    if report.get("profile") != "verl-opd-v0.8-single-gpu-v1":
+        raise ConfigError("materialize supports only the pure-OPD v0.8 single-GPU profile")
+    student_id = str(student_identity.get("model_id") or "")
+    teacher_id = str(teacher_identity.get("model_id") or "")
+    student_revision = _immutable_revision(student_identity.get("revision"), role="student")
+    teacher_revision = _immutable_revision(teacher_identity.get("revision"), role="teacher")
+    teacher_adapter = teacher_identity.get("adapter") or {}
+    adapter_required = bool(teacher_identity.get("upstream_materialization_required"))
+    teacher_adapter_revision: str | None = None
+    if adapter_required and not merge_teacher_adapter:
+        raise ConfigError(
+            "the recorded teacher adapter requires explicit --merge-teacher-adapter consent"
+        )
+    if adapter_required:
+        teacher_adapter_revision = _immutable_revision(
+            teacher_adapter.get("revision"), role="teacher adapter"
+        )
+
+    staging = root.parent / f".{root.name}.{uuid.uuid4().hex}.materializing"
+    downloads = root.parent / f".{root.name}.{uuid.uuid4().hex}.downloads"
+    downloads.mkdir()
+    try:
+        student_source, student_downloaded = _resolve_snapshot(
+            Path(student_snapshot) if student_snapshot is not None else None,
+            model_id=student_id,
+            revision=student_revision,
+            download=download,
+            offline=offline,
+            destination=downloads / "student",
+            role="student",
+        )
+        teacher_source, teacher_downloaded = _resolve_snapshot(
+            Path(teacher_snapshot) if teacher_snapshot is not None else None,
+            model_id=teacher_id,
+            revision=teacher_revision,
+            download=download,
+            offline=offline,
+            destination=downloads / "teacher",
+            role="teacher",
+        )
+        _validate_local_revision(
+            student_source,
+            model_id=student_id,
+            revision=student_revision,
+            downloaded=student_downloaded,
+        )
+        _validate_local_revision(
+            teacher_source,
+            model_id=teacher_id,
+            revision=teacher_revision,
+            downloaded=teacher_downloaded,
+        )
+        student_validation = _validate_snapshot_payload(student_source, role="student")
+        teacher_validation = _validate_snapshot_payload(teacher_source, role="teacher")
+        teacher_base_files = _tree_file_hashes(teacher_source, prefix="source-teacher-base")
+
+        shutil.copytree(root, staging)
+        student_destination = staging / "model/base"
+        teacher_destination = staging / "teacher/base"
+        student_files = _copy_snapshot_tree(
+            student_source, student_destination, bundle_prefix="model/base"
+        )
+        merge_software: dict[str, Any] | None = None
+        if adapter_required:
+            adapter_path = staging / "teacher/adapter"
+            if not adapter_path.is_dir():
+                recorded_adapter = teacher_adapter.get("path")
+                if not isinstance(recorded_adapter, str) or not recorded_adapter.strip():
+                    raise ConfigError(
+                        "the bundle has no teacher adapter payload or downloadable identity"
+                    )
+                adapter_source = _download_snapshot(
+                    model_id=recorded_adapter,
+                    revision=str(teacher_adapter_revision),
+                    destination=downloads / "teacher-adapter",
+                    offline=offline,
+                )
+                _copy_teacher_adapter(adapter_source, adapter_path)
+            adapter_validation = _validate_teacher_adapter(
+                adapter_path,
+                teacher_id=teacher_id,
+                teacher_revision=teacher_revision,
+                adapter_revision=str(teacher_adapter_revision),
+            )
+            merge_software = _merge_teacher_adapter(
+                teacher_source, adapter_path, teacher_destination
+            )
+            teacher_adapter_files = _tree_file_hashes(adapter_path, prefix="teacher/adapter")
+            _validate_snapshot_payload(teacher_destination, role="merged teacher")
+            teacher_files = {
+                path.relative_to(staging).as_posix(): _sha256(path)
+                for path in sorted(teacher_destination.rglob("*"))
+                if path.is_file()
+            }
+        else:
+            adapter_validation = None
+            teacher_adapter_files = {}
+            teacher_files = _copy_snapshot_tree(
+                teacher_source, teacher_destination, bundle_prefix="teacher/base"
+            )
+
+        write_json(
+            staging / "provenance/materialization-manifest.json",
+            {
+                "schema_version": 1,
+                "miniverl_version": __version__,
+                "student": {
+                    "model_id": student_id,
+                    "revision": student_revision,
+                    "source": "downloaded_exact_revision"
+                    if student_downloaded
+                    else "local_exact_snapshot",
+                    "validation": student_validation,
+                    "files": student_files,
+                },
+                "teacher": {
+                    "model_id": teacher_id,
+                    "revision": teacher_revision,
+                    "source": "downloaded_exact_revision"
+                    if teacher_downloaded
+                    else "local_exact_snapshot",
+                    "base_validation": teacher_validation,
+                    "base_files": teacher_base_files,
+                    "adapter": teacher_adapter,
+                    "adapter_validation": adapter_validation,
+                    "adapter_files": teacher_adapter_files,
+                    "adapter_merged": adapter_required,
+                    "merge_software": merge_software,
+                    "files": teacher_files,
+                },
+            },
+        )
+        upstream = _validate_upstream_bundle(staging)
+        template = staging / "recipe/launch.template.sh"
+        template.unlink(missing_ok=True)
+        write_text(staging / "recipe/launch.sh", _launch_script())
+        report.update(
+            {
+                "artifact_complete": True,
+                "artifact_bundle_complete": True,
+                "config_semantics_supported": True,
+                "student_artifact_loadable": True,
+                "teacher_artifact_loadable": True,
+                "dataset_loadable": True,
+                "upstream_parse_passed": True,
+                "upstream_config_parse_passed": True,
+                "upstream_tiny_smoke_passed": False,
+                "model_data_load_smoke_passed": True,
+                "launchable": True,
+                "distributed_execution_tested": False,
+                "distributed_execution_status": "not tested",
+                "launch_blockers": [],
+                "materialization": {
+                    "manifest": "provenance/materialization-manifest.json",
+                    "upstream_validation": upstream,
+                    "launch_script": "recipe/launch.sh",
+                },
+            }
+        )
+        write_json(staging / "provenance/compatibility-report.json", report)
+        _write_hashes(staging)
+        final_tree = preflight_bundle_tree(staging)
+        if final_tree["status"] != "ok":
+            raise ConfigError("materialized bundle failed final structural preflight")
+        _replace_directory(staging, root)
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+        shutil.rmtree(downloads, ignore_errors=True)
+    return report

--- a/src/miniverl/cli.py
+++ b/src/miniverl/cli.py
@@ -1708,6 +1708,61 @@ def export_verl_command(
     console.print("  distributed execution: not tested")
 
 
+@bridge_app.command("materialize")
+def bridge_materialize_command(
+    bundle: Path = typer.Argument(..., help="Exported pure-OPD scale-out bundle."),
+    student_snapshot: Optional[Path] = typer.Option(
+        None,
+        "--student-snapshot",
+        help="Exact local student snapshots/<40-character-commit> directory.",
+    ),
+    teacher_snapshot: Optional[Path] = typer.Option(
+        None,
+        "--teacher-snapshot",
+        help="Exact local teacher snapshots/<40-character-commit> directory.",
+    ),
+    download: bool = typer.Option(
+        False,
+        "--download",
+        help="Download both exact revisions recorded by the bundle.",
+    ),
+    offline: bool = typer.Option(
+        False,
+        "--offline",
+        help="Forbid network access; --download may only reuse the local Hub cache.",
+    ),
+    merge_teacher_adapter: bool = typer.Option(
+        False,
+        "--merge-teacher-adapter",
+        help="Explicitly consent to merging the bundled teacher adapter into a new snapshot.",
+    ),
+    as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
+) -> None:
+    """Bind exact snapshots and publish launch.sh after pinned upstream validation."""
+    try:
+        from miniverl.bridge.materialize import materialize_verl_bundle
+
+        report = materialize_verl_bundle(
+            bundle,
+            student_snapshot=student_snapshot,
+            teacher_snapshot=teacher_snapshot,
+            download=download,
+            offline=offline,
+            merge_teacher_adapter=merge_teacher_adapter,
+        )
+    except (MiniVerlError, OSError) as exc:
+        _fail(exc)
+        return
+    payload = {"bundle": str(bundle), **report}
+    if as_json:
+        _emit_json(payload)
+        return
+    console.print(f"[green]scale-out bundle materialized[/green] {_esc(bundle)}")
+    console.print("  launchable: true")
+    console.print("  launch script: recipe/launch.sh")
+    console.print("  distributed execution: not tested")
+
+
 @bridge_app.command("doctor")
 def bridge_doctor_command(
     bundle: Path = typer.Argument(..., help="Exported verl bundle directory."),

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -67,6 +67,7 @@ EXPECTED_COMMANDS = {
     "schema",
     "bridge doctor",
     "bridge compile-opd",
+    "bridge materialize",
     "cache stats",
     "cache validate",
 }

--- a/tests/cli/test_verl_bridge_cli.py
+++ b/tests/cli/test_verl_bridge_cli.py
@@ -11,6 +11,20 @@ from miniverl.bridge.opd_v08 import VERL_OPD_V08_PROFILE
 from miniverl.cli import app
 
 
+def test_bridge_materialize_cli_exposes_explicit_snapshot_and_network_controls() -> None:
+    result = CliRunner().invoke(app, ["bridge", "materialize", "--help"])
+    assert result.exit_code == 0, result.output
+    for option in (
+        "--student-snapshot",
+        "--teacher-snapshot",
+        "--download",
+        "--offline",
+        "--merge-teacher-adapter",
+        "--json",
+    ):
+        assert option in result.output
+
+
 def test_import_verl_cli_defaults_to_a_needs_input_template(tmp_path: Path) -> None:
     source = tmp_path / "verl.yaml"
     source.write_text(

--- a/tests/conformance/test_verl_v08_materialize.py
+++ b/tests/conformance/test_verl_v08_materialize.py
@@ -1,0 +1,85 @@
+"""Bounded launchability smoke under the exact pinned verl source."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.torch, pytest.mark.network, pytest.mark.verl_conformance]
+
+_MODEL_ID = "trl-internal-testing/tiny-Qwen3ForCausalLM"
+_REVISION = "52b2e48b0004586eff92c403efa5ce5547c43a45"
+
+
+def test_materialized_bundle_reaches_bounded_launchable_state(tmp_path: Path) -> None:
+    try:
+        importlib.metadata.distribution("verl")
+    except importlib.metadata.PackageNotFoundError:
+        pytest.skip("official verl v0.8.0 is not installed")
+    from peft import LoraConfig, get_peft_model
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    from miniverl.bridge.contract import VERL_TAG
+    from miniverl.bridge.doctor import inspect_bridge_bundle
+    from miniverl.bridge.export import export_verl_bundle
+    from miniverl.bridge.materialize import materialize_verl_bundle
+    from tests.unit.test_verl_opd_export import _opd_run
+
+    run, _, _ = _opd_run(tmp_path)
+    source_path = run / "verl-source-config.json"
+    source = json.loads(source_path.read_text(encoding="utf-8"))
+    source["actor_rollout_ref"]["model"]["path"] = _MODEL_ID
+    source["distillation"]["teacher_models"]["teacher_model"]["model_path"] = _MODEL_ID
+    source["miniverl"]["student_revision"] = _REVISION
+    source["miniverl"]["teacher_revision"] = _REVISION
+    source_path.write_text(json.dumps(source), encoding="utf-8")
+    compatibility_path = run / "verl-compatibility-report.json"
+    compatibility = json.loads(compatibility_path.read_text(encoding="utf-8"))
+    compatibility["source"] = source
+    compatibility_path.write_text(json.dumps(compatibility), encoding="utf-8")
+
+    adapter = run / "final-peft-adapter"
+    model = AutoModelForCausalLM.from_pretrained(
+        _MODEL_ID, revision=_REVISION, trust_remote_code=False
+    )
+    peft_model = get_peft_model(
+        model,
+        LoraConfig(r=2, lora_alpha=4, target_modules=["q_proj", "v_proj"]),
+    )
+    peft_model.save_pretrained(adapter, safe_serialization=True)
+    tokenizer = AutoTokenizer.from_pretrained(
+        _MODEL_ID, revision=_REVISION, trust_remote_code=False
+    )
+    tokenizer.save_pretrained(adapter)
+    adapter_config = json.loads((adapter / "adapter_config.json").read_text(encoding="utf-8"))
+    adapter_config["base_model_name_or_path"] = _MODEL_ID
+    adapter_config["revision"] = _REVISION
+    (adapter / "adapter_config.json").write_text(json.dumps(adapter_config), encoding="utf-8")
+    del peft_model, model, tokenizer
+
+    bundle = tmp_path / "scaleout"
+    exported = export_verl_bundle(run, target_verl=VERL_TAG, out=bundle)
+    assert exported["launchable"] is False
+    assert not (bundle / "recipe/launch.sh").exists()
+
+    materialized = materialize_verl_bundle(bundle, download=True)
+    assert materialized["launchable"] is True
+    assert materialized["distributed_execution_tested"] is False
+    assert (bundle / "recipe/launch.sh").is_file()
+    assert not (bundle / "recipe/launch.template.sh").exists()
+
+    diagnosis = inspect_bridge_bundle(
+        bundle,
+        require_verl=True,
+        require_tokenizer_load=True,
+        require_adapter_payload=True,
+    )
+    assert diagnosis["verdict"] == "ok", diagnosis
+    assert diagnosis["student_artifact_loadable"] is True
+    assert diagnosis["teacher_artifact_loadable"] is True
+    assert diagnosis["upstream_parse_passed"] is True
+    assert diagnosis["launchable"] is True
+    assert diagnosis["distributed_execution_tested"] is False

--- a/tests/unit/test_verl_opd_export.py
+++ b/tests/unit/test_verl_opd_export.py
@@ -43,6 +43,23 @@ def _opd_run(tmp_path: Path, *, teacher_adapter: bool = False) -> tuple[Path, Pa
     (model / "tokenizer_config.json").write_text(
         json.dumps({"tokenizer_class": "Qwen2Tokenizer"}), encoding="utf-8"
     )
+    if teacher_adapter:
+        teacher_model = run / "teacher-adapter"
+        teacher_model.mkdir()
+        (teacher_model / "adapter_config.json").write_text(
+            json.dumps(
+                {
+                    "peft_type": "LORA",
+                    "base_model_name_or_path": "Qwen/Qwen3-1.7B",
+                    "revision": "70d244cc86ccca08cf5af4e1e306ecf908b1ad5e",
+                    "target_modules": ["q_proj", "v_proj"],
+                    "r": 8,
+                    "lora_alpha": 16,
+                }
+            ),
+            encoding="utf-8",
+        )
+        (teacher_model / "adapter_model.safetensors").write_bytes(_safetensors_bytes())
     rows = [
         {
             "data_source": "unit",
@@ -188,9 +205,9 @@ def test_pure_opd_export_is_reward_free_and_preserves_data_bytes(tmp_path: Path)
     }
     assert overrides["actor_rollout_ref"]["actor"]["use_kl_loss"] is False
     assert overrides["algorithm"]["use_kl_in_reward"] is False
-    assert report["artifact_complete"] is True
+    assert report["artifact_complete"] is False
     assert report["config_semantics_supported"] is True
-    assert report["student_artifact_loadable"] is True
+    assert report["student_artifact_loadable"] is False
     assert report["teacher_artifact_loadable"] is False
     assert report["dataset_loadable"] is True
     assert report["upstream_parse_passed"] is False
@@ -224,6 +241,8 @@ def test_teacher_adapter_requires_upstream_materialization(tmp_path: Path) -> No
         (tmp_path / "bundle/teacher/teacher-model.json").read_text(encoding="utf-8")
     )
     assert identity["adapter"]["path"] == "teacher-adapter"
+    assert identity["adapter"]["bundled_path"] == "teacher/adapter"
+    assert (tmp_path / "bundle/teacher/adapter/adapter_model.safetensors").is_file()
     assert identity["upstream_materialization_required"] is True
 
 

--- a/tests/unit/test_verl_opd_materialize.py
+++ b/tests/unit/test_verl_opd_materialize.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import struct
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _safetensors_bytes() -> bytes:
+    header = json.dumps(
+        {"weight": {"dtype": "F32", "shape": [1], "data_offsets": [0, 4]}},
+        separators=(",", ":"),
+    ).encode()
+    header += b" " * ((8 - len(header) % 8) % 8)
+    return struct.pack("<Q", len(header)) + header + struct.pack("<f", 0.0)
+
+
+def _snapshot(root: Path, revision: str) -> Path:
+    snapshot = root / "snapshots" / revision
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_text(
+        json.dumps({"architectures": ["FixtureForCausalLM"], "model_type": "fixture"}),
+        encoding="utf-8",
+    )
+    (snapshot / "model.safetensors").write_bytes(_safetensors_bytes())
+    (snapshot / "tokenizer.json").write_text(
+        json.dumps({"version": "1.0", "model": {"type": "WordLevel", "vocab": {"x": 0}}}),
+        encoding="utf-8",
+    )
+    (snapshot / "tokenizer_config.json").write_text(
+        json.dumps({"tokenizer_class": "PreTrainedTokenizerFast"}), encoding="utf-8"
+    )
+    (snapshot / "special_tokens_map.json").write_text("{}", encoding="utf-8")
+    (snapshot / "LICENSE").write_text("fixture license\n", encoding="utf-8")
+    model_id = "Qwen/Qwen3-0.6B" if "student" in root.name else "Qwen/Qwen3-1.7B"
+    files = {
+        path.relative_to(snapshot).as_posix(): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in snapshot.iterdir()
+        if path.is_file()
+    }
+    (snapshot / "miniverl-snapshot.json").write_text(
+        json.dumps({"model_id": model_id, "revision": revision, "files": files}),
+        encoding="utf-8",
+    )
+    return snapshot
+
+
+def _bundle(tmp_path: Path, *, teacher_adapter: bool = False) -> tuple[Path, str, str]:
+    from miniverl.bridge.contract import VERL_TAG
+    from miniverl.bridge.export import export_verl_bundle
+    from tests.unit.test_verl_opd_export import _opd_run
+
+    run, _, _ = _opd_run(tmp_path, teacher_adapter=teacher_adapter)
+    bundle = tmp_path / "bundle"
+    export_verl_bundle(run, target_verl=VERL_TAG, out=bundle)
+    student_revision = "c1899de289a04d12100db370d81485cdf75e47ca"
+    teacher_revision = "70d244cc86ccca08cf5af4e1e306ecf908b1ad5e"
+    return bundle, student_revision, teacher_revision
+
+
+def _tree_hashes(root: Path) -> dict[str, str]:
+    return {
+        path.relative_to(root).as_posix(): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def _passed_upstream(root: Path) -> dict[str, Any]:
+    resolved = root / "recipe" / "verl-opd-resolved.yaml"
+    resolved.write_text("trainer:\n  total_training_steps: 1\n", encoding="utf-8")
+    return {
+        "status": "passed",
+        "resolved_config": resolved.relative_to(root).as_posix(),
+        "checks": {
+            "config_parse": "passed",
+            "parquet_schema": "passed",
+            "student_peft": "passed",
+            "student_snapshot": "passed",
+            "teacher_snapshot": "passed",
+            "topk_contract": "passed",
+        },
+    }
+
+
+def test_materialize_publishes_complete_launchable_bundle_transactionally(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from miniverl.bridge import materialize
+
+    bundle, student_revision, teacher_revision = _bundle(tmp_path)
+    student = _snapshot(tmp_path / "student-cache", student_revision)
+    teacher = _snapshot(tmp_path / "teacher-cache", teacher_revision)
+    monkeypatch.setattr(materialize, "_validate_upstream_bundle", _passed_upstream)
+
+    report = materialize.materialize_verl_bundle(
+        bundle,
+        student_snapshot=student,
+        teacher_snapshot=teacher,
+        offline=True,
+    )
+
+    assert report["launchable"] is True
+    assert report["student_artifact_loadable"] is True
+    assert report["teacher_artifact_loadable"] is True
+    assert report["upstream_parse_passed"] is True
+    assert report["distributed_execution_tested"] is False
+    assert (bundle / "recipe/launch.sh").is_file()
+    launch = (bundle / "recipe/launch.sh").read_text(encoding="utf-8")
+    assert "python -m verl.trainer.main_ppo" in launch
+    assert "--config-path" in launch
+    assert not (bundle / "recipe/launch.template.sh").exists()
+    assert (bundle / "model/base/LICENSE").read_text() == "fixture license\n"
+    assert (bundle / "teacher/base/LICENSE").read_text() == "fixture license\n"
+    manifest = json.loads(
+        (bundle / "provenance/materialization-manifest.json").read_text(encoding="utf-8")
+    )
+    assert manifest["student"]["revision"] == student_revision
+    assert manifest["teacher"]["revision"] == teacher_revision
+    assert "model/base/model.safetensors" in manifest["student"]["files"]
+    assert "teacher/base/model.safetensors" in manifest["teacher"]["files"]
+    assert report["launch_blockers"] == []
+
+    from miniverl.bridge import doctor
+
+    diagnosis = doctor.inspect_bridge_bundle(bundle)
+    assert diagnosis["verdict"] == "ok"
+    assert diagnosis["student_snapshot_loadability"]["status"] == "ok"
+    assert diagnosis["teacher_snapshot_loadability"]["status"] == "ok"
+    assert diagnosis["launchable"] is False
+    assert diagnosis["bundle_declared_claims"]["launchable"] is True
+
+    monkeypatch.setattr(
+        doctor,
+        "_installed_verl",
+        lambda: {"status": "ok", "expected_commit": "fixture", "version": "fixture"},
+    )
+    monkeypatch.setattr(
+        doctor,
+        "_recompute_upstream_smoke",
+        lambda root, installed, *, enabled: {"status": "passed"},
+    )
+    strict = doctor.inspect_bridge_bundle(bundle, require_verl=True)
+    assert strict["verdict"] == "ok"
+    assert strict["launchable"] is True
+
+
+def test_materialize_failure_leaves_original_bundle_byte_identical(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from miniverl.bridge import materialize
+
+    bundle, student_revision, teacher_revision = _bundle(tmp_path)
+    student = _snapshot(tmp_path / "student-cache", student_revision)
+    teacher = _snapshot(tmp_path / "teacher-cache", teacher_revision)
+    before = _tree_hashes(bundle)
+    real_copy = materialize._copy_snapshot_tree
+    calls = 0
+
+    def fail_second_copy(source: Path, destination: Path, *, bundle_prefix: str) -> Any:
+        nonlocal calls
+        calls += 1
+        result = real_copy(source, destination, bundle_prefix=bundle_prefix)
+        if calls == 2:
+            raise OSError("injected copy failure")
+        return result
+
+    monkeypatch.setattr(materialize, "_copy_snapshot_tree", fail_second_copy)
+    with pytest.raises(OSError, match="injected copy failure"):
+        materialize.materialize_verl_bundle(
+            bundle,
+            student_snapshot=student,
+            teacher_snapshot=teacher,
+            offline=True,
+        )
+
+    assert _tree_hashes(bundle) == before
+    assert not (bundle / "model/base").exists()
+
+
+def test_local_snapshot_must_be_bound_to_the_expected_immutable_revision(tmp_path: Path) -> None:
+    from miniverl.bridge.materialize import materialize_verl_bundle
+    from miniverl.errors import ConfigError
+
+    bundle, student_revision, teacher_revision = _bundle(tmp_path)
+    student = _snapshot(tmp_path / "student-cache", "f" * 40)
+    teacher = _snapshot(tmp_path / "teacher-cache", teacher_revision)
+
+    with pytest.raises(ConfigError, match="immutable revision"):
+        materialize_verl_bundle(
+            bundle,
+            student_snapshot=student,
+            teacher_snapshot=teacher,
+            offline=True,
+        )
+    assert not (bundle / "model/base").exists()
+    assert student_revision not in str(student)
+
+
+def test_portable_snapshot_manifest_must_bind_every_declared_file(tmp_path: Path) -> None:
+    from miniverl.bridge.materialize import _validate_local_revision
+    from miniverl.errors import ConfigError
+
+    snapshot = tmp_path / "portable"
+    snapshot.mkdir()
+    (snapshot / "config.json").write_text("{}", encoding="utf-8")
+    (snapshot / "miniverl-snapshot.json").write_text(
+        json.dumps(
+            {
+                "model_id": "fixture/model",
+                "revision": "a" * 40,
+                "files": {"config.json": "0" * 64},
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="hash mismatch"):
+        _validate_local_revision(
+            snapshot,
+            model_id="fixture/model",
+            revision="a" * 40,
+            downloaded=False,
+        )
+
+
+def test_portable_snapshot_manifest_must_enumerate_every_file(tmp_path: Path) -> None:
+    from miniverl.bridge.materialize import _validate_local_revision
+    from miniverl.errors import ConfigError
+
+    snapshot = tmp_path / "portable"
+    snapshot.mkdir()
+    (snapshot / "config.json").write_text("{}", encoding="utf-8")
+    (snapshot / "unlisted.bin").write_bytes(b"not identity-bound")
+    (snapshot / "miniverl-snapshot.json").write_text(
+        json.dumps(
+            {
+                "model_id": "fixture/model",
+                "revision": "a" * 40,
+                "files": {
+                    "config.json": hashlib.sha256(b"{}").hexdigest(),
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="enumerate every"):
+        _validate_local_revision(
+            snapshot,
+            model_id="fixture/model",
+            revision="a" * 40,
+            downloaded=False,
+        )
+
+
+def test_model_shard_index_may_not_escape_snapshot(tmp_path: Path) -> None:
+    from miniverl.bridge.materialize import _snapshot_model_files
+    from miniverl.errors import ConfigError
+
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    (snapshot / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"weight": "../outside.safetensors"}}),
+        encoding="utf-8",
+    )
+    (tmp_path / "outside.safetensors").write_bytes(_safetensors_bytes())
+    with pytest.raises(ConfigError, match="unsafe paths"):
+        _snapshot_model_files(snapshot)
+
+
+def test_offline_download_dereferences_only_one_repository_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    huggingface_hub = pytest.importorskip("huggingface_hub")
+
+    from miniverl.bridge.materialize import _download_snapshot
+
+    cache = tmp_path / "models--fixture--model"
+    source = cache / "snapshots" / ("a" * 40)
+    source.mkdir(parents=True)
+    (source / "config.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", lambda **kwargs: str(source))
+    destination = tmp_path / "regular"
+
+    resolved = _download_snapshot(
+        model_id="fixture/model",
+        revision="a" * 40,
+        destination=destination,
+        offline=True,
+    )
+
+    assert resolved == destination
+    assert (resolved / "config.json").read_text(encoding="utf-8") == "{}"
+    assert not (resolved / "config.json").is_symlink()
+
+
+def test_snapshot_symlink_is_rejected_before_publication(tmp_path: Path) -> None:
+    from miniverl.bridge.materialize import materialize_verl_bundle
+    from miniverl.errors import ConfigError
+
+    bundle, student_revision, teacher_revision = _bundle(tmp_path)
+    student = _snapshot(tmp_path / "student-cache", student_revision)
+    teacher = _snapshot(tmp_path / "teacher-cache", teacher_revision)
+    target = student / "outside.bin"
+    target.write_bytes(b"outside")
+    link = student / "linked.bin"
+    try:
+        link.symlink_to(target)
+    except OSError:
+        pytest.skip("this Windows account cannot create symlinks")
+
+    with pytest.raises(ConfigError, match=r"symlink|reparse"):
+        materialize_verl_bundle(
+            bundle,
+            student_snapshot=student,
+            teacher_snapshot=teacher,
+            offline=True,
+        )
+    assert not (bundle / "model/base").exists()
+
+
+def test_teacher_adapter_merge_requires_explicit_consent(tmp_path: Path) -> None:
+    from miniverl.bridge.materialize import materialize_verl_bundle
+    from miniverl.errors import ConfigError
+
+    bundle, student_revision, teacher_revision = _bundle(tmp_path, teacher_adapter=True)
+    student = _snapshot(tmp_path / "student-cache", student_revision)
+    teacher = _snapshot(tmp_path / "teacher-cache", teacher_revision)
+
+    with pytest.raises(ConfigError, match="--merge-teacher-adapter"):
+        materialize_verl_bundle(
+            bundle,
+            student_snapshot=student,
+            teacher_snapshot=teacher,
+            offline=True,
+        )
+
+
+def test_teacher_adapter_merge_is_new_explicit_audited_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from miniverl.bridge import materialize
+
+    bundle, student_revision, teacher_revision = _bundle(tmp_path, teacher_adapter=True)
+    student = _snapshot(tmp_path / "student-cache", student_revision)
+    teacher = _snapshot(tmp_path / "teacher-cache", teacher_revision)
+    original_teacher = _tree_hashes(teacher)
+
+    def fake_merge(base: Path, adapter: Path, destination: Path) -> dict[str, str]:
+        assert (adapter / "adapter_model.safetensors").is_file()
+        shutil.copytree(base, destination)
+        (destination / "merge-proof.json").write_text(
+            json.dumps(
+                {
+                    "adapter_sha256": hashlib.sha256(
+                        (adapter / "adapter_model.safetensors").read_bytes()
+                    ).hexdigest()
+                }
+            ),
+            encoding="utf-8",
+        )
+        return {"transformers": "fixture", "peft": "fixture", "torch": "fixture"}
+
+    monkeypatch.setattr(materialize, "_merge_teacher_adapter", fake_merge)
+    monkeypatch.setattr(materialize, "_validate_upstream_bundle", _passed_upstream)
+    report = materialize.materialize_verl_bundle(
+        bundle,
+        student_snapshot=student,
+        teacher_snapshot=teacher,
+        offline=True,
+        merge_teacher_adapter=True,
+    )
+
+    assert report["launchable"] is True
+    assert _tree_hashes(teacher) == original_teacher
+    manifest = json.loads(
+        (bundle / "provenance/materialization-manifest.json").read_text(encoding="utf-8")
+    )
+    assert manifest["teacher"]["adapter_merged"] is True
+    assert manifest["teacher"]["merge_software"]["peft"] == "fixture"
+    assert "teacher/base/merge-proof.json" in manifest["teacher"]["files"]
+
+
+def test_upstream_validation_failure_does_not_publish_partial_materialization(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from miniverl.bridge import materialize
+    from miniverl.errors import ConfigError
+
+    bundle, student_revision, teacher_revision = _bundle(tmp_path)
+    student = _snapshot(tmp_path / "student-cache", student_revision)
+    teacher = _snapshot(tmp_path / "teacher-cache", teacher_revision)
+    before = _tree_hashes(bundle)
+
+    def fail_upstream(root: Path) -> dict[str, Any]:
+        raise ConfigError("pinned upstream validation failed")
+
+    monkeypatch.setattr(materialize, "_validate_upstream_bundle", fail_upstream)
+    with pytest.raises(ConfigError, match="pinned upstream"):
+        materialize.materialize_verl_bundle(
+            bundle,
+            student_snapshot=student,
+            teacher_snapshot=teacher,
+            offline=True,
+        )
+    assert _tree_hashes(bundle) == before
+
+
+def test_directory_swap_rolls_back_when_new_bundle_rename_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from miniverl.bridge.materialize import _replace_directory
+
+    old = tmp_path / "bundle"
+    new = tmp_path / "staged"
+    old.mkdir()
+    new.mkdir()
+    (old / "value.txt").write_text("old", encoding="utf-8")
+    (new / "value.txt").write_text("new", encoding="utf-8")
+    real_replace = Path.replace
+
+    def fail_new_once(path: Path, target: Path) -> Path:
+        if path == new:
+            raise OSError("injected publication rename failure")
+        return real_replace(path, target)
+
+    monkeypatch.setattr(Path, "replace", fail_new_once)
+    with pytest.raises(OSError, match="publication rename"):
+        _replace_directory(new, old)
+
+    assert (old / "value.txt").read_text(encoding="utf-8") == "old"
+    assert (new / "value.txt").read_text(encoding="utf-8") == "new"

--- a/tests/unit/test_verl_opd_materialize.py
+++ b/tests/unit/test_verl_opd_materialize.py
@@ -311,6 +311,14 @@ def test_snapshot_symlink_is_rejected_before_publication(tmp_path: Path) -> None
         link.symlink_to(target)
     except OSError:
         pytest.skip("this Windows account cannot create symlinks")
+    manifest_path = student / "miniverl-snapshot.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["files"] = {
+        path.relative_to(student).as_posix(): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in student.iterdir()
+        if path.is_file() and path != manifest_path
+    }
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
     with pytest.raises(ConfigError, match=r"symlink|reparse"):
         materialize_verl_bundle(


### PR DESCRIPTION
## Summary

- add transactional `bridge materialize` for exact student/teacher snapshots, strict immutable identity and regular-file checks, and explicit teacher-adapter merging
- publish `launch.sh` only after PEFT, Parquet, tokenizer/model, top-k and pinned verl validation; keep distributed execution explicitly untested
- make fresh OPD exports report missing base-model loadability honestly, teach doctor to recompute materialized readiness, and document the offline-first workflow
- add a real tiny-Qwen3/LoRA conformance smoke under official verl v0.8.0 at `7aed6b23`

## Validation

- `ruff check .`; `ruff format --check .`
- `mypy src/miniverl scripts`
- actionlint 1.7.12
- 2,216 non-GPU/non-network tests passed; 83.69% coverage
- pinned verl conformance: 4 passed, including export -> materialize -> sequential model forwards -> doctor
- network: 13 passed, 3 skipped; GPU: 8 skipped because CUDA was unavailable in the final process
- strict MkDocs and Playwright: 11 pages at 1440, 1024, 820 and 390 px; no exemptions
- wheel/sdist build and Twine passed; clean core and `[train,bridge]` installs passed; extracted-sdist suite: 2,214 passed
- frozen calculator SHA-256 remains `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`; no benchmark file changed

## Boundary

`launchable: true` means the exact pinned config and local artifacts are complete enough to invoke the documented upstream entry point. No distributed verl job ran, and distributed execution and algorithmic parity remain false.