### PR TITLE
Release miniVERL v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to miniVERL are recorded here. The format follows
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-14
+
 ### Versioned compatibility profiles
 
 - Added a closed, typed compatibility-profile registry with independent
@@ -18,6 +20,41 @@ All notable changes to miniVERL are recorded here. The format follows
   third-party entry points.
 - Began the CLI domain split by moving profile and compatibility commands out
   of the root module without changing existing command names.
+
+### Sampled-k1 policy-gradient OPD
+
+- Added the closed `verl-opd-v0.8-single-gpu-pg-k1-v1` profile for the pinned
+  verl v0.8 `k1` estimator and vanilla policy loss, with task rewards,
+  reference KL, critics, multi-teacher and distributed execution rejected.
+- Bound sampled token IDs, old/current actor log-probabilities, teacher
+  sampled-token log-probabilities, policy version, tokenizer and estimator
+  identity to fresh trajectories and caches.
+- Matched the pinned upstream estimator, loss, metrics, gradient and tiny
+  optimizer step; added profile-specific resume, export, materialization and
+  doctor validation.
+
+### Measured runtime evidence
+
+- Published a Qwen3 PG systems record over 32 prompts and eight strict updates
+  on one RTX 4080, including exact interruption/resume and a launchable
+  materialized artifact bundle. This is not a task-quality comparison.
+- Promoted SmolLM2-360M/1.7B to a full direct-GKD recipe over 32 prompts and
+  eight updates, with 1.4961 GiB peak reserved VRAM, exact resume, PEFT reload
+  and materialized export checks.
+- Added a measured Ubuntu 26.04 WSL2 path on the same RTX 4080 covering plan,
+  bounded probe, rollout, teacher scoring, one update and PEFT reload.
+
+### Portable hardware records
+
+- Added torch-free `hardware record` and `hardware validate` commands plus a
+  generated strict schema that preserves measured, estimated and unknown
+  states across profile, model, batching, memory, timing, resume and artifact
+  evidence.
+- Community records remain unreviewed and are never uploaded automatically;
+  maintainer-measured publication requires explicit review and consent.
+
+No frozen benchmark or task-level result changed, and this release does not
+claim distributed execution, full verl compatibility or quality superiority.
 
 ## [0.9.1] - 2026-08-13
 
@@ -976,7 +1013,9 @@ Same-tokenizer only; one trajectory per forward pass; `swap` unavailable for
 quantized models; only Qwen3 and Qwen2 architectures tested; single-seed GPU
 results. The full list is in `docs/limitations.md`.
 
-[Unreleased]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.9.1...v0.10.0
+[0.9.1]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.7.1...v0.8.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 title: "miniVERL: A bounded single-GPU runtime for verl-style OPD"
 message: "If you use miniVERL in your work, please cite it as below."
 type: software
-version: 0.9.1
-date-released: 2026-08-13
+version: 0.10.0
+date-released: 2026-08-14
 license: Apache-2.0
 repository-code: "https://github.com/DaoyuanLi2816/mini-verl"
 url: "https://github.com/DaoyuanLi2816/mini-verl"

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -6,12 +6,11 @@ current product and evidence state rather than repeating release history.
 
 Last updated: 2026-08-14.
 
-Canonical release state: stable `v0.9.1` (`6c0f3d818c10419e0bfba81f3ad1c5adf24eaf09`), development `0.10.0.dev0`.
+Canonical release state: releasing `v0.10.0`.
 
 ## Release state
 
-- Stable: `v0.9.1` at `6c0f3d818c10419e0bfba81f3ad1c5adf24eaf09`.
-- Development: `0.10.0.dev0`.
+- Release candidate: `v0.10.0` (release commit pending).
 - Stable docs: <https://daoyuanli2816.github.io/mini-verl/>.
 - Development docs: <https://daoyuanli2816.github.io/mini-verl/dev/>.
 - Historical build log: [v0.1-v0.9 archive](docs/history/project-state-v0.1-v0.9.md).

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — run verl-style OPD on one consumer GPU" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.10.0/docs/banner.svg" alt="miniVERL — run verl-style OPD on one consumer GPU" width="880">
 </p>
 
 <div align="center">
@@ -8,7 +8,7 @@
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/LICENSE)
 
 </div>
 
@@ -16,7 +16,7 @@
   <a href="https://pypi.org/project/miniverl/"><strong>PyPI</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/"><strong>Stable docs</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/dev/">Development docs</a> ·
-  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/main/README.zh-CN.md">中文</a>
+  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/README.zh-CN.md">中文</a>
 </p>
 
 **Run a documented subset of verl-style on-policy distillation on one consumer
@@ -25,7 +25,7 @@ rollout → teacher scoring → actor update, records every local reinterpretati
 and exports standard PEFT, Parquet and config artifacts for a pinned scale-out
 handoff.
 
-PyPI `v0.9.1` is stable; `main` is development. miniVERL is an independent
+PyPI `v0.10.0` is stable; `main` is development. miniVERL is an independent
 project with no upstream endorsement. It does not execute arbitrary verl YAML,
 launch distributed jobs, or claim full algorithmic compatibility.
 
@@ -51,14 +51,14 @@ recipe and produce an inspectable PEFT adapter.
 
 The `train` extra installs the ML runtime, but does not choose the correct CUDA
 PyTorch wheel. The optional `cuda` extra adds bitsandbytes only. Follow the
-[one-GPU installation and memory guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) before a real
+[one-GPU installation and memory guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/docs/single-gpu-guide.md) before a real
 run.
 
 ## Architecture
 
 <picture>
-  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime-mobile.svg">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime.svg" alt="verl-shaped YAML, overrides and Parquet prompts pass through a typed compiler; one CUDA GPU runs actor rollout, teacher scoring and actor update; inspectable artifacts can be handed to pinned verl while distributed execution remains outside miniVERL.">
+  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.10.0/docs/verl-local-runtime-mobile.svg">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.10.0/docs/verl-local-runtime.svg" alt="verl-shaped YAML, overrides and Parquet prompts pass through a typed compiler; one CUDA GPU runs actor rollout, teacher scoring and actor update; inspectable artifacts can be handed to pinned verl while distributed execution remains outside miniVERL.">
 </picture>
 
 miniVERL uses one ordinary process and schedules model roles in phases. It does
@@ -114,13 +114,13 @@ miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml \
 
 External YAML must explicitly accept the high-risk local mappings printed by
 `plan` before `run`; the packaged profile carries a value-bound reviewed
-manifest. [Override precedence and safe input forms](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/config-overrides.md)
+manifest. [Override precedence and safe input forms](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/docs/config-overrides.md)
 are documented without executing Hydra interpolation or shell text.
 
 The public built-in profile deliberately uses upstream-shaped `name: vllm`
 values. miniVERL classifies both rollout and teacher engine names as local
 reinterpretations and executes them with sequential local HF phases; this is
-not vLLM equivalence. See [For verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/for-verl-users.md) for config,
+not vLLM equivalence. See [For verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/docs/for-verl-users.md) for config,
 data, role and error mappings.
 
 ## Tested profile boundary
@@ -161,12 +161,12 @@ with a 64-token response bound, and completed **8 current-policy updates** at
 **3.1914 GiB peak reserved VRAM**. Median steady-state rollout, teacher-scoring
 and update times were 9.7200, 0.4864 and 2.3260 seconds. A matched 4-update
 interruption resumed to the same byte-identical trajectories, adapter and
-optimizer tensors. See the [data-bound figure and full record](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-opd-reference-workload.md);
-the original one-update [pip smoke](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/opd-quickstart.md) remains preserved.
+optimizer tensors. See the [data-bound figure and full record](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/docs/verl-opd-reference-workload.md);
+the original one-update [pip smoke](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/docs/opd-quickstart.md) remains preserved.
 A separate pinned SmolLM2-360M/1.7B recipe consumed 32 distinct prompts across
 8 updates at 1.4961 GiB peak reserved VRAM. Interruption/resume was
 byte-identical, PEFT reload passed, and the exact-snapshot scale-out bundle
-materialized successfully. See the [full SmolLM2 systems record](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/smollm2-opd-workload.md).
+materialized successfully. See the [full SmolLM2 systems record](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/docs/smollm2-opd-workload.md).
 
 This is deliberately a runtime and artifact proof. It is not a throughput
 benchmark, an alignment-quality endpoint, or evidence that OPD beats SFT, DPO
@@ -186,7 +186,7 @@ Automatic BF16/FP16 selection follows device support; it is not inferred from
 marketing names such as 3070, 4080, 5090 or Titan. `miniverl doctor` reports the
 installed CUDA/PyTorch path. Normal planning is weight-free; explicit
 `plan --probe` adds bounded, cached CUDA measurements with zero optimizer
-updates. See [hardware planning](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/hardware-planning.md). There is no
+updates. See [hardware planning](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/docs/hardware-planning.md). There is no
 automatic downgrade to a different model,
 teacher, context, top-k or loss when memory is tight.
 
@@ -198,7 +198,7 @@ miniverl hardware validate hardware-record.json
 ```
 
 Community records remain unreviewed until their hashes and provenance pass the
-[documented maintainer gate](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/community-benchmarks.md).
+[documented maintainer gate](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/docs/community-benchmarks.md).
 
 ## Data and artifact interoperability
 
@@ -224,30 +224,30 @@ The v0.9 export preserves student/teacher identities, Parquet bytes and pure
 OPD overrides, but reports `launchable: false` until exact base snapshots are
 materialized and validated against the installed pinned verl commit. Only then
 does `bridge materialize` publish a checksummed `launch.sh`; distributed
-execution remains untested. Review the [current scale-out contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-opd-scaleout.md),
-[legacy bridge](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/legacy-verl-bridge.md) and [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md).
+execution remains untested. Review the [current scale-out contract](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/docs/verl-opd-scaleout.md),
+[legacy bridge](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/docs/legacy-verl-bridge.md) and [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/docs/compatibility.md).
 
 The intended operating loop is **plan → inspect → run → inspect → export**.
 `plan --out` byte-binds the YAML, ordered overrides and scanned Parquet inputs
 to the exact native config; `run --plan` rejects drift before loading weights.
 Its digest follows the run manifest, teacher cache and checkpoints. Direct
 `run --config` remains available for experiments. See [immutable execution
-plans](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/immutable-plans.md).
+plans](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/docs/immutable-plans.md).
 
 ## Research and validation
 
 miniVERL keeps every measured study—including negative results, superseded
 runs and preregistered early stops—public under the documentation. None is used
 as a claim that OPD universally beats SFT, DPO or KD: see the
-[v0.7 External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-external/alignment-external-v1.md),
-[Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md),
-[RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md), and the
-[calculator study](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md).
+[v0.7 External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/docs/alignment-external/alignment-external-v1.md),
+[Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/docs/alignment-lab/alignment-lab-v1.md),
+[RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/docs/recoverybench/recoverybench-v1.md), and the
+[calculator study](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/docs/benchmarking.md).
 
 New runs establish tokenizer compatibility through structural identity. The
 legacy behavioral fingerprint is retained only for migration and is not an
 identity proof. Scientific caveats and immutable source hashes remain in the
-detailed reports and [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md).
+detailed reports and [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/docs/limitations.md).
 
 ## Development, security and license
 
@@ -260,6 +260,6 @@ pytest -q -m "not gpu and not network"
 
 Contributions should keep the one-GPU boundary explicit and include tests for
 new failure modes. Report vulnerabilities privately through
-[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md). See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md), the
-[changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md), [citation metadata](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff),
-[reproducibility guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/reproducibility.md), and [Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE).
+[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/SECURITY.md). See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/CONTRIBUTING.md), the
+[changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/CHANGELOG.md), [citation metadata](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/CITATION.cff),
+[reproducibility guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/docs/reproducibility.md), and [Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.0/LICENSE).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ rollout → teacher scoring → actor update, records every local reinterpretati
 and exports standard PEFT, Parquet and config artifacts for a pinned scale-out
 handoff.
 
-PyPI `v0.9.1` is stable; `main` is development. miniVERL is an independent
+PyPI `v0.10.0` is stable; `main` is development. miniVERL is an independent
 project with no upstream endorsement. It does not execute arbitrary verl YAML,
 launch distributed jobs, or claim full algorithmic compatibility.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,7 +23,7 @@ verl 风格 YAML 与 Parquet prompt，在本地依次执行 actor rollout → te
 actor update，记录每个本地语义重解释，并导出标准 PEFT、Parquet 与配置产物供固定版本
 的 verl 接手扩展。
 
-PyPI `v0.9.1` 是稳定版；`main` 是开发版。miniVERL 是独立项目，不代表上游背书；它
+PyPI `v0.10.0` 是稳定版；`main` 是开发版。miniVERL 是独立项目，不代表上游背书；它
 不执行任意 verl YAML、不启动分布式任务，也不声称完整的算法兼容性。
 
 ## 仅用 pip 的快速开始

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -1,50 +1,37 @@
 {
   "schema_version": 2,
-  "release": "0.9.1",
-  "status": "released",
-  "quality_floor": "2,000+ tests and 80%+ branch coverage at v0.9.1",
+  "release": "0.10.0",
+  "status": "candidate",
+  "quality_floor": "2,000+ tests and 80%+ branch coverage at v0.10.0",
   "local_validation": {
     "scope": "the maintainer's workstation, where the GPU and Windows-specific paths actually run",
-    "commit": "7dd7bdbf65207e15fdebed7e9ceb0eb82883046a",
-    "commit_relationship": "final release PR head; the squash merge carries the same product tree",
-    "measured_at": "2026-08-13T22:10:22-07:00",
+    "commit": "b2157301e5d0fd5652d8a1bd02fbf5e87735f9d3",
+    "commit_relationship": "final product head before release-only metadata; merge 0749e58 carries the same tree and passed the full required CI matrix",
+    "measured_at": "2026-08-14T01:32:04-07:00",
     "platform": "Windows 11",
-    "python": "CPython 3.10 for coverage, local CUDA tests and the clean public CUDA install",
+    "python": "CPython 3.10 for coverage, local CUDA and network tests",
     "coverage_mode": "branch",
     "cpu_non_gpu_non_network": {
-      "passed": 2234,
-      "skipped": 10,
+      "passed": 2300,
+      "skipped": 7,
       "deselected": 22,
-      "branch_coverage_percent": 83.98,
-      "skip_reason": "eight platform or privilege skips plus two pinned-verl conformance skips while the official package was intentionally absent from the general environment; all three pinned checks ran separately"
+      "branch_coverage_percent": 83.70,
+      "skip_reason": "seven Windows platform or privilege skips; pinned-verl and package gates ran separately"
     },
     "gpu": {
       "passed": 8,
       "hardware": "NVIDIA GeForce RTX 4080"
     },
     "network": {
-      "passed": 15
+      "passed": 16
     }
   },
   "release_validation": {
-    "scope": "the exact immutable v0.9.1 release commit",
-    "commit": "6c0f3d818c10419e0bfba81f3ad1c5adf24eaf09",
-    "workflows": {
-      "ci": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31772652832",
-      "build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31772652856",
-      "docs": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31772945978",
-      "pinned_verl_bridge": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31772652801",
-      "release": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31772945981"
-    },
-    "conclusion": "success",
+    "scope": "the exact immutable v0.10.0 release commit",
+    "commit": "pending",
+    "workflows": {},
+    "conclusion": "pending",
     "gpu_coverage": "none; no GPU runner is configured for this repository, so the GPU counts above exist only from the local measurement",
-    "publication": {
-      "pypi": "https://pypi.org/project/miniverl/0.9.1/",
-      "github_release": "https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.9.1",
-      "documentation": "https://daoyuanli2816.github.io/mini-verl/",
-      "immutable_documentation_build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31772945978",
-      "wheel_sha256": "3cf1bd61b915e8ae57e0cccdc6ca9c017bbe5bcf1b81ac7ed20c7c9ed9808825",
-      "sdist_sha256": "9fc4e63d6efb70a0b635af4f61c4b01a99d3496634841d7a8e8e6d8d06784e9e"
-    }
+    "publication": null
   }
 }

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  <div class="docs-channel" data-stable-version="0.9.1" data-dev-version="0.10.0.dev0">
+  <div class="docs-channel" data-stable-version="0.10.0" data-dev-version="0.10.0">
     <strong id="docs-channel-label">Stable documentation</strong>
     <label for="docs-version-selector">Version</label>
     <select id="docs-version-selector" aria-label="Documentation version">
-      <option value="stable">Stable 0.9.1</option>
-      <option value="dev">Development 0.10.0.dev0</option>
+      <option value="stable">Stable 0.10.0</option>
+      <option value="dev">Development 0.10.0</option>
     </select>
   </div>
 {% endblock %}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -13,8 +13,12 @@ after the exact release commit and its remote checks are green.
       freshness, resume and export conformance.
 - [x] Publish bounded RTX 4080 systems evidence for PG k1 and a full SmolLM2
       direct-GKD developer recipe; do not add a task-quality benchmark.
-- [x] Add validated community hardware records and document the measured or
-      explicitly unmeasured Linux/WSL state.
+- [x] Add a validation schema and CLI for community hardware records and
+      document the measured or explicitly unmeasured Linux/WSL state.
+- [x] Pass the local CPU, GPU, network, packaging, docs, generated-artifact,
+      privacy, link and owner-only authorship gates on the release candidate.
+- [x] Preserve the frozen calculator artifact at SHA-256
+      `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`.
 
 ## v0.9.1 development
 

--- a/release-state.yaml
+++ b/release-state.yaml
@@ -17,13 +17,13 @@
 # such distinction, which is how its tag shipped a docs selector still
 # advertising "Stable 0.6.1 / Development 0.6.2.dev0".
 schema_version: 1
-phase: development
+phase: release
 
 stable:
-  version: "0.9.1"
-  tag: "v0.9.1"
-  release_commit: "6c0f3d818c10419e0bfba81f3ad1c5adf24eaf09"
-  released_at: "2026-08-13"
+  version: "0.10.0"
+  tag: "v0.10.0"
+  release_commit: "pending"
+  released_at: "2026-08-14"
 
 development:
-  version: "0.10.0.dev0"
+  version: "0.10.0"

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.10.0.dev0"
+__version__ = "0.10.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Release scope

- finalize v0.10.0 metadata for the versioned compatibility-profile platform
- release the pinned sampled-k1 policy-gradient OPD profile
- include measured Qwen3 PG, full SmolLM2 direct-GKD, and WSL2 systems evidence
- include strict private-by-default community hardware records

No frozen benchmark or task-level result changed. This release does not claim distributed execution, full verl compatibility, or quality superiority.

## Candidate validation

- CPU/non-GPU/non-network: 2300 passed, 7 skipped, 22 deselected; 83.70% coverage
- GPU: 8 passed on one RTX 4080
- network: 16 passed
- Python 3.10-3.13 core, minimum/latest training, Transformers 4.51/5.x: green on product main
- package/extracted-sdist, strict docs/browser, pinned verl bridge: green on product main
- release metadata/package/docs focused tests: 134 passed
- frozen calculator SHA-256: 53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc