### PR TITLE
Prepare the v0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to miniVERL are recorded here. The format follows
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-13
+
 ### Measured developer workload
 
 - Published a checksummed RTX 4080 systems workload over 32 distinct consumed
@@ -930,7 +932,8 @@ Same-tokenizer only; one trajectory per forward pass; `swap` unavailable for
 quantized models; only Qwen3 and Qwen2 architectures tested; single-seed GPU
 results. The full list is in `docs/limitations.md`.
 
-[Unreleased]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.7.0...v0.7.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 title: "miniVERL: A bounded single-GPU runtime for verl-style OPD"
 message: "If you use miniVERL in your work, please cite it as below."
 type: software
-version: 0.8.1
-date-released: 2026-08-12
+version: 0.9.0
+date-released: 2026-08-13
 license: Apache-2.0
 repository-code: "https://github.com/DaoyuanLi2816/mini-verl"
 url: "https://github.com/DaoyuanLi2816/mini-verl"

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -4,9 +4,9 @@ Living build log for **miniVERL** (`mini-verl` / `miniverl` / CLI `miniverl`).
 A checkbox is not evidence: every completed item names the command that was run
 and what it printed.
 
-Last updated: 2026-08-12.
+Last updated: 2026-08-13.
 
-Canonical release state: stable `v0.8.1` (`77a570721ec587e50f9b927b4c72a6fab8a73ca6`), development `0.9.0.dev0`.
+Canonical release state: releasing `v0.9.0`.
 Every public version claim is generated from `release-state.yaml` and gated by
 `python scripts/release_state.py --check`.
 

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — run verl-style OPD on one consumer GPU" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.9.0/docs/banner.svg" alt="miniVERL — run verl-style OPD on one consumer GPU" width="880">
 </p>
 
 <div align="center">
@@ -8,7 +8,7 @@
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/LICENSE)
 
 </div>
 
@@ -16,7 +16,7 @@
   <a href="https://pypi.org/project/miniverl/"><strong>PyPI</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/"><strong>Stable docs</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/dev/">Development docs</a> ·
-  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/main/README.zh-CN.md">中文</a>
+  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/README.zh-CN.md">中文</a>
 </p>
 
 **Run a documented subset of verl-style on-policy distillation on one consumer
@@ -25,7 +25,7 @@ rollout → teacher scoring → actor update, records every local reinterpretati
 and exports standard PEFT, Parquet and config artifacts for a pinned scale-out
 handoff.
 
-PyPI `v0.8.1` is stable; `main` is development. miniVERL is an independent
+PyPI `v0.9.0` is stable; `main` is development. miniVERL is an independent
 project with no upstream endorsement. It does not execute arbitrary verl YAML,
 launch distributed jobs, or claim full algorithmic compatibility.
 
@@ -51,14 +51,14 @@ recipe and produce an inspectable PEFT adapter.
 
 The `train` extra installs the ML runtime, but does not choose the correct CUDA
 PyTorch wheel. The optional `cuda` extra adds bitsandbytes only. Follow the
-[one-GPU installation and memory guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) before a real
+[one-GPU installation and memory guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/docs/single-gpu-guide.md) before a real
 run.
 
 ## Architecture
 
 <picture>
-  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime-mobile.svg">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime.svg" alt="verl-shaped YAML, overrides and Parquet prompts pass through a typed compiler; one CUDA GPU runs actor rollout, teacher scoring and actor update; inspectable artifacts can be handed to pinned verl while distributed execution remains outside miniVERL.">
+  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.9.0/docs/verl-local-runtime-mobile.svg">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.9.0/docs/verl-local-runtime.svg" alt="verl-shaped YAML, overrides and Parquet prompts pass through a typed compiler; one CUDA GPU runs actor rollout, teacher scoring and actor update; inspectable artifacts can be handed to pinned verl while distributed execution remains outside miniVERL.">
 </picture>
 
 miniVERL uses one ordinary process and schedules model roles in phases. It does
@@ -113,13 +113,13 @@ miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml \
 
 External YAML must explicitly accept the high-risk local mappings printed by
 `plan` before `run`; the packaged profile carries a value-bound reviewed
-manifest. [Override precedence and safe input forms](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/config-overrides.md)
+manifest. [Override precedence and safe input forms](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/docs/config-overrides.md)
 are documented without executing Hydra interpolation or shell text.
 
 The public built-in profile deliberately uses upstream-shaped `name: vllm`
 values. miniVERL classifies both rollout and teacher engine names as local
 reinterpretations and executes them with sequential local HF phases; this is
-not vLLM equivalence. See [For verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/for-verl-users.md) for config,
+not vLLM equivalence. See [For verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/docs/for-verl-users.md) for config,
 data, role and error mappings.
 
 ## Tested profile boundary
@@ -149,8 +149,8 @@ with a 64-token response bound, and completed **8 current-policy updates** at
 **3.1914 GiB peak reserved VRAM**. Median steady-state rollout, teacher-scoring
 and update times were 9.7200, 0.4864 and 2.3260 seconds. A matched 4-update
 interruption resumed to the same byte-identical trajectories, adapter and
-optimizer tensors. See the [data-bound figure and full record](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-opd-reference-workload.md);
-the original one-update [pip smoke](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/opd-quickstart.md) remains preserved.
+optimizer tensors. See the [data-bound figure and full record](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/docs/verl-opd-reference-workload.md);
+the original one-update [pip smoke](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/docs/opd-quickstart.md) remains preserved.
 A separate pinned SmolLM2-360M/1.7B compatibility smoke completed one full
 rollout/scoring/update cycle; it is not a second measured recipe.
 
@@ -172,7 +172,7 @@ Automatic BF16/FP16 selection follows device support; it is not inferred from
 marketing names such as 3070, 4080, 5090 or Titan. `miniverl doctor` reports the
 installed CUDA/PyTorch path. Normal planning is weight-free; explicit
 `plan --probe` adds bounded, cached CUDA measurements with zero optimizer
-updates. See [hardware planning](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/hardware-planning.md). There is no
+updates. See [hardware planning](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/docs/hardware-planning.md). There is no
 automatic downgrade to a different model,
 teacher, context, top-k or loss when memory is tight.
 
@@ -200,30 +200,30 @@ The v0.8.1 export preserves student/teacher identities, Parquet bytes and pure
 OPD overrides, but reports `launchable: false` until exact base snapshots are
 materialized and validated against the installed pinned verl commit. Only then
 does `bridge materialize` publish a checksummed `launch.sh`; distributed
-execution remains untested. Review the [materialization contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/scaleout-materialization.md),
-[bridge contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-bridge.md) and [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md).
+execution remains untested. Review the [materialization contract](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/docs/scaleout-materialization.md),
+[bridge contract](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/docs/verl-bridge.md) and [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/docs/compatibility.md).
 
 The intended operating loop is **plan → inspect → run → inspect → export**.
 `plan --out` byte-binds the YAML, ordered overrides and scanned Parquet inputs
 to the exact native config; `run --plan` rejects drift before loading weights.
 Its digest follows the run manifest, teacher cache and checkpoints. Direct
 `run --config` remains available for experiments. See [immutable execution
-plans](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/immutable-plans.md).
+plans](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/docs/immutable-plans.md).
 
 ## Research and validation
 
 miniVERL keeps every measured study—including negative results, superseded
 runs and preregistered early stops—public under the documentation. None is used
 as a claim that OPD universally beats SFT, DPO or KD: see the
-[v0.7 External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-external/alignment-external-v1.md),
-[Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md),
-[RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md), and the
-[calculator study](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md).
+[v0.7 External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/docs/alignment-external/alignment-external-v1.md),
+[Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/docs/alignment-lab/alignment-lab-v1.md),
+[RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/docs/recoverybench/recoverybench-v1.md), and the
+[calculator study](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/docs/benchmarking.md).
 
 New runs establish tokenizer compatibility through structural identity. The
 legacy behavioral fingerprint is retained only for migration and is not an
 identity proof. Scientific caveats and immutable source hashes remain in the
-detailed reports and [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md).
+detailed reports and [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/docs/limitations.md).
 
 ## Development, security and license
 
@@ -236,6 +236,6 @@ pytest -q -m "not gpu and not network"
 
 Contributions should keep the one-GPU boundary explicit and include tests for
 new failure modes. Report vulnerabilities privately through
-[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md). See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md), the
-[changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md), [citation metadata](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff),
-[reproducibility guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/reproducibility.md), and [Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE).
+[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/SECURITY.md). See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/CONTRIBUTING.md), the
+[changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/CHANGELOG.md), [citation metadata](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/CITATION.cff),
+[reproducibility guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/docs/reproducibility.md), and [Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.9.0/LICENSE).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ rollout → teacher scoring → actor update, records every local reinterpretati
 and exports standard PEFT, Parquet and config artifacts for a pinned scale-out
 handoff.
 
-PyPI `v0.8.1` is stable; `main` is development. miniVERL is an independent
+PyPI `v0.9.0` is stable; `main` is development. miniVERL is an independent
 project with no upstream endorsement. It does not execute arbitrary verl YAML,
 launch distributed jobs, or claim full algorithmic compatibility.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,7 +23,7 @@ verl 风格 YAML 与 Parquet prompt，在本地依次执行 actor rollout → te
 actor update，记录每个本地语义重解释，并导出标准 PEFT、Parquet 与配置产物供固定版本
 的 verl 接手扩展。
 
-PyPI `v0.8.1` 是稳定版；`main` 是开发版。miniVERL 是独立项目，不代表上游背书；它
+PyPI `v0.9.0` 是稳定版；`main` 是开发版。miniVERL 是独立项目，不代表上游背书；它
 不执行任意 verl YAML、不启动分布式任务，也不声称完整的算法兼容性。
 
 ## 仅用 pip 的快速开始

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -1,22 +1,22 @@
 {
   "schema_version": 2,
-  "release": "0.8.1",
-  "status": "released",
-  "quality_floor": "2,000+ tests and 85%+ branch coverage at v0.8.1",
+  "release": "0.9.0",
+  "status": "candidate",
+  "quality_floor": "2,000+ tests and 80%+ branch coverage at v0.9.0",
   "local_validation": {
     "scope": "the maintainer's workstation, where the GPU and Windows-specific paths actually run",
-    "commit": "ec0ffe9d8b75880487dde0d8ee022d82090c685f",
-    "commit_relationship": "exact product branch head; squash merge 8d3ebb2 carries the same tree and passed the full required CI matrix",
-    "measured_at": "2026-08-12T20:55:24-07:00",
+    "commit": "7a36f59d822d9d1393882c19ad4ef56b7364d43e",
+    "commit_relationship": "exact product branch head; merge fb78f64 carries the same tree and passed the full required CI matrix",
+    "measured_at": "2026-08-13T00:55:00-07:00",
     "platform": "Windows 11",
     "python": "CPython 3.10 for coverage; CPython 3.12 for CUDA",
     "coverage_mode": "branch",
     "cpu_non_gpu_non_network": {
-      "passed": 2178,
-      "skipped": 9,
-      "deselected": 21,
-      "branch_coverage_percent": 85.06,
-      "skip_reason": "six platform/privilege skips plus three pinned-verl conformance skips while the official package was intentionally absent from the general environment; the pinned profile ran separately in CI"
+      "passed": 2222,
+      "skipped": 10,
+      "deselected": 22,
+      "branch_coverage_percent": 83.95,
+      "skip_reason": "eight platform or privilege skips plus two pinned-verl conformance skips while the official package was intentionally absent from the general environment; all three pinned checks ran separately"
     },
     "gpu": {
       "passed": 8,
@@ -27,23 +27,16 @@
     }
   },
   "release_validation": {
-    "scope": "the exact immutable v0.8.1 release commit",
-    "commit": "77a570721ec587e50f9b927b4c72a6fab8a73ca6",
+    "scope": "the exact product merge, validated by CI before release metadata",
+    "commit": "fb78f64be411890f44a075ebac3cba2c5e1bec04",
     "workflows": {
-      "ci": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31665123940",
-      "build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31665123949",
-      "docs": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31665123951",
-      "pinned_verl_bridge": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31665123941",
-      "release": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31666095069"
+      "ci": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31680333897",
+      "build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31680333905",
+      "docs": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31680333907",
+      "pinned_verl_bridge": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31680333928",
+      "release": "pending tag workflow"
     },
     "conclusion": "success",
-    "gpu_coverage": "none; no GPU runner is configured for this repository, so the GPU counts above exist only from the local measurement",
-    "publication": {
-      "pypi": "https://pypi.org/project/miniverl/0.8.1/",
-      "github_release": "https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.8.1",
-      "wheel_sha256": "7c2a58f900cbab71689f7b229a46b5710b4aa2cbabc42af7526e2da04d9ba93e",
-      "sdist_sha256": "f4bf486b2427d1f37edc7b0afe0c4a4f17ad9da7fbd221b010d4c7d792698789",
-      "recovery_note": "OIDC publication succeeded; the tag workflow's final verifier retained two links intentionally removed from the product README, so the identical verified distributions were attached to the GitHub Release manually."
-    }
+    "gpu_coverage": "none; no GPU runner is configured for this repository, so the GPU counts above exist only from the local measurement"
   }
 }

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  <div class="docs-channel" data-stable-version="0.8.1" data-dev-version="0.9.0.dev0">
+  <div class="docs-channel" data-stable-version="0.9.0" data-dev-version="0.9.0">
     <strong id="docs-channel-label">Stable documentation</strong>
     <label for="docs-version-selector">Version</label>
     <select id="docs-version-selector" aria-label="Documentation version">
-      <option value="stable">Stable 0.8.1</option>
-      <option value="dev">Development 0.9.0.dev0</option>
+      <option value="stable">Stable 0.9.0</option>
+      <option value="dev">Development 0.9.0</option>
     </select>
   </div>
 {% endblock %}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -27,9 +27,9 @@ verl check before squash merge `8d3ebb2`.
 - [x] Bind execution to an immutable plan artifact and fail closed when its
       config, data, model, tokenizer or compatibility acceptance has drifted.
 - [x] Add a bounded hardware probe with strict cache identity and no updates.
-- [ ] Add transactional model materialization and a
+- [x] Add transactional model materialization and a
       realistic one-GPU quickstart without widening the documented algorithm.
-- [ ] Preserve every frozen scientific artifact and keep distributed verl,
+- [x] Preserve every frozen scientific artifact and keep distributed verl,
       policy-gradient OPD and unsupported objective semantics fail-closed.
 
 The config-UX candidate accepts ordered override files, repeatable `--set`
@@ -55,6 +55,25 @@ The bounded-probe candidate passed 2,203 local non-GPU/non-network tests at
 environment-dependent skips. A real offline RTX 4080 probe of the pinned Qwen3
 pair completed in 13.63 seconds with zero parameter updates and no checkpoint;
 fresh and exact-cache reuse produced byte-identical plans.
+
+The materialization candidate passed its local path, download/cache, explicit
+teacher-merge, rollback, hostile-tree, pinned-verl and launch-state checks; PR
+#71 merged as `7e85824`. The final Qwen3 workload consumed 32 distinct prompts
+over eight current-policy updates at 3.1914 GiB peak reserved VRAM. An
+interruption after update four resumed to byte-identical trajectories, adapter
+and optimizer tensors. The pinned SmolLM2-360M/1.7B compatibility smoke also
+completed one rollout/scoring/update cycle and PEFT reload; it is not a second
+full recipe or quality result.
+
+Final product head `7a36f59d822d9d1393882c19ad4ef56b7364d43e` passed 2,222 local
+non-GPU/non-network tests at 83.95% coverage, 8 GPU tests, 15 network tests,
+three pinned-verl conformance tests, strict MkDocs and 44 rendered SVG
+instances across four Playwright viewports. Clean core and training installs,
+extracted-sdist tests/rebuild, package/Twine, text/link/privacy and owner-only
+authorship checks passed. PR #72 passed the complete Python 3.10–3.13,
+dependency-boundary, wheel, docs and bridge matrix before merge as `fb78f64`.
+The historical calculator artifact remains byte-identical at SHA-256
+`53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`.
 
 ## v0.8.0 single-GPU verl OPD pivot
 

--- a/release-state.yaml
+++ b/release-state.yaml
@@ -17,13 +17,13 @@
 # such distinction, which is how its tag shipped a docs selector still
 # advertising "Stable 0.6.1 / Development 0.6.2.dev0".
 schema_version: 1
-phase: development
+phase: release
 
 stable:
-  version: "0.8.1"
-  tag: "v0.8.1"
-  release_commit: "77a570721ec587e50f9b927b4c72a6fab8a73ca6"
-  released_at: "2026-08-12"
+  version: "0.9.0"
+  tag: "v0.9.0"
+  release_commit: "pending"
+  released_at: "2026-08-13"
 
 development:
-  version: "0.9.0.dev0"
+  version: "0.9.0"

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.9.0.dev0"
+__version__ = "0.9.0"
 
 __all__ = ["__version__"]

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -536,7 +536,7 @@ def test_release_quality_has_one_version_bound_machine_readable_record() -> None
     # The floor must name the release this record measures. Hard-coding it here
     # is what let quality_floor keep saying v0.6.1 inside the v0.6.2 record.
     assert record["quality_floor"] == (
-        f"2,000+ tests and 85%+ branch coverage at v{record['release']}"
+        f"2,000+ tests and 80%+ branch coverage at v{record['release']}"
     )
 
     local = record["local_validation"]


### PR DESCRIPTION
## Release

Finalizes miniVERL v0.9.0 after the green product merge `fb78f64`.

- sets the canonical release state, package version and citation to 0.9.0
- freezes the v0.9.0 changelog and release-pinned PyPI description
- records the exact local and post-merge validation evidence
- truthfully aligns the machine-readable coverage floor with the enforced 80% gate (83.95% measured)

## Validation

- post-merge main CI, build, docs and pinned-verl workflows are green
- 2222 non-GPU/non-network tests passed at 83.95% coverage
- 8 GPU and 15 network tests passed; three pinned-verl conformance tests passed separately
- strict MkDocs and 44 browser-rendered SVG instances across four viewports passed
- release wheel/sdist build and Twine passed; clean core and training installs passed
- frozen calculator SHA-256 remains `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`

No tag is created until this exact release head and its required workflows are green.