### PR TITLE
Harden exact-SHA GPU qualification and maintainer release gates

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,4 @@
 self-hosted-runner:
   labels:
     - cuda
+    - rtx4080

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
               "CODE_OF_CONDUCT.md",
               "SECURITY.md",
               "PROJECT_STATE.md",
+              "environments/known-good-rtx4080-cu130.json",
+              "environments/known-good-rtx4080-cu130.txt",
               "LICENSE",
               "README.md",
           ):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
         run: |
           python scripts/build_pypi_readme.py --check
           python scripts/release_state.py --check
+          python scripts/check_known_good_environment.py
+          python scripts/publish_gpu_qualification_schema.py --check
           python scripts/check_markdown_links.py
           python scripts/check_text_integrity.py
           miniverl --help

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,6 +35,8 @@ jobs:
           python scripts/publish_verl_bridge_diagrams.py --check
           python scripts/publish_verl_opd_compatibility.py --check
           python scripts/publish_hardware_record_schema.py --check
+          python scripts/publish_gpu_qualification_schema.py --check
+          python scripts/check_known_good_environment.py
       - name: Build complete development site strictly
         run: mkdocs build --strict
       - name: Install deterministic Chromium

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -1,74 +1,144 @@
 name: gpu
 
-# Manual only. There is no GPU runner configured for this repository, so this
-# workflow is never part of a required check -- it exists so that a maintainer
-# with a self-hosted CUDA runner (Actions Runner >= 2.327.1 for Node 24 actions)
-# can execute the GPU tests on demand, and so the
-# exact commands are version-controlled rather than living in someone's shell
-# history.
-#
-# To use it, register a self-hosted runner with the label `cuda` and dispatch
-# this workflow. Without such a runner the job will simply stay queued; that is
-# expected and is not a failure of the project.
-
+# Manual, maintainer-operated qualification on the one measured workstation.
+# This is not hosted GPU CI and is not a required pull-request check. Registering
+# the private runner is an external maintainer action; without it this workflow
+# remains queued and no qualification may be claimed.
 on:
   workflow_dispatch:
     inputs:
-      run_recipe:
-        description: "Also run the full single-GPU recipe (slow, ~10 minutes)"
+      qualification_level:
+        description: "Release smoke, or all three canonical full workloads"
+        type: choice
+        required: true
+        default: smoke
+        options:
+          - smoke
+          - full
+      offline:
+        description: "Require all pinned model snapshots to be present locally"
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
+concurrency:
+  group: gpu-qualification-${{ github.sha }}
+  cancel-in-progress: false
+
 jobs:
-  gpu-tests:
-    name: gpu tests (self-hosted cuda)
-    runs-on: [self-hosted, cuda]
-    timeout-minutes: 120
+  qualify:
+    name: exact-commit RTX 4080 qualification
+    runs-on: [self-hosted, cuda, rtx4080]
+    timeout-minutes: 360
+    defaults:
+      run:
+        shell: pwsh
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
 
-      - name: Environment
+      - name: Verify the dedicated measured device
         run: |
+          $name = nvidia-smi --query-gpu=name --format=csv,noheader
+          if (($name | Measure-Object).Count -ne 1) { throw "exactly one visible GPU is required" }
+          if ($name.Trim() -ne "NVIDIA GeForce RTX 4080") { throw "unexpected GPU: $name" }
           nvidia-smi
           python --version
 
-      - name: Install
+      - name: Build source distributions from the exact checkout
         run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev,train,cuda]"
+          python -m pip install --upgrade pip build
+          python -m build
+          $wheel = Get-ChildItem -LiteralPath dist -Filter '*.whl'
+          if (($wheel | Measure-Object).Count -ne 1) { throw "expected exactly one wheel" }
+          New-Item -ItemType Directory -Path qualification | Out-Null
+          Copy-Item -LiteralPath $wheel.FullName -Destination qualification
+          "QUALIFICATION_WHEEL=$((Resolve-Path (Join-Path qualification $wheel.Name)).Path)" | Out-File -FilePath $env:GITHUB_ENV -Append
 
-      - name: doctor
+      - name: Install the wheel into a clean known-good environment
         run: |
-          miniverl doctor
-          miniverl doctor --json > doctor.json
-          python -c "import json; d=json.load(open('doctor.json')); assert d['verdict']['gpu_training'] is True"
+          python -m venv .gpu-qualification-venv
+          $python = (Resolve-Path '.gpu-qualification-venv/Scripts/python.exe').Path
+          & $python -m pip install --upgrade pip
+          & $python -m pip install 'torch==2.13.0+cu130' --index-url https://download.pytorch.org/whl/cu130
+          & $python -m pip install "$env:QUALIFICATION_WHEEL[train,cuda]" --constraint environments/known-good-rtx4080-cu130.txt
+          (Resolve-Path '.gpu-qualification-venv/Scripts').Path | Out-File -FilePath $env:GITHUB_PATH -Append
+          "QUALIFICATION_PYTHON=$python" | Out-File -FilePath $env:GITHUB_ENV -Append
 
-      - name: GPU tests
-        run: pytest -q -m gpu -ra
-
-      - name: Full single-GPU recipe
-        if: ${{ inputs.run_recipe }}
-        env:
-          MINIVERL_LOG_LEVEL: INFO
+      - name: Run wheel-installed release smoke
         run: |
-          miniverl train recipes/qwen_consumer_gpu_calc.yaml --output runs --run-id ci-4080 --json > train.json
-          miniverl eval --run runs/ci-4080 --split test --json > eval.json
-          miniverl report runs/ci-4080 --out runs/ci-4080/report.html
-          miniverl export-benchmark runs/ci-4080 --out runs/ci-4080/benchmark-submission.json
-          python - <<'PY'
-          import json
-          from miniverl.evaluation.schema import BenchmarkResult
-          BenchmarkResult.model_validate(json.load(open("runs/ci-4080/benchmark-submission.json")))
-          print("submission validates against the published schema")
-          PY
+          $offline = @()
+          if ('${{ inputs.offline }}' -eq 'true') { $offline = @('--offline') }
+          & $env:QUALIFICATION_PYTHON scripts/run_gpu_qualification.py `
+            --commit $env:GITHUB_SHA `
+            --wheel $env:QUALIFICATION_WHEEL `
+            --known-good environments/known-good-rtx4080-cu130.json `
+            --output qualification `
+            --work qualification-work `
+            @offline
+          & $env:QUALIFICATION_PYTHON scripts/validate_gpu_qualification.py `
+            qualification/qualification.json `
+            --commit $env:GITHUB_SHA `
+            --required-gpu-name 'NVIDIA GeForce RTX 4080'
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - name: Run GPU regression tests
+        run: '& $env:QUALIFICATION_PYTHON -m pytest -q -m gpu -ra'
+
+      - name: Run full canonical qualification workloads
+        if: ${{ inputs.qualification_level == 'full' }}
+        run: |
+          $offline = @()
+          if ('${{ inputs.offline }}' -eq 'true') { $offline = @('--offline') }
+          New-Item -ItemType Directory -Path qualification-full | Out-Null
+          & $env:QUALIFICATION_PYTHON scripts/run_verl_opd_reference_workload.py `
+            --out qualification-full-work/direct `
+            --result qualification-full/direct.json `
+            @offline
+          & $env:QUALIFICATION_PYTHON scripts/run_verl_pg_k1_workload.py `
+            --out qualification-full-work/pg-k1 `
+            --result qualification-full/pg-k1.json `
+            @offline
+          & $env:QUALIFICATION_PYTHON scripts/run_smollm2_opd_reference_workload.py `
+            --out qualification-full-work/smollm2 `
+            --result qualification-full/smollm2.json `
+            @offline
+          & $env:QUALIFICATION_PYTHON scripts/promote_full_gpu_qualification.py `
+            --qualification qualification/qualification.json `
+            --direct qualification-full/direct.json `
+            --pg-k1 qualification-full/pg-k1.json `
+            --smollm2 qualification-full/smollm2.json
+
+      - name: Upload exact-commit release smoke
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: gpu-run
-          path: |
-            runs/ci-4080/manifest.json
-            runs/ci-4080/eval.json
-            runs/ci-4080/summary.md
-            runs/ci-4080/benchmark-submission.json
-          if-no-files-found: ignore
+          name: gpu-release-smoke
+          path: qualification/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload full qualification records
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ always() && inputs.qualification_level == 'full' }}
+        with:
+          name: gpu-full-qualification
+          path: qualification/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Remove runner-local environments and model-free work products
+        if: always()
+        run: |
+          foreach ($relative in @('.gpu-qualification-venv', 'qualification-work', 'qualification-full-work')) {
+            if (Test-Path -LiteralPath $relative) {
+              $target = (Resolve-Path -LiteralPath $relative).Path
+              $workspace = (Resolve-Path -LiteralPath $env:GITHUB_WORKSPACE).Path
+              if (-not $target.StartsWith($workspace, [System.StringComparison]::OrdinalIgnoreCase)) {
+                throw "refusing cleanup outside workspace: $target"
+              }
+              Remove-Item -LiteralPath $target -Recurse -Force
+            }
+          }

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -32,6 +32,8 @@ jobs:
     name: exact-commit RTX 4080 qualification
     runs-on: [self-hosted, cuda, rtx4080]
     timeout-minutes: 360
+    env:
+      PYTHONUTF8: "1"
     defaults:
       run:
         shell: pwsh
@@ -92,6 +94,8 @@ jobs:
         run: |
           $offline = @()
           if ('${{ inputs.offline }}' -eq 'true') { $offline = @('--offline') }
+          & $env:QUALIFICATION_PYTHON -m pip install 'hydra-core>=1.3,<2'
+          & $env:QUALIFICATION_PYTHON -m pip install --no-deps 'git+https://github.com/verl-project/verl.git@7aed6b230776f963fa09509c10d9c3a767d1102c'
           New-Item -ItemType Directory -Path qualification-full | Out-Null
           & $env:QUALIFICATION_PYTHON scripts/run_verl_opd_reference_workload.py `
             --out qualification-full-work/direct `

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -1,9 +1,7 @@
 name: gpu
 
-# Manual, maintainer-operated qualification on the one measured workstation.
-# This is not hosted GPU CI and is not a required pull-request check. Registering
-# the private runner is an external maintainer action; without it this workflow
-# remains queued and no qualification may be claimed.
+# Manual maintainer qualification. The hosted job builds the only candidate
+# bytes; the private RTX 4080 job downloads and qualifies that same artifact.
 on:
   workflow_dispatch:
     inputs:
@@ -12,9 +10,7 @@ on:
         type: choice
         required: true
         default: smoke
-        options:
-          - smoke
-          - full
+        options: [smoke, full]
       offline:
         description: "Require all pinned model snapshots to be present locally"
         type: boolean
@@ -28,12 +24,46 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  build-candidate:
+    name: build candidate distributions once
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Build the closed candidate byte set
+        run: |
+          python -m pip install --disable-pip-version-check \
+            build==1.5.0 hatchling==1.32.0 twine==7.0.0 \
+            pydantic==2.13.4 PyYAML==6.0.3
+          python scripts/build_release_candidate.py \
+            --output candidate \
+            --commit "$GITHUB_SHA"
+          python scripts/build_release_candidate.py \
+            --output candidate \
+            --commit "$GITHUB_SHA" \
+            --check
+      - name: Upload the only candidate distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: candidate-distributions
+          path: candidate/
+          if-no-files-found: error
+          retention-days: 90
+
   qualify:
-    name: exact-commit RTX 4080 qualification
+    name: qualify exact candidate on RTX 4080
+    needs: build-candidate
     runs-on: [self-hosted, cuda, rtx4080]
     timeout-minutes: 360
     env:
       PYTHONUTF8: "1"
+      PYTHONPATH: ""
+      PYTHONHOME: ""
     defaults:
       run:
         shell: pwsh
@@ -41,7 +71,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-
+      - name: Download this run's candidate distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: candidate-distributions
+          path: candidate
       - name: Verify the dedicated measured device
         run: |
           $name = nvidia-smi --query-gpu=name --format=csv,noheader
@@ -49,46 +83,53 @@ jobs:
           if ($name.Trim() -ne "NVIDIA GeForce RTX 4080") { throw "unexpected GPU: $name" }
           nvidia-smi
           python --version
-
-      - name: Build source distributions from the exact checkout
-        run: |
-          python -m pip install --upgrade pip build
-          python -m build
-          $wheel = Get-ChildItem -LiteralPath dist -Filter '*.whl'
-          if (($wheel | Measure-Object).Count -ne 1) { throw "expected exactly one wheel" }
-          New-Item -ItemType Directory -Path qualification | Out-Null
-          Copy-Item -LiteralPath $wheel.FullName -Destination qualification
-          "QUALIFICATION_WHEEL=$((Resolve-Path (Join-Path qualification $wheel.Name)).Path)" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Install the wheel into a clean known-good environment
+      - name: Validate candidate before installation
         run: |
           python -m venv .gpu-qualification-venv
           $python = (Resolve-Path '.gpu-qualification-venv/Scripts/python.exe').Path
           & $python -m pip install --upgrade pip
-          & $python -m pip install 'torch==2.13.0+cu130' --index-url https://download.pytorch.org/whl/cu130
-          & $python -m pip install "$env:QUALIFICATION_WHEEL[train,cuda]" --constraint environments/known-good-rtx4080-cu130.txt
-          (Resolve-Path '.gpu-qualification-venv/Scripts').Path | Out-File -FilePath $env:GITHUB_PATH -Append
+          & $python -m pip install pydantic==2.13.4 PyYAML==6.0.3
+          & $python scripts/build_release_candidate.py `
+            --output candidate `
+            --commit $env:GITHUB_SHA `
+            --repository $env:GITHUB_REPOSITORY `
+            --workflow-path .github/workflows/gpu.yml `
+            --run-id $env:GITHUB_RUN_ID `
+            --run-attempt $env:GITHUB_RUN_ATTEMPT `
+            --check
+          $manifest = Get-Content -Raw -LiteralPath 'candidate/candidate-manifest.json' | ConvertFrom-Json
+          $wheel = (Resolve-Path (Join-Path 'candidate' $manifest.wheel.filename)).Path
+          "QUALIFICATION_WHEEL=$wheel" | Out-File -FilePath $env:GITHUB_ENV -Append
           "QUALIFICATION_PYTHON=$python" | Out-File -FilePath $env:GITHUB_ENV -Append
-
+      - name: Install the exact candidate wheel
+        run: |
+          & $env:QUALIFICATION_PYTHON -m pip install 'torch==2.13.0+cu130' --index-url https://download.pytorch.org/whl/cu130
+          & $env:QUALIFICATION_PYTHON -m pip install "$env:QUALIFICATION_WHEEL[dev,train,cuda]" --constraint environments/known-good-rtx4080-cu130.txt
+          (Resolve-Path '.gpu-qualification-venv/Scripts').Path | Out-File -FilePath $env:GITHUB_PATH -Append
       - name: Run wheel-installed release smoke
         run: |
           $offline = @()
           if ('${{ inputs.offline }}' -eq 'true') { $offline = @('--offline') }
+          New-Item -ItemType Directory -Path qualification | Out-Null
+          Copy-Item -LiteralPath $env:QUALIFICATION_WHEEL -Destination qualification
           & $env:QUALIFICATION_PYTHON scripts/run_gpu_qualification.py `
             --commit $env:GITHUB_SHA `
-            --wheel $env:QUALIFICATION_WHEEL `
+            --wheel (Join-Path 'qualification' (Split-Path $env:QUALIFICATION_WHEEL -Leaf)) `
+            --candidate-manifest candidate/candidate-manifest.json `
             --known-good environments/known-good-rtx4080-cu130.json `
             --output qualification `
             --work qualification-work `
             @offline
+          $candidate = Get-Content -Raw candidate/candidate-manifest.json | ConvertFrom-Json
+          $manifestSha = (Get-FileHash -Algorithm SHA256 candidate/candidate-manifest.json).Hash.ToLower()
           & $env:QUALIFICATION_PYTHON scripts/validate_gpu_qualification.py `
             qualification/qualification.json `
             --commit $env:GITHUB_SHA `
+            --wheel-sha256 $candidate.wheel.sha256 `
+            --candidate-manifest-sha256 $manifestSha `
             --required-gpu-name 'NVIDIA GeForce RTX 4080'
-
       - name: Run GPU regression tests
         run: '& $env:QUALIFICATION_PYTHON -m pytest -q -m gpu -ra'
-
       - name: Run full canonical qualification workloads
         if: ${{ inputs.qualification_level == 'full' }}
         run: |
@@ -97,24 +138,14 @@ jobs:
           & $env:QUALIFICATION_PYTHON -m pip install 'hydra-core>=1.3,<2'
           & $env:QUALIFICATION_PYTHON -m pip install --no-deps 'git+https://github.com/verl-project/verl.git@7aed6b230776f963fa09509c10d9c3a767d1102c'
           New-Item -ItemType Directory -Path qualification-full | Out-Null
-          & $env:QUALIFICATION_PYTHON scripts/run_verl_opd_reference_workload.py `
-            --out qualification-full-work/direct `
-            --result qualification-full/direct.json `
-            @offline
-          & $env:QUALIFICATION_PYTHON scripts/run_verl_pg_k1_workload.py `
-            --out qualification-full-work/pg-k1 `
-            --result qualification-full/pg-k1.json `
-            @offline
-          & $env:QUALIFICATION_PYTHON scripts/run_smollm2_opd_reference_workload.py `
-            --out qualification-full-work/smollm2 `
-            --result qualification-full/smollm2.json `
-            @offline
+          & $env:QUALIFICATION_PYTHON scripts/run_verl_opd_reference_workload.py --out qualification-full-work/direct --result qualification-full/direct.json @offline
+          & $env:QUALIFICATION_PYTHON scripts/run_verl_pg_k1_workload.py --out qualification-full-work/pg-k1 --result qualification-full/pg-k1.json @offline
+          & $env:QUALIFICATION_PYTHON scripts/run_smollm2_opd_reference_workload.py --out qualification-full-work/smollm2 --result qualification-full/smollm2.json @offline
           & $env:QUALIFICATION_PYTHON scripts/promote_full_gpu_qualification.py `
             --qualification qualification/qualification.json `
             --direct qualification-full/direct.json `
             --pg-k1 qualification-full/pg-k1.json `
             --smollm2 qualification-full/smollm2.json
-
       - name: Upload exact-commit release smoke
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
@@ -122,8 +153,7 @@ jobs:
           name: gpu-release-smoke
           path: qualification/
           if-no-files-found: error
-          retention-days: 30
-
+          retention-days: 90
       - name: Upload full qualification records
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ always() && inputs.qualification_level == 'full' }}
@@ -131,18 +161,15 @@ jobs:
           name: gpu-full-qualification
           path: qualification/
           if-no-files-found: error
-          retention-days: 30
-
-      - name: Remove runner-local environments and model-free work products
+          retention-days: 90
+      - name: Remove runner-local environments and model work products
         if: always()
         run: |
           foreach ($relative in @('.gpu-qualification-venv', 'qualification-work', 'qualification-full-work')) {
             if (Test-Path -LiteralPath $relative) {
               $target = (Resolve-Path -LiteralPath $relative).Path
               $workspace = (Resolve-Path -LiteralPath $env:GITHUB_WORKSPACE).Path
-              if (-not $target.StartsWith($workspace, [System.StringComparison]::OrdinalIgnoreCase)) {
-                throw "refusing cleanup outside workspace: $target"
-              }
+              if (-not $target.StartsWith($workspace, [System.StringComparison]::OrdinalIgnoreCase)) { throw "refusing cleanup outside workspace: $target" }
               Remove-Item -LiteralPath $target -Recurse -Force
             }
           }

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -29,6 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - name: Require a fresh workflow dispatch
+        run: |
+          if [ "$GITHUB_RUN_ATTEMPT" != "1" ]; then
+            echo "::error::GPU qualification cannot use a rerun attempt; start a new workflow_dispatch run."
+            exit 1
+          fi
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
@@ -68,6 +74,11 @@ jobs:
       run:
         shell: pwsh
     steps:
+      - name: Require a fresh workflow dispatch
+        run: |
+          if ($env:GITHUB_RUN_ATTEMPT -ne "1") {
+            throw "GPU qualification cannot use a rerun attempt; start a new workflow_dispatch run."
+          }
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
@@ -130,6 +141,13 @@ jobs:
             --required-gpu-name 'NVIDIA GeForce RTX 4080'
       - name: Run GPU regression tests
         run: '& $env:QUALIFICATION_PYTHON -m pytest -q -m gpu -ra'
+      - name: Upload exact-commit release smoke
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gpu-release-smoke
+          path: qualification/
+          if-no-files-found: error
+          retention-days: 90
       - name: Run full canonical qualification workloads
         if: ${{ inputs.qualification_level == 'full' }}
         run: |
@@ -146,17 +164,9 @@ jobs:
             --direct qualification-full/direct.json `
             --pg-k1 qualification-full/pg-k1.json `
             --smollm2 qualification-full/smollm2.json
-      - name: Upload exact-commit release smoke
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: always()
-        with:
-          name: gpu-release-smoke
-          path: qualification/
-          if-no-files-found: error
-          retention-days: 90
       - name: Upload full qualification records
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ always() && inputs.qualification_level == 'full' }}
+        if: ${{ success() && inputs.qualification_level == 'full' }}
         with:
           name: gpu-full-qualification
           path: qualification/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,23 +9,20 @@ permissions:
   contents: read
 
 jobs:
-  verify-gpu-qualification:
-    name: verify exact-commit RTX 4080 qualification
+  verify-qualified-candidate:
+    name: accept same-run exact-SHA qualified candidate
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-
       - name: Install torch-free validator dependencies
         run: python -m pip install .
-
-      - name: Fetch and validate the exact-SHA workflow artifact
+      - name: Fetch candidate and qualification from one successful GPU run
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -33,22 +30,22 @@ jobs:
             --repository "$GITHUB_REPOSITORY" \
             --workflow gpu.yml \
             --commit "$GITHUB_SHA" \
-            --artifact-name gpu-release-smoke \
+            --candidate-artifact-name candidate-distributions \
+            --qualification-artifact-name gpu-release-smoke \
             --required-gpu-name "NVIDIA GeForce RTX 4080" \
             --known-good environments/known-good-rtx4080-cu130.json \
-            --output verified-gpu-qualification
-
-      - name: Preserve the verified qualification for distribution binding
+            --output verified-qualified-candidate
+      - name: Preserve the verified byte chain
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: verified-gpu-qualification
-          path: verified-gpu-qualification/
+          name: verified-qualified-candidate
+          path: verified-qualified-candidate/
           if-no-files-found: error
           retention-days: 14
 
   validate-and-test:
-    name: validate metadata and run release gates
-    needs: verify-gpu-qualification
+    name: validate metadata, source and the accepted candidate
+    needs: verify-qualified-candidate
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -56,163 +53,120 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-
-      - name: Install test dependencies
+      - name: Download the accepted same-run pair
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: verified-qualified-candidate
+          path: ${{ runner.temp }}/verified-qualified-candidate
+      - name: Install release-gate dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install torch --index-url https://download.pytorch.org/whl/cpu
-          pip install -e ".[dev,train]"
-
+          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install -e ".[dev,train]"
+          python -m playwright install --with-deps chromium
+          cd "$RUNNER_TEMP"
+          curl -fsSLO https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint_1.7.12_linux_amd64.tar.gz" | sha256sum --check
+          tar -xzf actionlint_1.7.12_linux_amd64.tar.gz actionlint
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
       - name: Release metadata and tag must agree
         run: |
           python - <<'PY'
-          import os
-          import pathlib
-          import re
-          import sys
-
+          import os, pathlib, re, sys
           from miniverl import __version__ as version
-
           ref = os.environ.get("GITHUB_REF", "")
           tag = ref.rsplit("/", 1)[-1] if ref.startswith("refs/tags/") else ""
           problems = []
           if tag and tag != f"v{version}":
               problems.append(f"tag {tag} does not match v{version}")
-
-          changelog = pathlib.Path("CHANGELOG.md").read_text(encoding="utf-8")
-          if f"## [{version}]" not in changelog:
-              problems.append(f"CHANGELOG.md has no '## [{version}]' section")
-
+          if f"## [{version}]" not in pathlib.Path("CHANGELOG.md").read_text(encoding="utf-8"):
+              problems.append(f"CHANGELOG.md has no section for {version}")
           citation = pathlib.Path("CITATION.cff").read_text(encoding="utf-8")
           if not re.search(rf"^version:\s*{re.escape(version)}\s*$", citation, re.M):
               problems.append(f"CITATION.cff version is not {version}")
-
           if problems:
-              print("\n".join(problems))
-              sys.exit(1)
-          print(f"release metadata is consistent at {version}")
+              raise SystemExit("\n".join(problems))
           PY
-
       - name: Release checklist must be complete before a tag
         run: |
           python - <<'PY'
           import pathlib
-          import sys
-
           text = pathlib.Path("docs/release-checklist.md").read_text(encoding="utf-8")
           head = text.split("## After the tag", 1)[0]
           unchecked = [line for line in head.splitlines() if line.strip().startswith("- [ ]")]
           if unchecked:
-              print("unchecked release-checklist items:")
-              print("\n".join(unchecked))
-              sys.exit(1)
-          print("release checklist is complete")
+              raise SystemExit("unchecked release-checklist items:\n" + "\n".join(unchecked))
           PY
-
-      - name: Full quality gate
-        env:
-          HF_HUB_OFFLINE: "1"
+      - name: Run the non-publishing gate against the accepted bytes
         run: |
-          ruff check .
-          ruff format --check .
-          mypy src/miniverl
-          python scripts/build_pypi_readme.py --check
-          python scripts/release_state.py --check
-          python scripts/check_known_good_environment.py
-          python scripts/publish_gpu_qualification_schema.py --check
-          python scripts/check_markdown_links.py
+          python scripts/release_gate.py \
+            --candidate-dir "${{ runner.temp }}/verified-qualified-candidate/candidate" \
+            --candidate-manifest "${{ runner.temp }}/verified-qualified-candidate/candidate/candidate-manifest.json" \
+            --qualification "${{ runner.temp }}/verified-qualified-candidate/qualification/qualification.json" \
+            --summary "${{ runner.temp }}/release-gate-summary.json"
           echo "53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc  benchmarks/results/gpu-calc-hard-equal-update-v2.json" | sha256sum --check
-          pytest -q -m "not gpu and not network" \
-            --cov=miniverl --cov-report=term-missing --cov-fail-under=80
 
-      - name: Working tree must be clean
-        run: |
-          git status --short
-          test -z "$(git status --porcelain)"
-
-  build-distributions:
-    name: build distributions exactly once
-    needs: validate-and-test
+  prepare-verified-distributions:
+    name: prepare already-qualified distributions without rebuilding
+    needs: [verify-qualified-candidate, validate-and-test]
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-
-      - name: Download the verified GPU qualification
+      - name: Download the accepted same-run pair
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: verified-gpu-qualification
-          path: verified-gpu-qualification
-
-      - name: Build and inspect wheel and sdist
+          name: verified-qualified-candidate
+          path: accepted
+      - name: Revalidate and copy the identical candidate bytes
         run: |
-          python -m pip install --upgrade pip build twine
-          python -m build
-          python -m twine check dist/*
+          python -m pip install .
+          python scripts/build_release_candidate.py --output accepted/candidate --commit "$GITHUB_SHA" --check
           python - <<'PY'
-          import hashlib
-          import pathlib
-          import sys
-
-          dist = pathlib.Path("dist")
-          files = sorted(path for path in dist.iterdir() if path.is_file())
-          wheels = [path for path in files if path.suffix == ".whl"]
-          sdists = [path for path in files if path.name.endswith(".tar.gz")]
-          if len(wheels) != 1 or len(sdists) != 1 or len(files) != 2:
-              print(f"expected one wheel and one sdist, found {[path.name for path in files]}")
-              sys.exit(1)
-          lines = [
-              f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.as_posix()}"
-              for path in files
-          ]
-          pathlib.Path("SHA256SUMS").write_text("\n".join(lines) + "\n", encoding="ascii")
-          print("\n".join(lines))
+          import hashlib, json, pathlib, shutil
+          root = pathlib.Path("accepted")
+          candidate = root / "candidate"
+          qualification = root / "qualification/qualification.json"
+          manifest_path = candidate / "candidate-manifest.json"
+          manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+          manifest_sha = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+          record = json.loads(qualification.read_text(encoding="utf-8"))
+          if record["candidate"]["manifest_sha256"] != manifest_sha:
+              raise SystemExit("qualification candidate-manifest binding changed")
+          if record["wheel"]["sha256"] != manifest["wheel"]["sha256"]:
+              raise SystemExit("qualification wheel binding changed")
+          output = pathlib.Path("release-distributions")
+          (output / "dist").mkdir(parents=True)
+          for key in ("wheel", "sdist"):
+              shutil.copy2(candidate / manifest[key]["filename"], output / "dist")
+          shutil.copy2(candidate / "SHA256SUMS", output / "SHA256SUMS")
+          shutil.copy2(manifest_path, output / "candidate-manifest.json")
+          shutil.copy2(qualification, output / "qualification.json")
+          shutil.copy2(root / "verification.json", output / "verification.json")
+          for key in ("wheel", "sdist"):
+              copied = output / "dist" / manifest[key]["filename"]
+              if hashlib.sha256(copied.read_bytes()).hexdigest() != manifest[key]["sha256"]:
+                  raise SystemExit(f"copy changed {key} bytes")
           PY
-
-      - name: Bind the release wheel to the qualified wheel
-        run: |
-          python - <<'PY'
-          import hashlib
-          import json
-          import pathlib
-
-          qualification = json.loads(
-              pathlib.Path("verified-gpu-qualification/qualification.json").read_text()
-          )
-          wheels = list(pathlib.Path("dist").glob("*.whl"))
-          if len(wheels) != 1:
-              raise SystemExit(f"expected one wheel, found {len(wheels)}")
-          actual = hashlib.sha256(wheels[0].read_bytes()).hexdigest()
-          expected = qualification["wheel"]["sha256"]
-          if actual != expected:
-              raise SystemExit(
-                  f"release wheel {actual} differs from exact-SHA qualified wheel {expected}"
-              )
-          print(f"release wheel matches exact-SHA qualification: {actual}")
-          PY
-
-      - name: Upload immutable release distributions
+          (cd release-distributions/dist && sha256sum --check ../SHA256SUMS)
+      - name: Upload the identical qualified distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-distributions
-          path: |
-            dist/*
-            SHA256SUMS
+          path: release-distributions/
           if-no-files-found: error
           retention-days: 14
 
   publish-pypi:
-    name: publish exact distributions to PyPI with OIDC
-    needs: build-distributions
+    name: publish exact qualified distributions to PyPI with OIDC
+    needs: prepare-verified-distributions
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     environment:
@@ -222,18 +176,13 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Download release distributions
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-distributions
           path: release-artifacts
-
-      - name: Verify downloaded artifact hashes
-        working-directory: release-artifacts
-        run: sha256sum --check SHA256SUMS
-
-      - name: Publish with trusted publishing and attestations
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
+      - name: Verify bytes immediately before publication
+        run: (cd release-artifacts/dist && sha256sum --check ../SHA256SUMS)
+      - uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
         with:
           packages-dir: release-artifacts/dist/
 
@@ -246,32 +195,25 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-
-      - name: Download the published distributions
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-distributions
           path: release-artifacts
-
-      - name: Verify PyPI metadata, file hashes and trusted-publisher attestations
+      - name: Verify public hashes and trusted-publisher attestations
         env:
           VERSION: ${{ github.ref_name }}
         run: |
+          (cd release-artifacts/dist && sha256sum --check ../SHA256SUMS)
           python -m pip install --upgrade pip pypi-attestations
           python scripts/verify_pypi_release.py \
-            --project miniverl \
-            --version "${VERSION#v}" \
+            --project miniverl --version "${VERSION#v}" \
             --sums release-artifacts/SHA256SUMS \
-            --artifact-root release-artifacts \
+            --artifact-root release-artifacts/dist \
             --repository https://github.com/DaoyuanLi2816/mini-verl \
-            --attempts 12 \
-            --delay 10 \
-            --allow-rendered-page-challenge
-
+            --attempts 12 --delay 10 --allow-rendered-page-challenge
       - name: Install and exercise the exact public version
         env:
           VERSION: ${{ github.ref_name }}
@@ -280,51 +222,39 @@ jobs:
           python -m venv release-verify
           release-verify/bin/python -m pip install --upgrade pip
           for attempt in {1..12}; do
-            if release-verify/bin/python -m pip install \
-              --no-cache-dir --index-url https://pypi.org/simple \
-              "miniverl==$VERSION"; then
-              break
-            fi
-            if [ "$attempt" -eq 12 ]; then
-              echo "public simple index did not expose miniverl==$VERSION"
-              exit 1
-            fi
-            echo "public simple index is still propagating; retrying in 10 seconds"
+            if release-verify/bin/python -m pip install --no-cache-dir --index-url https://pypi.org/simple "miniverl==$VERSION"; then break; fi
+            if [ "$attempt" -eq 12 ]; then exit 1; fi
             sleep 10
           done
           test "$(release-verify/bin/miniverl --version)" = "miniverl $VERSION"
           release-verify/bin/miniverl doctor --json > doctor.json
           release-verify/bin/python - <<'PY'
-          import json
-          import pathlib
-
+          import json, pathlib
           payload = json.loads(pathlib.Path("doctor.json").read_text(encoding="utf-8"))
           assert payload["verdict"]["core_commands"] is True
           PY
 
   create-github-release:
-    name: create GitHub Release from the verified distributions
+    name: create GitHub Release from the verified identical bytes
     needs: verify-pypi
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Download the verified distributions
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-distributions
           path: release-artifacts
-
       - name: Recheck hashes and create the release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          (cd release-artifacts && sha256sum --check SHA256SUMS)
+          (cd release-artifacts/dist && sha256sum --check ../SHA256SUMS)
           gh release create "$GITHUB_REF_NAME" \
             release-artifacts/dist/* \
             release-artifacts/SHA256SUMS \
-            --repo "$GITHUB_REPOSITORY" \
-            --verify-tag \
-            --title "miniVERL $GITHUB_REF_NAME" \
-            --generate-notes
+            release-artifacts/candidate-manifest.json \
+            release-artifacts/qualification.json \
+            --repo "$GITHUB_REPOSITORY" --verify-tag \
+            --title "miniVERL $GITHUB_REF_NAME" --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,46 @@ permissions:
   contents: read
 
 jobs:
+  verify-gpu-qualification:
+    name: verify exact-commit RTX 4080 qualification
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install torch-free validator dependencies
+        run: python -m pip install .
+
+      - name: Fetch and validate the exact-SHA workflow artifact
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/verify_release_qualification.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --workflow gpu.yml \
+            --commit "$GITHUB_SHA" \
+            --artifact-name gpu-release-smoke \
+            --required-gpu-name "NVIDIA GeForce RTX 4080" \
+            --known-good environments/known-good-rtx4080-cu130.json \
+            --output verified-gpu-qualification
+
+      - name: Preserve the verified qualification for distribution binding
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: verified-gpu-qualification
+          path: verified-gpu-qualification/
+          if-no-files-found: error
+          retention-days: 14
+
   validate-and-test:
     name: validate metadata and run release gates
+    needs: verify-gpu-qualification
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -84,6 +122,8 @@ jobs:
           mypy src/miniverl
           python scripts/build_pypi_readme.py --check
           python scripts/release_state.py --check
+          python scripts/check_known_good_environment.py
+          python scripts/publish_gpu_qualification_schema.py --check
           python scripts/check_markdown_links.py
           echo "53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc  benchmarks/results/gpu-calc-hard-equal-update-v2.json" | sha256sum --check
           pytest -q -m "not gpu and not network" \
@@ -106,6 +146,12 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+
+      - name: Download the verified GPU qualification
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: verified-gpu-qualification
+          path: verified-gpu-qualification
 
       - name: Build and inspect wheel and sdist
         run: |
@@ -130,6 +176,28 @@ jobs:
           ]
           pathlib.Path("SHA256SUMS").write_text("\n".join(lines) + "\n", encoding="ascii")
           print("\n".join(lines))
+          PY
+
+      - name: Bind the release wheel to the qualified wheel
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          import pathlib
+
+          qualification = json.loads(
+              pathlib.Path("verified-gpu-qualification/qualification.json").read_text()
+          )
+          wheels = list(pathlib.Path("dist").glob("*.whl"))
+          if len(wheels) != 1:
+              raise SystemExit(f"expected one wheel, found {len(wheels)}")
+          actual = hashlib.sha256(wheels[0].read_bytes()).hexdigest()
+          expected = qualification["wheel"]["sha256"]
+          if actual != expected:
+              raise SystemExit(
+                  f"release wheel {actual} differs from exact-SHA qualified wheel {expected}"
+              )
+          print(f"release wheel matches exact-SHA qualification: {actual}")
           PY
 
       - name: Upload immutable release distributions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,8 @@ jobs:
             --workflow gpu.yml \
             --commit "$GITHUB_SHA" \
             --candidate-artifact-name candidate-distributions \
-            --qualification-artifact-name gpu-release-smoke \
+            --qualification-artifact-name gpu-full-qualification \
+            --required-level full_qualification \
             --required-gpu-name "NVIDIA GeForce RTX 4080" \
             --known-good environments/known-good-rtx4080-cu130.json \
             --output verified-qualified-candidate
@@ -133,7 +134,8 @@ jobs:
           import hashlib, json, pathlib, shutil
           root = pathlib.Path("accepted")
           candidate = root / "candidate"
-          qualification = root / "qualification/qualification.json"
+          qualification_root = root / "qualification"
+          qualification = qualification_root / "qualification.json"
           manifest_path = candidate / "candidate-manifest.json"
           manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
           manifest_sha = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
@@ -150,12 +152,31 @@ jobs:
           shutil.copy2(manifest_path, output / "candidate-manifest.json")
           shutil.copy2(qualification, output / "qualification.json")
           shutil.copy2(root / "verification.json", output / "verification.json")
+          evidence_output = output / "qualification-evidence"
+          evidence_output.mkdir()
+          version = manifest["miniverl_version"]
+          evidence_files = [("full-qualification", qualification)]
+          evidence_files.extend(
+              (item["name"].replace("_", "-"), qualification_root / item["path"])
+              for item in record["artifacts"]
+          )
+          sums = []
+          for label, source in evidence_files:
+              suffix = source.suffix or ".bin"
+              target = evidence_output / f"miniverl-{version}-{label}{suffix}"
+              shutil.copy2(source, target)
+              digest = hashlib.sha256(target.read_bytes()).hexdigest()
+              sums.append(f"{digest}  {target.name}")
+          (output / "qualification-full-SHA256SUMS").write_text(
+              "\n".join(sums) + "\n", encoding="utf-8", newline="\n"
+          )
           for key in ("wheel", "sdist"):
               copied = output / "dist" / manifest[key]["filename"]
               if hashlib.sha256(copied.read_bytes()).hexdigest() != manifest[key]["sha256"]:
                   raise SystemExit(f"copy changed {key} bytes")
           PY
           (cd release-distributions/dist && sha256sum --check ../SHA256SUMS)
+          (cd release-distributions/qualification-evidence && sha256sum --check ../qualification-full-SHA256SUMS)
       - name: Upload the identical qualified distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -176,13 +197,27 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-distributions
           path: release-artifacts
       - name: Verify bytes immediately before publication
-        run: (cd release-artifacts/dist && sha256sum --check ../SHA256SUMS)
+        run: |
+          (cd release-artifacts/dist && sha256sum --check ../SHA256SUMS)
+          (cd release-artifacts/qualification-evidence && sha256sum --check ../qualification-full-SHA256SUMS)
+      - name: Determine whether exact candidate bytes already exist on PyPI
+        id: pypi-state
+        run: |
+          python scripts/check_pypi_publish_state.py \
+            --manifest release-artifacts/candidate-manifest.json \
+            --project miniverl \
+            --github-output "$GITHUB_OUTPUT"
       - uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
+        if: ${{ steps.pypi-state.outputs.publish_needed == 'true' }}
         with:
           packages-dir: release-artifacts/dist/
 
@@ -254,6 +289,8 @@ jobs:
           gh release create "$GITHUB_REF_NAME" \
             release-artifacts/dist/* \
             release-artifacts/SHA256SUMS \
+            release-artifacts/qualification-full-SHA256SUMS \
+            release-artifacts/qualification-evidence/* \
             release-artifacts/candidate-manifest.json \
             release-artifacts/qualification.json \
             --repo "$GITHUB_REPOSITORY" --verify-tag \

--- a/.github/workflows/verify-existing-release.yml
+++ b/.github/workflows/verify-existing-release.yml
@@ -62,13 +62,16 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          (cd release-artifacts && sha256sum --check SHA256SUMS)
+          (cd release-artifacts/dist && sha256sum --check ../SHA256SUMS)
+          if test -f release-artifacts/qualification-full-SHA256SUMS; then
+            (cd release-artifacts/qualification-evidence && sha256sum --check ../qualification-full-SHA256SUMS)
+          fi
           python -m pip install --upgrade pip pypi-attestations
           python scripts/verify_pypi_release.py \
             --project miniverl \
             --version "$VERSION" \
             --sums release-artifacts/SHA256SUMS \
-            --artifact-root release-artifacts \
+            --artifact-root release-artifacts/dist \
             --repository https://github.com/DaoyuanLi2816/mini-verl \
             --attempts 12 \
             --delay 10 \
@@ -116,14 +119,26 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           TAG="v$VERSION"
-          (cd release-artifacts && sha256sum --check SHA256SUMS)
+          (cd release-artifacts/dist && sha256sum --check ../SHA256SUMS)
+          if test -f release-artifacts/qualification-full-SHA256SUMS; then
+            (cd release-artifacts/qualification-evidence && sha256sum --check ../qualification-full-SHA256SUMS)
+          fi
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "GitHub Release $TAG already exists"
             exit 0
           fi
-          gh release create "$TAG" \
-            release-artifacts/dist/* \
-            release-artifacts/SHA256SUMS \
+          assets=(release-artifacts/dist/* release-artifacts/SHA256SUMS)
+          for path in \
+            release-artifacts/candidate-manifest.json \
+            release-artifacts/qualification.json \
+            release-artifacts/verification.json \
+            release-artifacts/qualification-full-SHA256SUMS; do
+            if test -f "$path"; then assets+=("$path"); fi
+          done
+          if test -d release-artifacts/qualification-evidence; then
+            assets+=(release-artifacts/qualification-evidence/*)
+          fi
+          gh release create "$TAG" "${assets[@]}" \
             --repo "$GITHUB_REPOSITORY" \
             --verify-tag \
             --title "miniVERL $TAG" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to miniVERL are recorded here. The format follows
 
 ## [Unreleased]
 
+### Product maturity and release qualification
+
+- Added a strict, torch-free GPU qualification schema and validator, a
+  wheel-installed RTX 4080 self-hosted workflow, and an exact-source-SHA
+  release gate that also binds the release wheel hash to the qualified wheel.
+- Added a machine-readable maintainer-measured CUDA stack with exact top-level
+  constraints while preserving flexible package dependency ranges.
+- Extended canonical release-state checks to security support and current
+  product prose, and documented v1 readiness, immutable upstream-profile
+  lifecycle, runner safety and maintainer architecture.
+- Added one non-publishing release-gate command that composes the existing
+  metadata, quality, documentation, build, clean-install and qualification
+  checks into a strict JSON summary.
+
 ## [0.10.0] - 2026-08-14
 
 ### Versioned compatibility profiles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,20 @@ All notable changes to miniVERL are recorded here. The format follows
 
 ### Product maturity and release qualification
 
-- Added a strict, torch-free GPU qualification schema and validator, a
-  wheel-installed RTX 4080 self-hosted workflow, and an exact-source-SHA
-  release gate that also binds the release wheel hash to the qualified wheel.
+- Added a strict, torch-free candidate and GPU qualification chain: a hosted
+  job builds one wheel/sdist pair, and the RTX 4080 job installs and qualifies
+  that exact same-run wheel with import and CLI origin checks.
+- Hardened release artifact discovery against expired, fork, wrong-workflow,
+  cross-run, duplicate, traversal and symlink inputs. Release publication now
+  reuses the qualified candidate bytes and performs no distribution rebuild.
 - Added a machine-readable maintainer-measured CUDA stack with exact top-level
   constraints while preserving flexible package dependency ranges.
 - Extended canonical release-state checks to security support and current
   product prose, and documented v1 readiness, immutable upstream-profile
   lifecycle, runner safety and maintainer architecture.
-- Added one non-publishing release-gate command that composes the existing
-  metadata, quality, documentation, build, clean-install and qualification
-  checks into a strict JSON summary.
+- Added one non-publishing release-gate command that composes metadata,
+  candidate integrity, exact qualification binding, quality, documentation and
+  clean-install checks into a strict JSON summary.
 
 ## [0.10.0] - 2026-08-14
 

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -31,7 +31,7 @@ Executable compatibility claims are mutation-tested and recorded in
 unknown-size quantized roles require proof instead of receiving an executable
 plan.
 
-Development `0.10.0.dev0` has a closed typed profile registry and torch-free
+Development `0.10.1.dev0` has a closed typed profile registry and torch-free
 compatibility introspection. Profile-scoped plans, caches, checkpoints and
 exports bind an independent identity. The direct-GKD and sampled-k1 vanilla
 policy-loss profiles both have pinned conformance and measured RTX 4080 paths.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -4,7 +4,7 @@ Current maintainer handoff for **miniVERL** (`mini-verl` package, `miniverl`
 CLI). `release-state.yaml` is the canonical version source; this page indexes
 current product and evidence state rather than repeating release history.
 
-Last updated: 2026-08-14.
+Last updated: 2026-08-15.
 
 Canonical release state: stable `v0.10.0` (`51264f86e8226b1abc6ca1901d379c5e6fabb81e`), development `0.10.1.dev0`.
 
@@ -37,6 +37,9 @@ exports bind an independent identity. The direct-GKD and sampled-k1 vanilla
 policy-loss profiles both have pinned conformance and measured RTX 4080 paths.
 Portable hardware records preserve measured, estimated and unknown states;
 schema-valid community submissions remain unreviewed until maintainer validation.
+The development release chain now builds one hosted-runner candidate and binds
+the private RTX 4080 qualification to that exact manifest and wheel. Release
+jobs may publish only the same verified bytes and never rebuild them.
 
 Arbitrary verl YAML, other policy-gradient modes, rewards, PPO/GRPO, Ray, FSDP,
 Megatron, multi-GPU and distributed execution remain unsupported. The legacy

--- a/PYPI.md
+++ b/PYPI.md
@@ -49,10 +49,22 @@ and `run --dry-run` validates the native execution contract. On one NVIDIA CUDA
 GPU, remove `--dry-run` to run the pinned Qwen3-0.6B actor and Qwen3-1.7B teacher
 recipe and produce an inspectable PEFT adapter.
 
+After reviewing the plan, the canonical continuation is:
+
+```bash
+miniverl run --profile verl-opd-v0.8-single-gpu-v1 --plan plan.json \
+  --output runs --run-id my-opd
+miniverl inspect runs/my-opd/trajectories.jsonl
+miniverl cache stats runs/my-opd/teacher-cache
+miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout
+miniverl bridge doctor scaleout --json
+```
+
 The `train` extra installs the ML runtime, but does not choose the correct CUDA
 PyTorch wheel. The optional `cuda` extra adds bitsandbytes only. Follow the
-[one-GPU installation and memory guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) before a real
-run.
+[one-GPU installation and memory guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) for both the
+flexible install and the machine-readable RTX 4080 known-good stack. Hardware
+other than that one measured RTX 4080 remains unmeasured.
 
 ## Architecture
 
@@ -171,7 +183,11 @@ materialized successfully. See the [full SmolLM2 systems record](https://github.
 This is deliberately a runtime and artifact proof. It is not a throughput
 benchmark, an alignment-quality endpoint, or evidence that OPD beats SFT, DPO
 or KD. Other NVIDIA GPUs use the same device-name-agnostic CUDA path, but model
-fit depends on VRAM, context length, quantization and installed kernels.
+fit depends on VRAM, context length, quantization and installed kernels; they
+remain unmeasured. The [release qualification contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/release-qualification.md)
+adds an exact-SHA wheel smoke on the one RTX 4080, while the
+[upstream support policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/upstream-support-policy.md) keeps both published
+profile identities fixed. Runner activation is not described as continuous CI.
 
 ### Choose a path by hardware, not GPU branding
 

--- a/PYPI.md
+++ b/PYPI.md
@@ -185,7 +185,8 @@ benchmark, an alignment-quality endpoint, or evidence that OPD beats SFT, DPO
 or KD. Other NVIDIA GPUs use the same device-name-agnostic CUDA path, but model
 fit depends on VRAM, context length, quantization and installed kernels; they
 remain unmeasured. The [release qualification contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/release-qualification.md)
-adds an exact-SHA wheel smoke on the one RTX 4080, while the
+builds one candidate wheel on a hosted runner and qualifies those exact bytes
+on the RTX 4080 before any release can reuse them, while the
 [upstream support policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/upstream-support-policy.md) keeps both published
 profile identities fixed. Runner activation is not described as continuous CI.
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ benchmark, an alignment-quality endpoint, or evidence that OPD beats SFT, DPO
 or KD. Other NVIDIA GPUs use the same device-name-agnostic CUDA path, but model
 fit depends on VRAM, context length, quantization and installed kernels; they
 remain unmeasured. The [release qualification contract](docs/release-qualification.md)
-adds an exact-SHA wheel smoke on the one RTX 4080, while the
+builds one candidate wheel on a hosted runner and qualifies those exact bytes
+on the RTX 4080 before any release can reuse them, while the
 [upstream support policy](docs/upstream-support-policy.md) keeps both published
 profile identities fixed. Runner activation is not described as continuous CI.
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,22 @@ and `run --dry-run` validates the native execution contract. On one NVIDIA CUDA
 GPU, remove `--dry-run` to run the pinned Qwen3-0.6B actor and Qwen3-1.7B teacher
 recipe and produce an inspectable PEFT adapter.
 
+After reviewing the plan, the canonical continuation is:
+
+```bash
+miniverl run --profile verl-opd-v0.8-single-gpu-v1 --plan plan.json \
+  --output runs --run-id my-opd
+miniverl inspect runs/my-opd/trajectories.jsonl
+miniverl cache stats runs/my-opd/teacher-cache
+miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout
+miniverl bridge doctor scaleout --json
+```
+
 The `train` extra installs the ML runtime, but does not choose the correct CUDA
 PyTorch wheel. The optional `cuda` extra adds bitsandbytes only. Follow the
-[one-GPU installation and memory guide](docs/single-gpu-guide.md) before a real
-run.
+[one-GPU installation and memory guide](docs/single-gpu-guide.md) for both the
+flexible install and the machine-readable RTX 4080 known-good stack. Hardware
+other than that one measured RTX 4080 remains unmeasured.
 
 ## Architecture
 
@@ -171,7 +183,11 @@ materialized successfully. See the [full SmolLM2 systems record](docs/smollm2-op
 This is deliberately a runtime and artifact proof. It is not a throughput
 benchmark, an alignment-quality endpoint, or evidence that OPD beats SFT, DPO
 or KD. Other NVIDIA GPUs use the same device-name-agnostic CUDA path, but model
-fit depends on VRAM, context length, quantization and installed kernels.
+fit depends on VRAM, context length, quantization and installed kernels; they
+remain unmeasured. The [release qualification contract](docs/release-qualification.md)
+adds an exact-SHA wheel smoke on the one RTX 4080, while the
+[upstream support policy](docs/upstream-support-policy.md) keeps both published
+profile identities fixed. Runner activation is not described as continuous CI.
 
 ### Choose a path by hardware, not GPU branding
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -45,8 +45,20 @@ miniverl run --profile verl-opd-v0.8-single-gpu-v1 \
 上移除 `--dry-run`，即可运行固定版本的 Qwen3-0.6B actor 与 Qwen3-1.7B teacher，并
 得到可检查、可重新加载的 PEFT adapter。
 
+检查 plan 后，标准后续路径为：
+
+```bash
+miniverl run --profile verl-opd-v0.8-single-gpu-v1 --plan plan.json \
+  --output runs --run-id my-opd
+miniverl inspect runs/my-opd/trajectories.jsonl
+miniverl cache stats runs/my-opd/teacher-cache
+miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout
+miniverl bridge doctor scaleout --json
+```
+
 `train` extra 安装训练运行时，但不会选择正确的 CUDA PyTorch；`cuda` extra 只额外安装
-bitsandbytes。真实运行前请阅读[单卡安装与显存指南](docs/single-gpu-guide.md)。
+bitsandbytes。[单卡安装与显存指南](docs/single-gpu-guide.md)同时提供灵活安装与机器可读的
+RTX 4080 known-good 环境；除这一张实测 RTX 4080 外，其余硬件仍是未测量状态。
 
 ## 架构
 
@@ -144,7 +156,10 @@ snapshot 的 scale-out 物化均通过。详见[完整 SmolLM2 系统记录](doc
 
 这只证明一个运行时与产物路径，不是吞吐 benchmark、对齐质量 endpoint，也不证明 OPD
 优于 SFT、DPO 或 KD。其他 NVIDIA GPU 使用相同的 device-name-agnostic CUDA 路径，但
-能否装下仍取决于显存、上下文、量化与 kernel。
+能否装下仍取决于显存、上下文、量化与 kernel，并且仍未测量。
+[发布资格契约](docs/release-qualification.md)要求在唯一实测 RTX 4080 上绑定 exact-SHA
+wheel smoke；[上游支持政策](docs/upstream-support-policy.md)保证已发布 profile identity
+不原地漂移。runner 尚未激活时不会被描述成持续 GPU CI。
 
 ### 按硬件条件选择路径，而不是按显卡名称
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -157,9 +157,10 @@ snapshot 的 scale-out 物化均通过。详见[完整 SmolLM2 系统记录](doc
 这只证明一个运行时与产物路径，不是吞吐 benchmark、对齐质量 endpoint，也不证明 OPD
 优于 SFT、DPO 或 KD。其他 NVIDIA GPU 使用相同的 device-name-agnostic CUDA 路径，但
 能否装下仍取决于显存、上下文、量化与 kernel，并且仍未测量。
-[发布资格契约](docs/release-qualification.md)要求在唯一实测 RTX 4080 上绑定 exact-SHA
-wheel smoke；[上游支持政策](docs/upstream-support-policy.md)保证已发布 profile identity
-不原地漂移。runner 尚未激活时不会被描述成持续 GPU CI。
+[发布资格契约](docs/release-qualification.md)先在 GitHub-hosted runner 上构建唯一 candidate
+wheel，再在实测 RTX 4080 上验证完全相同的字节；发布只能复用这份制品。
+[上游支持政策](docs/upstream-support-policy.md)保证已发布 profile identity 不原地漂移。
+runner 尚未激活时不会被描述成持续 GPU CI。
 
 ### 按硬件条件选择路径，而不是按显卡名称
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-The current supported stable line is `0.2.4`; security fixes land on `main` and
+The current supported stable line is `0.10.0`; security fixes land on `main` and
 in the next patch release. There are no separately maintained older branches.
 
 ## Reporting a vulnerability
@@ -29,6 +29,11 @@ the model weights you load. It does **not** assume you trust:
   anywhere in the project. A corrupted or truncated shard raises
   `CacheCorruptionError`.
 * **A checkpoint.** Checkpoints are safetensors plus JSON, for the same reason.
+* **A qualification workflow artifact.** Release validation downloads it only
+  from a successful manual workflow run bound to the exact source SHA. Archive
+  members are count/size bounded; absolute paths, traversal and symlinks are
+  rejected before extraction, then every declared file hash and portable JSON
+  field is checked without importing Torch.
 * **Text produced by the model.** The tool-call parser uses bounded strict JSON:
   duplicate keys, non-finite/pathological numbers, excessive depth or members,
   invalid Unicode and trailing action blocks are rejected. Rollouts are bounded

--- a/docs/generated/gpu-qualification-v1.schema.json
+++ b/docs/generated/gpu-qualification-v1.schema.json
@@ -1,0 +1,437 @@
+{
+  "$defs": {
+    "ArtifactEvidence": {
+      "additionalProperties": false,
+      "properties": {
+        "bytes": {
+          "minimum": 0,
+          "title": "Bytes",
+          "type": "integer"
+        },
+        "name": {
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "path": {
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "path",
+        "sha256",
+        "bytes"
+      ],
+      "title": "ArtifactEvidence",
+      "type": "object"
+    },
+    "CheckEvidence": {
+      "additionalProperties": false,
+      "properties": {
+        "executed": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Executed",
+          "type": "array"
+        },
+        "not_applicable": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Not Applicable",
+          "type": "array"
+        },
+        "skipped": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Skipped",
+          "type": "array"
+        }
+      },
+      "required": [
+        "executed",
+        "skipped",
+        "not_applicable"
+      ],
+      "title": "CheckEvidence",
+      "type": "object"
+    },
+    "EnvironmentEvidence": {
+      "additionalProperties": false,
+      "properties": {
+        "cuda_runtime": {
+          "minLength": 1,
+          "title": "Cuda Runtime",
+          "type": "string"
+        },
+        "driver": {
+          "minLength": 1,
+          "title": "Driver",
+          "type": "string"
+        },
+        "gpu_count": {
+          "const": 1,
+          "title": "Gpu Count",
+          "type": "integer"
+        },
+        "gpu_name": {
+          "minLength": 1,
+          "title": "Gpu Name",
+          "type": "string"
+        },
+        "known_good_manifest_sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Known Good Manifest Sha256",
+          "type": "string"
+        },
+        "packages": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Packages",
+          "type": "object"
+        },
+        "python": {
+          "minLength": 1,
+          "title": "Python",
+          "type": "string"
+        },
+        "vram_gib": {
+          "exclusiveMinimum": 0,
+          "title": "Vram Gib",
+          "type": "number"
+        }
+      },
+      "required": [
+        "known_good_manifest_sha256",
+        "gpu_name",
+        "gpu_count",
+        "vram_gib",
+        "driver",
+        "cuda_runtime",
+        "python",
+        "packages"
+      ],
+      "title": "EnvironmentEvidence",
+      "type": "object"
+    },
+    "ExecutionEvidence": {
+      "additionalProperties": false,
+      "properties": {
+        "cuda_allocated_after_teardown_bytes": {
+          "minimum": 0,
+          "title": "Cuda Allocated After Teardown Bytes",
+          "type": "integer"
+        },
+        "cuda_allocated_before_bytes": {
+          "minimum": 0,
+          "title": "Cuda Allocated Before Bytes",
+          "type": "integer"
+        },
+        "cuda_teardown_tolerance_bytes": {
+          "minimum": 0,
+          "title": "Cuda Teardown Tolerance Bytes",
+          "type": "integer"
+        },
+        "optimizer_updates": {
+          "minimum": 1,
+          "title": "Optimizer Updates",
+          "type": "integer"
+        },
+        "peft_adapter_exported": {
+          "const": true,
+          "title": "Peft Adapter Exported",
+          "type": "boolean"
+        },
+        "peft_adapter_reload_verified": {
+          "const": true,
+          "title": "Peft Adapter Reload Verified",
+          "type": "boolean"
+        },
+        "rollout_completed": {
+          "const": true,
+          "title": "Rollout Completed",
+          "type": "boolean"
+        },
+        "teacher_scoring_completed": {
+          "const": true,
+          "title": "Teacher Scoring Completed",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "rollout_completed",
+        "teacher_scoring_completed",
+        "optimizer_updates",
+        "peft_adapter_exported",
+        "peft_adapter_reload_verified",
+        "cuda_allocated_before_bytes",
+        "cuda_allocated_after_teardown_bytes",
+        "cuda_teardown_tolerance_bytes"
+      ],
+      "title": "ExecutionEvidence",
+      "type": "object"
+    },
+    "InputEvidence": {
+      "additionalProperties": false,
+      "properties": {
+        "config_sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Config Sha256",
+          "type": "string"
+        },
+        "parquet_sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Parquet Sha256",
+          "type": "string"
+        },
+        "plan_sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Plan Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "config_sha256",
+        "plan_sha256",
+        "parquet_sha256"
+      ],
+      "title": "InputEvidence",
+      "type": "object"
+    },
+    "ModelEvidence": {
+      "additionalProperties": false,
+      "properties": {
+        "model_id": {
+          "minLength": 1,
+          "title": "Model Id",
+          "type": "string"
+        },
+        "revision": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Revision",
+          "type": "string"
+        },
+        "role": {
+          "enum": [
+            "actor",
+            "teacher"
+          ],
+          "title": "Role",
+          "type": "string"
+        }
+      },
+      "required": [
+        "role",
+        "model_id",
+        "revision"
+      ],
+      "title": "ModelEvidence",
+      "type": "object"
+    },
+    "ProfileEvidence": {
+      "additionalProperties": false,
+      "properties": {
+        "identity_digest": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Identity Digest",
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "upstream_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "title": "Upstream Commit",
+          "type": "string"
+        },
+        "upstream_tag": {
+          "minLength": 1,
+          "title": "Upstream Tag",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "identity_digest",
+        "upstream_tag",
+        "upstream_commit"
+      ],
+      "title": "ProfileEvidence",
+      "type": "object"
+    },
+    "ScientificScope": {
+      "additionalProperties": false,
+      "properties": {
+        "alignment_quality_evaluated": {
+          "const": false,
+          "title": "Alignment Quality Evaluated",
+          "type": "boolean"
+        },
+        "distributed_execution_tested": {
+          "const": false,
+          "title": "Distributed Execution Tested",
+          "type": "boolean"
+        },
+        "other_hardware_measured": {
+          "const": false,
+          "title": "Other Hardware Measured",
+          "type": "boolean"
+        },
+        "runtime_correctness_only": {
+          "const": true,
+          "title": "Runtime Correctness Only",
+          "type": "boolean"
+        },
+        "task_quality_evaluated": {
+          "const": false,
+          "title": "Task Quality Evaluated",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "runtime_correctness_only",
+        "task_quality_evaluated",
+        "alignment_quality_evaluated",
+        "distributed_execution_tested",
+        "other_hardware_measured"
+      ],
+      "title": "ScientificScope",
+      "type": "object"
+    },
+    "WheelEvidence": {
+      "additionalProperties": false,
+      "properties": {
+        "filename": {
+          "minLength": 1,
+          "pattern": "^[^/\\\\]+\\.whl$",
+          "title": "Filename",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "filename",
+        "sha256"
+      ],
+      "title": "WheelEvidence",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Strict version-1 exact-commit qualification record.",
+  "properties": {
+    "artifacts": {
+      "items": {
+        "$ref": "#/$defs/ArtifactEvidence"
+      },
+      "minItems": 1,
+      "title": "Artifacts",
+      "type": "array"
+    },
+    "checks": {
+      "$ref": "#/$defs/CheckEvidence"
+    },
+    "environment": {
+      "$ref": "#/$defs/EnvironmentEvidence"
+    },
+    "execution": {
+      "$ref": "#/$defs/ExecutionEvidence"
+    },
+    "inputs": {
+      "$ref": "#/$defs/InputEvidence"
+    },
+    "kind": {
+      "const": "miniverl_gpu_qualification",
+      "default": "miniverl_gpu_qualification",
+      "title": "Kind",
+      "type": "string"
+    },
+    "level": {
+      "enum": [
+        "release_smoke",
+        "full_qualification"
+      ],
+      "title": "Level",
+      "type": "string"
+    },
+    "measured_at": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
+      "title": "Measured At",
+      "type": "string"
+    },
+    "miniverl_version": {
+      "minLength": 1,
+      "title": "Miniverl Version",
+      "type": "string"
+    },
+    "models": {
+      "items": {
+        "$ref": "#/$defs/ModelEvidence"
+      },
+      "maxItems": 2,
+      "minItems": 2,
+      "title": "Models",
+      "type": "array"
+    },
+    "profile": {
+      "$ref": "#/$defs/ProfileEvidence"
+    },
+    "schema_version": {
+      "const": 1,
+      "default": 1,
+      "title": "Schema Version",
+      "type": "integer"
+    },
+    "scientific_scope": {
+      "$ref": "#/$defs/ScientificScope"
+    },
+    "source_commit": {
+      "pattern": "^[0-9a-f]{40}$",
+      "title": "Source Commit",
+      "type": "string"
+    },
+    "status": {
+      "const": "passed",
+      "title": "Status",
+      "type": "string"
+    },
+    "wheel": {
+      "$ref": "#/$defs/WheelEvidence"
+    }
+  },
+  "required": [
+    "level",
+    "status",
+    "measured_at",
+    "source_commit",
+    "miniverl_version",
+    "wheel",
+    "profile",
+    "environment",
+    "models",
+    "execution",
+    "inputs",
+    "artifacts",
+    "checks",
+    "scientific_scope"
+  ],
+  "title": "GPUQualification",
+  "type": "object"
+}

--- a/docs/generated/gpu-qualification-v1.schema.json
+++ b/docs/generated/gpu-qualification-v1.schema.json
@@ -33,6 +33,101 @@
       "title": "ArtifactEvidence",
       "type": "object"
     },
+    "CandidateBinding": {
+      "additionalProperties": false,
+      "properties": {
+        "artifact_name": {
+          "const": "candidate-distributions",
+          "title": "Artifact Name",
+          "type": "string"
+        },
+        "cli_origin_verified": {
+          "const": true,
+          "title": "Cli Origin Verified",
+          "type": "boolean"
+        },
+        "import_origin": {
+          "const": "qualification_venv_site_packages",
+          "title": "Import Origin",
+          "type": "string"
+        },
+        "import_origin_verified": {
+          "const": true,
+          "title": "Import Origin Verified",
+          "type": "boolean"
+        },
+        "installed_from_candidate": {
+          "const": true,
+          "title": "Installed From Candidate",
+          "type": "boolean"
+        },
+        "manifest_sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Manifest Sha256",
+          "type": "string"
+        },
+        "workflow_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Workflow Path"
+        },
+        "workflow_repository": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Workflow Repository"
+        },
+        "workflow_run_attempt": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Workflow Run Attempt"
+        },
+        "workflow_run_id": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Workflow Run Id"
+        }
+      },
+      "required": [
+        "manifest_sha256",
+        "artifact_name",
+        "installed_from_candidate",
+        "import_origin_verified",
+        "cli_origin_verified",
+        "import_origin"
+      ],
+      "title": "CandidateBinding",
+      "type": "object"
+    },
     "CheckEvidence": {
       "additionalProperties": false,
       "properties": {
@@ -345,6 +440,9 @@
       "title": "Artifacts",
       "type": "array"
     },
+    "candidate": {
+      "$ref": "#/$defs/CandidateBinding"
+    },
     "checks": {
       "$ref": "#/$defs/CheckEvidence"
     },
@@ -423,6 +521,7 @@
     "source_commit",
     "miniverl_version",
     "wheel",
+    "candidate",
     "profile",
     "environment",
     "models",

--- a/docs/generated/upstream-support-matrix.json
+++ b/docs/generated/upstream-support-matrix.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "policy": "closed_immutable_profiles",
+  "upstream_repository": "https://github.com/volcengine/verl",
+  "profiles": [
+    {
+      "name": "verl-opd-v0.8-single-gpu-v1",
+      "status": "active",
+      "upstream_tag": "v0.8.0",
+      "upstream_commit": "7aed6b230776f963fa09509c10d9c3a767d1102c",
+      "objective": "forward_kl_topk",
+      "distributed_execution_tested": false
+    },
+    {
+      "name": "verl-opd-v0.8-single-gpu-pg-k1-v1",
+      "status": "active",
+      "upstream_tag": "v0.8.0",
+      "upstream_commit": "7aed6b230776f963fa09509c10d9c3a767d1102c",
+      "objective": "sampled_k1_vanilla_policy_loss",
+      "distributed_execution_tested": false
+    }
+  ],
+  "unprofiled_versions": "unsupported"
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,9 @@ independent; distributed execution and full verl compatibility are not claimed.
 ## Pip-only OPD quickstart
 
 ```bash
+python -m pip install torch --index-url https://download.pytorch.org/whl/cu130
 python -m pip install "miniverl[train,cuda]"
+miniverl doctor
 miniverl data sample --format verl-parquet --out prompts.parquet
 miniverl plan --profile verl-opd-v0.8-single-gpu-v1 \
   --config builtin:qwen3-0.6b-1.7b-opd \
@@ -24,6 +26,12 @@ miniverl run --profile verl-opd-v0.8-single-gpu-v1 \
 Planning loads no weights. Remove `--dry-run` on one CUDA GPU to execute the
 pinned Qwen3 recipe and export a standard PEFT adapter. Install the matching
 CUDA-enabled PyTorch wheel first; the `[cuda]` extra does not select one.
+For the exact maintainer-measured versions, use the
+[machine-readable known-good stack](single-gpu-guide.md).
+
+After inspection, write `plan.json` with `plan --out`, run it without
+`--dry-run`, then use `inspect`, `cache stats`, `export-verl` and `bridge
+doctor`; the [quickstart](opd-quickstart.md) carries the complete copyable path.
 
 ## Runtime and compatibility boundary
 

--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -1,0 +1,73 @@
+# Maintainer architecture
+
+This page describes change boundaries, not product marketing.
+
+## Config to runtime
+
+`bridge.profiles` selects one closed profile and dispatches to its typed source
+compiler. The compiler classifies every source field and produces a resolved
+compatibility plan. `bridge.opd_runtime` derives legal one-device placement and
+the native `RunConfig`; `bridge.opd_plan` binds data files, revisions, profile
+identity and native config into an immutable plan. `OPDTrainer.from_config`
+then constructs the local runtime. No generic dynamic profile loader exists.
+
+The profile identity enters immutable plans and is copied into run manifests,
+teacher-cache metadata, checkpoint identity and export/materialization reports.
+Any reader that combines those artifacts compares the complete identity before
+using their contents.
+
+## Logical roles and physical placement
+
+Actor, teacher and optional reference are distinct logical identities. Rollout
+generates with the current actor policy; teacher scoring observes only the
+visited positions; update consumes provenance-bound targets. Physical
+placement may be resident phased models, an allowed unquantized swap, or a
+shared backbone with separate adapters. Quantized swap remains illegal.
+
+`training.trainer.OPDTrainer` is the compatibility facade and state-machine
+owner. Batching, memory planning, optimizer construction, checkpoint I/O and
+offline-dataset persistence live in dedicated `training` modules; model and
+tokenizer construction live under `models`; cache transactions live under
+`cache`. Public methods remain on the facade so internal extraction does not
+change user imports.
+
+## State and transaction boundaries
+
+Construction reserves a run directory and either finishes a valid starting
+manifest or removes/marks failed construction. `train`, `evaluate`, checkpoint
+load/save and close acquire explicit lifecycle ownership. A transactional
+checkpoint publishes a complete manifest only after all tensor and state files
+are durable. Resume verifies identity and restores the policy/parameter
+versions, cursor, optimizer and RNG state before another rollout. Attaching an
+evaluation writes a derived artifact without rewriting original run
+provenance.
+
+## Import boundary
+
+Base-install modules, CLI help, schemas, config compilation, plan inspection,
+qualification validation and artifact verification must not import Torch.
+Torch is allowed inside trainer/model/loss execution paths and GPU workload
+drivers, and is imported lazily by commands that require `[train]`.
+
+## Adding a profile
+
+Do not modify an existing profile or digest. Add a new typed source model,
+field rules, registry identity, native compiler version, loss-conformance
+version and export version. Prove every accepted field has the claimed native
+effect, add pinned upstream scalar/gradient/optimizer conformance, exercise
+plan/cache/checkpoint/export identity mismatch failures, then complete the
+[upstream lifecycle](upstream-support-policy.md) and GPU qualification.
+
+## Validation entry points
+
+```bash
+pytest -q -m "not gpu and not network"
+pytest -q -m network
+pytest -q -m gpu
+python scripts/release_gate.py --qualification path/to/qualification.json
+```
+
+The first command is CPU CI. Network tests verify pinned remote resources. GPU
+tests exercise local CUDA behavior. The qualification workflow additionally
+uses a built wheel and the exact-SHA release contract.
+

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -8,6 +8,28 @@ after the exact release commit and its remote checks are green.
 
 - [x] Begin from the verified v0.10.0 release and advance only the canonical
       development state to `0.10.1.dev0`.
+- [x] Add strict release-smoke qualification schema, torch-free validation,
+      exact-SHA artifact lookup and release-wheel hash binding.
+- [x] Add the measured RTX 4080 CUDA manifest, exact constraints and drift
+      checker without narrowing ordinary dependency ranges.
+- [x] Add v1 readiness, upstream profile lifecycle, runner safety, maintainer
+      architecture and repository-settings audit documents.
+- [x] Preserve every frozen benchmark and profile identity.
+- [ ] Register the private runner with `[self-hosted, cuda, rtx4080]` and obtain
+      a successful release-smoke artifact for the final candidate SHA.
+- [ ] Run `python scripts/release_gate.py --qualification <artifact>/qualification.json`
+      on the final clean candidate and retain its passed JSON summary.
+
+### Maintainer self-review for v0.10.1
+
+- [ ] Public API and CLI compatibility reviewed; no published command or option
+      silently changed.
+- [ ] Artifact schemas, transactional boundaries and old-version readers
+      reviewed.
+- [ ] Hostile input, archive, path, secret and privacy regression tests passed.
+- [ ] Exact-SHA GPU evidence and known-good environment agree.
+- [ ] README, Chinese README, PyPI text, stable/dev docs and limitations agree.
+- [ ] Owner-only authorship and commit trailers audited.
 
 ## v0.10.0 development
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -16,10 +16,17 @@ after the exact release commit and its remote checks are green.
       architecture and repository-settings audit documents.
 - [x] Preserve every frozen benchmark and profile identity.
 - [ ] Register the private runner with `[self-hosted, cuda, rtx4080]` and obtain
-      a successful release-smoke artifact for the final candidate SHA.
+      one successful first-attempt full-qualification run for the final
+      candidate SHA. Do not recover with workflow rerun; create a fresh
+      dispatch.
 - [ ] Run `python scripts/release_gate.py --candidate-dir <candidate> --candidate-manifest
       <candidate>/candidate-manifest.json --qualification <qualification>/qualification.json`
       on the final clean candidate and retain its passed JSON summary.
+- [ ] Verify the formal dry run consumes same-run `candidate-distributions`
+      and `gpu-full-qualification`, preserves the complete evidence set and
+      does not rebuild candidate distributions.
+- [ ] Verify release assets contain the versioned full qualification records
+      and `qualification-full-SHA256SUMS`; release smoke alone is not accepted.
 
 ### Maintainer self-review for v0.10.1
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -8,8 +8,8 @@ after the exact release commit and its remote checks are green.
 
 - [x] Begin from the verified v0.10.0 release and advance only the canonical
       development state to `0.10.1.dev0`.
-- [x] Add strict release-smoke qualification schema, torch-free validation,
-      exact-SHA artifact lookup and release-wheel hash binding.
+- [x] Build a single hosted-runner candidate and bind the self-hosted RTX 4080
+      qualification, release gate and publisher to those exact bytes.
 - [x] Add the measured RTX 4080 CUDA manifest, exact constraints and drift
       checker without narrowing ordinary dependency ranges.
 - [x] Add v1 readiness, upstream profile lifecycle, runner safety, maintainer
@@ -17,7 +17,8 @@ after the exact release commit and its remote checks are green.
 - [x] Preserve every frozen benchmark and profile identity.
 - [ ] Register the private runner with `[self-hosted, cuda, rtx4080]` and obtain
       a successful release-smoke artifact for the final candidate SHA.
-- [ ] Run `python scripts/release_gate.py --qualification <artifact>/qualification.json`
+- [ ] Run `python scripts/release_gate.py --candidate-dir <candidate> --candidate-manifest
+      <candidate>/candidate-manifest.json --qualification <qualification>/qualification.json`
       on the final clean candidate and retain its passed JSON summary.
 
 ### Maintainer self-review for v0.10.1

--- a/docs/release-qualification.md
+++ b/docs/release-qualification.md
@@ -9,13 +9,16 @@ workflow is manual, not continuous GPU CI and not a pull-request required check.
 
 | level | cadence | executed scope |
 | --- | --- | --- |
-| release smoke | every release candidate | install the hosted-runner candidate wheel, verify import/CLI origin, run CLI doctor/plan/dry-run, pinned Qwen actor and teacher, one rollout/score/update, PEFT export/reload and CUDA teardown |
-| full qualification | important minor or v1 candidate | release smoke plus the unchanged direct-GKD, sampled-k1 and SmolLM2 canonical workloads, including interruption/resume and their existing export/materialization checks |
+| release smoke | diagnostic use | install the hosted-runner candidate wheel, verify import/CLI origin, run CLI doctor/plan/dry-run, pinned Qwen actor and teacher, one rollout/score/update, PEFT export/reload and CUDA teardown |
+| full qualification | every formal release | release smoke plus the unchanged direct-GKD, sampled-k1 and SmolLM2 canonical workloads, including interruption/resume and their existing export/materialization checks |
 
 The smoke budget is intentionally small and is never substituted for a frozen
 full workload or a scientific benchmark. Both levels record runtime
 correctness only. Other hardware is unmeasured; distributed verl execution is
 `not_tested`.
+`gpu-release-smoke` is diagnostic and cannot authorize a formal release. The
+release gate requires `candidate-distributions` and `gpu-full-qualification`
+from the same successful run and first attempt.
 
 ## Repository contract
 
@@ -36,12 +39,22 @@ exact resume, resource, PEFT and scale-out fields, then promotes that same
 record to `full_qualification`; three loose result files cannot claim the
 higher level.
 
+Every dispatch is single-use. Both jobs reject `GITHUB_RUN_ATTEMPT` values
+other than `1`; if infrastructure fails, start a new `workflow_dispatch`
+instead of using GitHub's rerun button. This prevents a hosted candidate from
+attempt 1 being combined with GPU evidence created by attempt 2.
+
 The release workflow queries GitHub Actions for one successful manual
 `gpu.yml` run whose repository, workflow identity and `head_sha` equal the
 release target. It accepts only the unexpired candidate and qualification from
 that same run, safely extracts both, and verifies the candidate manifest, API
 artifact digest when provided, wheel byte hash and qualification bindings. It
-publishes the accepted wheel and sdist without rebuilding them. A committed
+also checks each declared evidence file's regular-file type, byte count and
+SHA-256. Cross-origin artifact redirects retain ordinary API headers but strip
+authorization, proxy authorization and cookies. It publishes the accepted
+wheel and sdist without rebuilding them. The workflow and GitHub Release retain
+the full qualification record, declared evidence files and a separate checksum
+inventory under versioned names. A committed
 JSON file, manual upload, fork run, different workflow or cross-run artifact
 pair cannot satisfy this gate.
 
@@ -69,6 +82,9 @@ Do not add `pull_request` or `pull_request_target`: model downloads and training
 execute repository code on the workstation. Keep the runner application and
 GPU driver patched, keep credentials out of the service environment, and
 review the exact SHA before dispatch.
+Prefer an ephemeral runner for one new dispatch. A rerun is not a recovery
+mechanism: let the runner leave, fix the cause, register a fresh runner and
+create a fresh dispatch.
 
 The job deletes and recreates its qualification virtual environment, clears
 `PYTHONPATH` and `PYTHONHOME`, never uses an editable package, uploads only

--- a/docs/release-qualification.md
+++ b/docs/release-qualification.md
@@ -1,14 +1,15 @@
 # RTX 4080 release qualification
 
 miniVERL has a version-controlled qualification path for the one machine on
-which CUDA behavior is maintainer-measured. It is deliberately a manual
-self-hosted workflow, not hosted GPU CI and not a pull-request required check.
+which CUDA behavior is maintainer-measured. Candidate construction runs on a
+GitHub-hosted runner; only CUDA qualification runs on the private runner. The
+workflow is manual, not continuous GPU CI and not a pull-request required check.
 
 ## Two levels
 
 | level | cadence | executed scope |
 | --- | --- | --- |
-| release smoke | every release candidate | build wheel, clean known-good install, CLI doctor/plan/dry-run, pinned Qwen actor and teacher, one rollout/score/update, PEFT export/reload, CUDA teardown |
+| release smoke | every release candidate | install the hosted-runner candidate wheel, verify import/CLI origin, run CLI doctor/plan/dry-run, pinned Qwen actor and teacher, one rollout/score/update, PEFT export/reload and CUDA teardown |
 | full qualification | important minor or v1 candidate | release smoke plus the unchanged direct-GKD, sampled-k1 and SmolLM2 canonical workloads, including interruption/resume and their existing export/materialization checks |
 
 The smoke budget is intentionally small and is never substituted for a frozen
@@ -18,29 +19,41 @@ correctness only. Other hardware is unmeasured; distributed verl execution is
 
 ## Repository contract
 
-`.github/workflows/gpu.yml` runs only through `workflow_dispatch` on labels
-`[self-hosted, cuda, rtx4080]`. It builds the exact checkout into a wheel,
-installs that wheel in a clean virtual environment using the
-[known-good stack](single-gpu-guide.md), and uploads `gpu-release-smoke`.
-`qualification.json` binds the full source SHA, wheel hash, profile identity,
-model revisions, input and plan hashes, measured environment, output hashes
-and explicit executed/skipped/not-applicable states.
+`.github/workflows/gpu.yml` runs only through `workflow_dispatch`. Its
+GitHub-hosted `build-candidate` job creates exactly one wheel and one sdist with
+the pinned build toolchain, validates them with Twine, and uploads
+`candidate-distributions` with canonical checksums and a strict manifest. The
+dependent `[self-hosted, cuda, rtx4080]` job downloads that same-run artifact,
+validates it before installation, then installs the candidate wheel in a fresh
+virtual environment using the [known-good stack](single-gpu-guide.md). It does
+not build a distribution. `qualification.json` binds the candidate manifest,
+full source SHA, exact wheel hash, workflow run, profile identity, model
+revisions, inputs, measured environment and output hashes. It also proves that
+both the imported package and `miniverl` executable came from the qualification
+environment rather than a checkout or user site.
 For a full run, the workflow additionally validates each canonical result's
 exact resume, resource, PEFT and scale-out fields, then promotes that same
 record to `full_qualification`; three loose result files cannot claim the
 higher level.
 
-The release workflow queries GitHub Actions for a successful manual `gpu.yml`
-run whose `head_sha` equals the release SHA. It downloads and validates that
-artifact, then rebuilds the distributions and rejects a wheel whose hash is not
-the qualified wheel hash. A committed JSON file cannot satisfy this gate.
+The release workflow queries GitHub Actions for one successful manual
+`gpu.yml` run whose repository, workflow identity and `head_sha` equal the
+release target. It accepts only the unexpired candidate and qualification from
+that same run, safely extracts both, and verifies the candidate manifest, API
+artifact digest when provided, wheel byte hash and qualification bindings. It
+publishes the accepted wheel and sdist without rebuilding them. A committed
+JSON file, manual upload, fork run, different workflow or cross-run artifact
+pair cannot satisfy this gate.
 
 Local validation is torch-free:
 
 ```bash
-python scripts/validate_gpu_qualification.py \
-  path/to/qualification.json \
+python scripts/validate_release_chain.py \
+  --candidate-dir path/to/candidate \
+  --candidate-manifest path/to/candidate/candidate-manifest.json \
+  --qualification path/to/qualification/qualification.json \
   --commit <full-release-sha> \
+  --known-good-sha256 <known-good-manifest-sha256> \
   --required-gpu-name "NVIDIA GeForce RTX 4080"
 ```
 
@@ -49,15 +62,19 @@ python scripts/validate_gpu_qualification.py \
 Runner registration is an external maintainer action. Use a dedicated local
 account and working directory, apply the labels exactly, disable unattended
 access by other repository users, and allow only maintainer-dispatched jobs.
+The runner needs repository read access and Actions artifact download/upload;
+it does not need PyPI credentials or a publishing environment. Keep it offline
+when not qualifying a reviewed commit.
 Do not add `pull_request` or `pull_request_target`: model downloads and training
 execute repository code on the workstation. Keep the runner application and
 GPU driver patched, keep credentials out of the service environment, and
 review the exact SHA before dispatch.
 
-The job installs into a fresh workspace virtual environment, never uses an
-editable package, uploads only portable bounded artifacts, and checks cleanup
-targets remain under `GITHUB_WORKSPACE`. Model caches remain runner-local and
-are not uploaded. Rotate the runner token after suspected exposure.
+The job deletes and recreates its qualification virtual environment, clears
+`PYTHONPATH` and `PYTHONHOME`, never uses an editable package, uploads only
+portable bounded artifacts, and checks cleanup targets remain under
+`GITHUB_WORKSPACE`. Model caches remain runner-local and are not uploaded.
+Rotate the runner token after suspected exposure.
 
 ## Activation state
 

--- a/docs/release-qualification.md
+++ b/docs/release-qualification.md
@@ -1,0 +1,67 @@
+# RTX 4080 release qualification
+
+miniVERL has a version-controlled qualification path for the one machine on
+which CUDA behavior is maintainer-measured. It is deliberately a manual
+self-hosted workflow, not hosted GPU CI and not a pull-request required check.
+
+## Two levels
+
+| level | cadence | executed scope |
+| --- | --- | --- |
+| release smoke | every release candidate | build wheel, clean known-good install, CLI doctor/plan/dry-run, pinned Qwen actor and teacher, one rollout/score/update, PEFT export/reload, CUDA teardown |
+| full qualification | important minor or v1 candidate | release smoke plus the unchanged direct-GKD, sampled-k1 and SmolLM2 canonical workloads, including interruption/resume and their existing export/materialization checks |
+
+The smoke budget is intentionally small and is never substituted for a frozen
+full workload or a scientific benchmark. Both levels record runtime
+correctness only. Other hardware is unmeasured; distributed verl execution is
+`not_tested`.
+
+## Repository contract
+
+`.github/workflows/gpu.yml` runs only through `workflow_dispatch` on labels
+`[self-hosted, cuda, rtx4080]`. It builds the exact checkout into a wheel,
+installs that wheel in a clean virtual environment using the
+[known-good stack](single-gpu-guide.md), and uploads `gpu-release-smoke`.
+`qualification.json` binds the full source SHA, wheel hash, profile identity,
+model revisions, input and plan hashes, measured environment, output hashes
+and explicit executed/skipped/not-applicable states.
+For a full run, the workflow additionally validates each canonical result's
+exact resume, resource, PEFT and scale-out fields, then promotes that same
+record to `full_qualification`; three loose result files cannot claim the
+higher level.
+
+The release workflow queries GitHub Actions for a successful manual `gpu.yml`
+run whose `head_sha` equals the release SHA. It downloads and validates that
+artifact, then rebuilds the distributions and rejects a wheel whose hash is not
+the qualified wheel hash. A committed JSON file cannot satisfy this gate.
+
+Local validation is torch-free:
+
+```bash
+python scripts/validate_gpu_qualification.py \
+  path/to/qualification.json \
+  --commit <full-release-sha> \
+  --required-gpu-name "NVIDIA GeForce RTX 4080"
+```
+
+## Runner setup and safety
+
+Runner registration is an external maintainer action. Use a dedicated local
+account and working directory, apply the labels exactly, disable unattended
+access by other repository users, and allow only maintainer-dispatched jobs.
+Do not add `pull_request` or `pull_request_target`: model downloads and training
+execute repository code on the workstation. Keep the runner application and
+GPU driver patched, keep credentials out of the service environment, and
+review the exact SHA before dispatch.
+
+The job installs into a fresh workspace virtual environment, never uses an
+editable package, uploads only portable bounded artifacts, and checks cleanup
+targets remain under `GITHUB_WORKSPACE`. Model caches remain runner-local and
+are not uploaded. Rotate the runner token after suspected exposure.
+
+## Activation state
+
+Repository code, schema, validator and workflows can be complete while runner
+registration remains incomplete. Until the first successful exact-commit run
+exists, report `blocked_external_setup`; do not write “exact-commit
+qualification passed” or “continuous GPU CI”.

--- a/docs/repository-settings.md
+++ b/docs/repository-settings.md
@@ -13,9 +13,13 @@ inspect.
 - Register the private RTX 4080 runner only after following the
   [runner safety guide](release-qualification.md); do not allow fork-triggered
   execution. Apply exactly `self-hosted`, `cuda` and `rtx4080`; keep the runner
-  offline except during a maintainer-dispatched qualification.
+  offline except during a maintainer-dispatched qualification. Prefer an
+  ephemeral registration and never rerun an existing workflow attempt; use a
+  new dispatch so both jobs have `GITHUB_RUN_ATTEMPT=1`.
 - Keep candidate construction on `ubuntu-latest`; the private runner downloads
   the same-run artifact and must never rebuild release distributions.
+- Require formal releases to consume `gpu-full-qualification` from that run.
+  `gpu-release-smoke` is diagnostic and is not release authorization.
 
 Confirm branch rules, tag rules, private vulnerability reporting and runner
 registration in GitHub settings before each major release. Repository files

--- a/docs/repository-settings.md
+++ b/docs/repository-settings.md
@@ -12,9 +12,11 @@ inspect.
 - Keep Actions permissions read-only by default and grant write scopes per job.
 - Register the private RTX 4080 runner only after following the
   [runner safety guide](release-qualification.md); do not allow fork-triggered
-  execution.
+  execution. Apply exactly `self-hosted`, `cuda` and `rtx4080`; keep the runner
+  offline except during a maintainer-dispatched qualification.
+- Keep candidate construction on `ubuntu-latest`; the private runner downloads
+  the same-run artifact and must never rebuild release distributions.
 
 Confirm branch rules, tag rules, private vulnerability reporting and runner
 registration in GitHub settings before each major release. Repository files
 cannot prove those external controls are enabled.
-

--- a/docs/repository-settings.md
+++ b/docs/repository-settings.md
@@ -1,0 +1,20 @@
+# Repository settings audit
+
+This is a maintainer checklist, not a claim about settings that code cannot
+inspect.
+
+- Default branch: `main`.
+- Require a pull request and the current CPU/build/docs/pinned-verl checks.
+- Do not require a second approval; this is a single-maintainer project.
+- Restrict tag creation for release tags to the maintainer.
+- Keep PyPI trusted publishing bound to `release.yml` and environment `pypi`.
+- Enable private vulnerability reporting.
+- Keep Actions permissions read-only by default and grant write scopes per job.
+- Register the private RTX 4080 runner only after following the
+  [runner safety guide](release-qualification.md); do not allow fork-triggered
+  execution.
+
+Confirm branch rules, tag rules, private vulnerability reporting and runner
+registration in GitHub settings before each major release. Repository files
+cannot prove those external controls are enabled.
+

--- a/docs/security-review-v0.10.1.md
+++ b/docs/security-review-v0.10.1.md
@@ -1,0 +1,29 @@
+# v0.10.1 focused security review
+
+This review covers input and artifact boundaries touched by the current local
+runtime and release qualification. It does not claim sandboxing of model code
+or third-party libraries.
+
+| surface | enforced boundary | regression evidence |
+| --- | --- | --- |
+| YAML and overrides | `safe_load`, typed fields, no unresolved interpolation, no shell evaluation | config, interpolation and hostile-tag tests |
+| Parquet and nested metadata | typed prompt rows; bridge inspection has row/byte bounds | dataset streaming, semantics and metadata privacy tests |
+| bundle trees | regular files under one root; symlink, junction/reparse, traversal, count and nominal-size rejection | hostile-bundle and preflight tests |
+| qualification ZIP | exact GitHub run/SHA, bounded entries and expanded bytes, no traversal or symlink, declared hashes | qualification extraction and binding tests |
+| reward scaffold | fail-closed AST inspection; dynamic import requires the explicit trusted path | reward static and definition-time tests |
+| checkpoints/caches | finite JSON plus safetensors, checksums and atomic publication; no pickle | cache, checkpoint, resume and transaction tests |
+| JSON | non-finite numbers rejected; strict parsers bound depth, members and size where model text is accepted | protocol, strict-JSON and qualification tests |
+| output publication | input/output conflict checks, exclusive run locks and transactional directory replacement | bridge publish, run-lock and lifecycle tests |
+| privacy | portable projections remove home/user/environment/credential text; qualification JSON rejects private paths | privacy completeness, hardware and qualification tests |
+
+Repository code uses argv-based subprocess calls and does not add a
+`shell=True` execution path. The pinned conformance tests execute checked-out
+upstream source only inside their explicit test environment. Model repositories
+still become executable when a user opts into `trust_remote_code: true`; the
+default remains false.
+
+The review found one public maintenance defect: `SECURITY.md` still named the
+obsolete 0.2.4 line. The canonical release-state checker now owns that current
+stable claim. The new external qualification download also introduced a new
+archive boundary, so extraction was implemented fail-closed with dedicated
+tests rather than relying on `extractall`.

--- a/docs/single-gpu-guide.md
+++ b/docs/single-gpu-guide.md
@@ -21,9 +21,7 @@ RTX 4080. Its portable defaults are:
 ## Start here
 
 First use the [PyTorch install selector](https://pytorch.org/get-started/locally/)
-to install the wheel matching your CUDA driver. The measured stack used the
-following channel; choose a different supported channel when your system needs
-one:
+to install the wheel matching your CUDA driver. For a flexible install:
 
 ```bash
 python -m pip install torch --index-url https://download.pytorch.org/whl/cu130
@@ -35,6 +33,23 @@ miniverl train recipes/qwen_consumer_gpu_calc.yaml --dry-run
 
 The `train,cuda` extra adds the training and quantization dependencies; it does
 not select a CUDA-enabled PyTorch build on its own.
+
+For the exact stack measured by the maintainer on one RTX 4080, use the
+machine-readable
+[`environments/known-good-rtx4080-cu130.json`](https://github.com/DaoyuanLi2816/mini-verl/blob/main/environments/known-good-rtx4080-cu130.json)
+and its constraints:
+
+```bash
+python -m pip install "torch==2.13.0+cu130" \
+  --index-url https://download.pytorch.org/whl/cu130
+python -m pip install "miniverl[train,cuda]" \
+  --constraint environments/known-good-rtx4080-cu130.txt
+python scripts/check_known_good_environment.py
+```
+
+The ordinary dependency ranges remain the library contract. This manifest is
+one maintainer-measured known-good stack, not a universal lock: other GPUs are
+unmeasured, and other CUDA/PyTorch combinations remain user-selected.
 
 Then watch free memory in another terminal before the real run:
 

--- a/docs/single-gpu-guide.md
+++ b/docs/single-gpu-guide.md
@@ -47,9 +47,11 @@ python -m pip install "miniverl[train,cuda]" \
 python scripts/check_known_good_environment.py
 ```
 
-The ordinary dependency ranges remain the library contract. This manifest is
-one maintainer-measured known-good stack, not a universal lock: other GPUs are
-unmeasured, and other CUDA/PyTorch combinations remain user-selected.
+The ordinary dependency ranges remain the library contract. In the manifest,
+Python and package pins are required reproducibility inputs; GPU name, VRAM,
+driver and CUDA runtime are observed audit fields, not install requirements.
+This is one maintainer-measured known-good stack, not a universal lock: other
+GPUs are unmeasured, and other CUDA/PyTorch combinations remain user-selected.
 
 Then watch free memory in another terminal before the real run:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -72,9 +72,15 @@ another branch or a rebuilt local JSON is intentionally insufficient.
 
 **Fix.** Register the private runner with labels `[self-hosted, cuda,
 rtx4080]`, review the candidate SHA, dispatch `gpu.yml` at that SHA, and wait
-for the `gpu-release-smoke` artifact. Validate it with `miniverl qualification
-validate`. Until then the correct status is `blocked_external_setup`, not
-passed GPU CI.
+for both `candidate-distributions` and `gpu-full-qualification` from that one
+run. Validate the full record with `miniverl qualification validate`.
+`gpu-release-smoke` is diagnostic only. Until the full record exists, the
+correct status is `blocked_external_setup`, not passed GPU CI.
+
+If the run fails, do not use **Re-run jobs**. Qualification requires
+`GITHUB_RUN_ATTEMPT=1` to prevent cross-attempt artifact reuse. Fix the cause,
+make a fresh ephemeral runner available, then create a new
+`workflow_dispatch` run for the same reviewed SHA.
 
 ## Missing extras
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -37,6 +37,44 @@ Contents:
 - [Config validation errors](#config-validation-errors)
 - [Report or eval on a non-run directory](#report-or-eval-on-a-non-run-directory)
 - [Resume refused: config digest mismatch](#resume-refused-config-digest-mismatch)
+- [Known-good environment mismatch](#known-good-environment-mismatch)
+- [Release qualification not found](#release-qualification-not-found)
+
+## Known-good environment mismatch
+
+**Symptom**
+
+```
+installed packages do not match the known-good stack
+```
+
+**Cause.** The qualification smoke is deliberately stricter than the flexible
+library dependency ranges. It requires the exact versions in
+`environments/known-good-rtx4080-cu130.json`; installing the `cuda` extra does
+not select a CUDA PyTorch wheel or pin the rest of the stack.
+
+**Fix.** Install PyTorch from the manifest's explicit index, apply the adjacent
+constraints, then run `python scripts/check_known_good_environment.py`. If you
+choose another stack, it may still be within the supported dependency ranges,
+but it is not the maintainer-measured qualification environment.
+
+## Release qualification not found
+
+**Symptom**
+
+```
+no successful gpu.yml workflow_dispatch run exists for <sha>
+```
+
+**Cause.** The release workflow accepts only a successful manual GPU artifact
+whose `head_sha` is the exact release commit. A successful run for a parent,
+another branch or a rebuilt local JSON is intentionally insufficient.
+
+**Fix.** Register the private runner with labels `[self-hosted, cuda,
+rtx4080]`, review the candidate SHA, dispatch `gpu.yml` at that SHA, and wait
+for the `gpu-release-smoke` artifact. Validate it with `miniverl qualification
+validate`. Until then the correct status is `blocked_external_setup`, not
+passed GPU CI.
 
 ## Missing extras
 

--- a/docs/upstream-support-policy.md
+++ b/docs/upstream-support-policy.md
@@ -1,0 +1,29 @@
+# Upstream verl support policy
+
+miniVERL supports closed compatibility profiles, not “latest verl” and not
+arbitrary upstream configuration. The machine-readable matrix is
+[`generated/upstream-support-matrix.json`](generated/upstream-support-matrix.json).
+
+## Lifecycle
+
+- **active**: documented local execution, conformance and current release
+  qualification are maintained.
+- **maintenance**: identity and readers remain stable; security and clear
+  compatibility defects may be fixed, but no new source-field coverage is
+  implied.
+- **legacy**: retained for artifact inspection or migration only; no runnable
+  support claim.
+- **unsupported**: no profile identity exists and generic YAML must fail closed.
+
+Every profile pins an upstream release and full commit. Once published, its
+identity, field meanings, objective and upstream pin never move in place.
+Promotion of another upstream version requires a separately named profile,
+complete field matrix, upstream conformance, native runtime effects,
+export/materialization checks, and exact-commit RTX 4080 qualification. A
+template or partially compiling YAML is not support.
+
+The active direct-GKD and sampled-k1 profiles both target official verl
+`v0.8.0` at `7aed6b230776f963fa09509c10d9c3a767d1102c`. No v0.9-or-newer profile is
+currently supported. Existing bridge artifacts remain independent-project
+handoffs and do not imply upstream endorsement.
+

--- a/docs/v1-readiness.md
+++ b/docs/v1-readiness.md
@@ -1,0 +1,55 @@
+# v1 readiness contract
+
+Version 1 is a stability promise, not a feature-count milestone. miniVERL may
+be proposed as a v1 candidate only when every required row below is `passed` on
+the exact candidate commit. The current development line remains Beta.
+
+## Compatibility commitments
+
+- Stable CLI commands retain their names, option meanings, exit-code class and
+  documented JSON shape. A rename or semantic change requires deprecation for
+  at least one minor release.
+- `miniverl.config.RunConfig`, `miniverl.trainer.OPDTrainer` and documented
+  adapter/cache/checkpoint readers remain import-compatible across the v1
+  line. Internal coordinators are not public APIs.
+- Published compatibility profile identities never drift. A new upstream verl
+  version, estimator or compiler contract receives a new profile identity.
+- Plan, trajectory, teacher-cache, checkpoint, run-manifest, hardware-record,
+  qualification and export-bundle schemas are versioned. Readers either accept
+  an older version exactly or reject it with a migration path; writers never
+  silently reuse a version number for new semantics.
+- Security fixes may tighten acceptance of hostile or ambiguous input without
+  a deprecation window. They must not reinterpret an accepted training
+  objective.
+
+Exact resume means the documented tensors, progress cursor, policy version,
+optimizer/RNG state and trajectory order match for an eligible same-platform,
+same-profile run. It does not promise equivalence across different CUDA,
+PyTorch, kernels, model revisions, objectives or unsupported distributed
+runtimes.
+
+## Candidate gate
+
+| requirement | required state |
+| --- | --- |
+| stable docs and PyPI quickstart agree with `release-state.yaml` | passed |
+| base wheel install remains torch-free | passed |
+| known-good CUDA environment is machine-readable and installable | passed |
+| release smoke is successful on one RTX 4080 for the exact candidate SHA | passed |
+| full qualification covers both profiles, SmolLM2 and exact resume | passed for a v1 candidate |
+| public schemas and profile lifecycle policy are documented | passed |
+| pre-release gate, build, Twine, sdist, link, visual and privacy checks | passed |
+| deprecation and supported-version policy are current | passed |
+| working tree, tag target, distributions and attestations share provenance | passed |
+
+The following are explicitly outside v1: arbitrary verl YAML, PPO, GRPO,
+critics, general reward pipelines, Ray, FSDP, Megatron, vLLM/SGLang execution,
+multi-GPU, multi-node, distributed launch, multimodal models, multiple teachers
+and broad cross-hardware qualification. Scale-out artifacts do not prove
+distributed execution.
+
+At present miniVERL is **not a v1 candidate**: the exact-SHA qualification
+workflow is defined, but its private runner registration and first successful
+artifact are an external pending step. No version change follows from this
+document alone.
+

--- a/docs/v1-readiness.md
+++ b/docs/v1-readiness.md
@@ -35,12 +35,12 @@ runtimes.
 | stable docs and PyPI quickstart agree with `release-state.yaml` | passed |
 | base wheel install remains torch-free | passed |
 | known-good CUDA environment is machine-readable and installable | passed |
-| release smoke is successful on one RTX 4080 for the exact candidate SHA | passed |
+| hosted-built candidate wheel is the exact wheel qualified on one RTX 4080 | passed |
 | full qualification covers both profiles, SmolLM2 and exact resume | passed for a v1 candidate |
 | public schemas and profile lifecycle policy are documented | passed |
 | pre-release gate, build, Twine, sdist, link, visual and privacy checks | passed |
 | deprecation and supported-version policy are current | passed |
-| working tree, tag target, distributions and attestations share provenance | passed |
+| candidate manifest, same-run qualification, tag, published bytes and attestations share provenance | passed |
 
 The following are explicitly outside v1: arbitrary verl YAML, PPO, GRPO,
 critics, general reward pipelines, Ray, FSDP, Megatron, vLLM/SGLang execution,
@@ -48,8 +48,7 @@ multi-GPU, multi-node, distributed launch, multimodal models, multiple teachers
 and broad cross-hardware qualification. Scale-out artifacts do not prove
 distributed execution.
 
-At present miniVERL is **not a v1 candidate**: the exact-SHA qualification
-workflow is defined, but its private runner registration and first successful
-artifact are an external pending step. No version change follows from this
-document alone.
-
+At present miniVERL is **not a v1 candidate**: the byte-identical candidate
+chain is defined, but private-runner activation and its first successful
+same-run candidate/qualification pair are external pending steps. No version
+change follows from this document alone.

--- a/environments/known-good-rtx4080-cu130.json
+++ b/environments/known-good-rtx4080-cu130.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "name": "rtx4080-windows-cu130-v1",
+  "status": "maintainer_measured",
+  "measured_at": "2026-08-14",
+  "source_release": {
+    "version": "0.10.0",
+    "commit": "51264f86e8226b1abc6ca1901d379c5e6fabb81e",
+    "wheel_sha256": "ff6bff4169dc5076fb6f3b10c2e38003dd681fb6513b1a0e3719948af16cc560"
+  },
+  "platform": {
+    "os": "Windows 11",
+    "python": "3.10.11"
+  },
+  "hardware": {
+    "gpu": "NVIDIA GeForce RTX 4080",
+    "vram_mib": 16376,
+    "driver": "596.49",
+    "cuda_runtime": "13.0"
+  },
+  "pytorch": {
+    "package": "torch",
+    "version": "2.13.0+cu130",
+    "index_url": "https://download.pytorch.org/whl/cu130"
+  },
+  "packages": {
+    "torch": "2.13.0+cu130",
+    "transformers": "5.14.1",
+    "peft": "0.18.0",
+    "accelerate": "1.14.0",
+    "bitsandbytes": "0.50.0",
+    "numpy": "2.2.6",
+    "pyarrow": "25.0.0",
+    "safetensors": "0.8.0"
+  },
+  "constraints": "environments/known-good-rtx4080-cu130.txt",
+  "scope": {
+    "classification": "maintainer-measured on one RTX 4080",
+    "other_hardware": "unmeasured",
+    "distributed_execution": "not_tested"
+  }
+}

--- a/environments/known-good-rtx4080-cu130.json
+++ b/environments/known-good-rtx4080-cu130.json
@@ -8,30 +8,29 @@
     "commit": "51264f86e8226b1abc6ca1901d379c5e6fabb81e",
     "wheel_sha256": "ff6bff4169dc5076fb6f3b10c2e38003dd681fb6513b1a0e3719948af16cc560"
   },
-  "platform": {
-    "os": "Windows 11",
-    "python": "3.10.11"
+  "required": {
+    "gpu_name": "NVIDIA GeForce RTX 4080",
+    "python": "3.10.11",
+    "packages": {
+      "torch": "2.13.0+cu130",
+      "transformers": "5.14.1",
+      "peft": "0.18.0",
+      "accelerate": "1.14.0",
+      "bitsandbytes": "0.50.0",
+      "numpy": "2.2.6",
+      "pyarrow": "25.0.0",
+      "safetensors": "0.8.0"
+    }
   },
-  "hardware": {
-    "gpu": "NVIDIA GeForce RTX 4080",
+  "observed": {
+    "os": "Windows 11",
     "vram_mib": 16376,
     "driver": "596.49",
     "cuda_runtime": "13.0"
   },
   "pytorch": {
     "package": "torch",
-    "version": "2.13.0+cu130",
     "index_url": "https://download.pytorch.org/whl/cu130"
-  },
-  "packages": {
-    "torch": "2.13.0+cu130",
-    "transformers": "5.14.1",
-    "peft": "0.18.0",
-    "accelerate": "1.14.0",
-    "bitsandbytes": "0.50.0",
-    "numpy": "2.2.6",
-    "pyarrow": "25.0.0",
-    "safetensors": "0.8.0"
   },
   "constraints": "environments/known-good-rtx4080-cu130.txt",
   "scope": {

--- a/environments/known-good-rtx4080-cu130.txt
+++ b/environments/known-good-rtx4080-cu130.txt
@@ -1,0 +1,10 @@
+# miniVERL known-good top-level ML stack; see the adjacent JSON manifest.
+# Install the CUDA PyTorch wheel from its explicit index before using this file.
+torch==2.13.0+cu130
+transformers==5.14.1
+peft==0.18.0
+accelerate==1.14.0
+bitsandbytes==0.50.0; platform_system != "Darwin"
+numpy==2.2.6
+pyarrow==25.0.0
+safetensors==0.8.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
   - SmolLM2 developer workload: smollm2-opd-workload.md
   - RTX 4080 PG-k1 workload: verl-pg-k1-workload.md
   - Start on one GPU: single-gpu-guide.md
+  - Release qualification: release-qualification.md
   - Align:
       - "External Alignment Gate v1: early stop": alignment-external/alignment-external-v1.md
       - When OPD should follow SFT: alignment-lab/when-opd-should-follow-sft.md
@@ -69,6 +70,12 @@ nav:
       - Demo recording script: verl-bridge-demo.md
       - Legacy environment/PPO bridge: legacy-verl-bridge.md
   - Community benchmarks: community-benchmarks.md
+  - Maintainer:
+      - Architecture: maintainer-architecture.md
+      - Upstream support policy: upstream-support-policy.md
+      - v1 readiness: v1-readiness.md
+      - Repository settings audit: repository-settings.md
+      - v0.10.1 security review: security-review-v0.10.1.md
   - Schemas:
       - Trajectories: trajectory-schema.md
       - Benchmark results: benchmarking.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ include = [
   "/docs",
   "/paper",
   "/scripts",
+  "/environments",
   "/.github",
   "/README.md",
   "/README.zh-CN.md",

--- a/scripts/build_release_candidate.py
+++ b/scripts/build_release_candidate.py
@@ -1,0 +1,58 @@
+"""Build or validate the single miniVERL release-candidate byte set."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from miniverl import __version__  # noqa: E402
+from miniverl.release_candidate import (  # noqa: E402
+    build_release_candidate,
+    validate_candidate_directory,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--commit")
+    parser.add_argument("--repository")
+    parser.add_argument("--workflow-path")
+    parser.add_argument("--run-id", type=int)
+    parser.add_argument("--run-attempt", type=int)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    commit = args.commit
+    if commit is None:
+        commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    if args.check:
+        problems = validate_candidate_directory(
+            args.output,
+            expected_commit=commit,
+            expected_version=__version__,
+            expected_repository=args.repository,
+            expected_workflow_path=args.workflow_path,
+            expected_run_id=args.run_id,
+            expected_run_attempt=args.run_attempt,
+        )
+        print(json.dumps({"valid": not problems, "problems": problems}, sort_keys=True))
+        return 1 if problems else 0
+    record = build_release_candidate(args.output, source_commit=commit, project_root=ROOT)
+    print(json.dumps(record.model_dump(mode="json"), sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_known_good_environment.py
+++ b/scripts/check_known_good_environment.py
@@ -1,0 +1,104 @@
+"""Check the measured CUDA manifest, constraints and install documentation agree."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+MANIFEST = Path("environments/known-good-rtx4080-cu130.json")
+REQUIRED_PACKAGES = {
+    "torch",
+    "transformers",
+    "peft",
+    "accelerate",
+    "bitsandbytes",
+    "numpy",
+    "pyarrow",
+    "safetensors",
+}
+
+
+def _constraints(path: Path) -> dict[str, str]:
+    versions: dict[str, str] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        requirement = line.split(";", 1)[0].strip()
+        if "==" not in requirement:
+            raise ValueError(f"constraint is not exact: {raw}")
+        name, version = requirement.split("==", 1)
+        versions[name.strip().lower()] = version.strip()
+    return versions
+
+
+def check_known_good_environment(root: Path) -> list[str]:
+    problems: list[str] = []
+    try:
+        payload: dict[str, Any] = json.loads((root / MANIFEST).read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        return [f"manifest: {exc}"]
+    if payload.get("schema_version") != 1:
+        problems.append("manifest: schema_version must be 1")
+    if payload.get("status") != "maintainer_measured":
+        problems.append("manifest: status must be maintainer_measured")
+    packages = payload.get("packages")
+    if not isinstance(packages, dict):
+        return [*problems, "manifest: packages must be an object"]
+    missing = sorted(REQUIRED_PACKAGES - packages.keys())
+    if missing:
+        problems.append("manifest: missing packages " + ", ".join(missing))
+    constraints_value = payload.get("constraints")
+    if not isinstance(constraints_value, str):
+        return [*problems, "manifest: constraints must be a path"]
+    constraints_path = root / constraints_value
+    try:
+        pinned = _constraints(constraints_path)
+    except (OSError, UnicodeError, ValueError) as exc:
+        return [*problems, f"constraints: {exc}"]
+    for package, expected in packages.items():
+        actual = pinned.get(package.lower())
+        if actual != expected:
+            problems.append(
+                f"constraints: {package} is {actual!r}, expected manifest value {expected!r}"
+            )
+    pytorch = payload.get("pytorch") or {}
+    if pytorch.get("version") != packages.get("torch"):
+        problems.append("manifest: pytorch.version and packages.torch disagree")
+    if not str(pytorch.get("index_url", "")).startswith("https://download.pytorch.org/whl/"):
+        problems.append("manifest: PyTorch index must be an official CUDA wheel index")
+    private = re.compile(r"(?i)(?:[a-z]:\\users\\|/home/|onedrive|token|credential)")
+    if private.search(json.dumps(payload, sort_keys=True)):
+        problems.append("privacy: known-good manifest contains private text")
+    guide = " ".join((root / "docs/single-gpu-guide.md").read_text(encoding="utf-8").split())
+    for required in (
+        constraints_value,
+        str(pytorch.get("index_url")),
+        f"torch=={pytorch.get('version')}",
+        "other GPUs are unmeasured",
+    ):
+        if required not in guide:
+            problems.append(f"docs: single-GPU guide is missing {required!r}")
+    return problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    problems = check_known_good_environment(args.root)
+    payload = {"valid": not problems, "problems": problems}
+    print(
+        json.dumps(payload, sort_keys=True)
+        if args.json
+        else "\n".join(problems) or "known-good environment agrees"
+    )
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_known_good_environment.py
+++ b/scripts/check_known_good_environment.py
@@ -45,7 +45,11 @@ def check_known_good_environment(root: Path) -> list[str]:
         problems.append("manifest: schema_version must be 1")
     if payload.get("status") != "maintainer_measured":
         problems.append("manifest: status must be maintainer_measured")
-    packages = payload.get("packages")
+    required = payload.get("required")
+    observed = payload.get("observed")
+    if not isinstance(required, dict) or not isinstance(observed, dict):
+        return [*problems, "manifest: required and observed must be objects"]
+    packages = required.get("packages")
     if not isinstance(packages, dict):
         return [*problems, "manifest: packages must be an object"]
     missing = sorted(REQUIRED_PACKAGES - packages.keys())
@@ -66,10 +70,14 @@ def check_known_good_environment(root: Path) -> list[str]:
                 f"constraints: {package} is {actual!r}, expected manifest value {expected!r}"
             )
     pytorch = payload.get("pytorch") or {}
-    if pytorch.get("version") != packages.get("torch"):
-        problems.append("manifest: pytorch.version and packages.torch disagree")
     if not str(pytorch.get("index_url", "")).startswith("https://download.pytorch.org/whl/"):
         problems.append("manifest: PyTorch index must be an official CUDA wheel index")
+    for field in ("gpu_name", "python"):
+        if not required.get(field):
+            problems.append(f"manifest: required.{field} must be non-empty")
+    for field in ("os", "driver", "cuda_runtime", "vram_mib"):
+        if field not in observed:
+            problems.append(f"manifest: observed.{field} is missing")
     private = re.compile(r"(?i)(?:[a-z]:\\users\\|/home/|onedrive|token|credential)")
     if private.search(json.dumps(payload, sort_keys=True)):
         problems.append("privacy: known-good manifest contains private text")
@@ -77,8 +85,9 @@ def check_known_good_environment(root: Path) -> list[str]:
     for required in (
         constraints_value,
         str(pytorch.get("index_url")),
-        f"torch=={pytorch.get('version')}",
+        f"torch=={packages.get('torch')}",
         "other GPUs are unmeasured",
+        "driver and CUDA runtime are observed audit fields",
     ):
         if required not in guide:
             problems.append(f"docs: single-GPU guide is missing {required!r}")

--- a/scripts/check_pypi_publish_state.py
+++ b/scripts/check_pypi_publish_state.py
@@ -1,0 +1,95 @@
+"""Decide whether exact release-candidate bytes still need PyPI publication."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+def _request_version(project: str, version: str, *, attempts: int, timeout: int) -> Any | None:
+    project_part = urllib.parse.quote(project, safe="")
+    version_part = urllib.parse.quote(version, safe="")
+    request = urllib.request.Request(
+        f"https://pypi.org/pypi/{project_part}/{version_part}/json",
+        headers={"Accept": "application/json", "User-Agent": "miniVERL-release-state"},
+    )
+    for attempt in range(1, attempts + 1):
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                return json.load(response)
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return None
+            if attempt == attempts:
+                raise RuntimeError(f"PyPI JSON request failed with HTTP {exc.code}") from None
+        except (urllib.error.URLError, TimeoutError):
+            if attempt == attempts:
+                raise RuntimeError("PyPI JSON request failed after bounded retries") from None
+        time.sleep(min(attempt, 3))
+    raise AssertionError("retry loop must return or raise")
+
+
+def publish_needed(
+    manifest_path: Path,
+    *,
+    project: str,
+    attempts: int = 4,
+    timeout: int = 15,
+) -> bool:
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if payload.get("kind") != "miniverl_release_candidate":
+        raise ValueError("candidate manifest kind is invalid")
+    version = payload.get("miniverl_version")
+    expected = {payload[key]["filename"]: payload[key]["sha256"] for key in ("wheel", "sdist")}
+    public = _request_version(project, version, attempts=attempts, timeout=timeout)
+    if public is None:
+        return True
+    urls = public.get("urls") if isinstance(public, dict) else None
+    if not isinstance(urls, list):
+        raise ValueError("PyPI response has no release file list")
+    observed: dict[str, str] = {}
+    for item in urls:
+        filename = item.get("filename") if isinstance(item, dict) else None
+        digest = (item.get("digests") or {}).get("sha256") if isinstance(item, dict) else None
+        if not isinstance(filename, str) or not isinstance(digest, str):
+            raise ValueError("PyPI release file identity is incomplete")
+        if filename in observed:
+            raise ValueError(f"PyPI release repeats file {filename!r}")
+        observed[filename] = digest
+    if observed != expected:
+        raise ValueError(
+            "PyPI version exists but its complete file set does not match the candidate"
+        )
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--project", default="miniverl")
+    parser.add_argument("--attempts", type=int, default=4)
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args()
+    needed = publish_needed(
+        args.manifest,
+        project=args.project,
+        attempts=args.attempts,
+        timeout=args.timeout,
+    )
+    result = {"publish_needed": needed}
+    if args.github_output is not None:
+        with args.github_output.open("a", encoding="utf-8", newline="\n") as output:
+            output.write(f"publish_needed={str(needed).lower()}\n")
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/promote_full_gpu_qualification.py
+++ b/scripts/promote_full_gpu_qualification.py
@@ -1,0 +1,147 @@
+"""Bind the three canonical full workloads into a strict qualification artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+from miniverl.qualification import GPUQualification, sha256_file, validate_qualification_file
+from miniverl.utils.runs import write_json_atomic
+
+_RESULTS = {
+    "direct": ("single_gpu_opd_developer_workload", "measured"),
+    "pg_k1": ("single_gpu_verl_pg_k1_systems_workload", "measured"),
+    "smollm2": ("single_gpu_smollm2_direct_gkd_developer_workload", "maintainer_measured"),
+}
+_EQUIVALENCE = (
+    "adapter_and_optimizer_byte_identical",
+    "training_state_fields_identical",
+    "trajectories_byte_identical",
+)
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(
+        path.read_text(encoding="utf-8"),
+        parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)),
+    )
+
+
+def _validate_result(name: str, payload: dict[str, Any], qualification: GPUQualification) -> None:
+    expected_kind, expected_status = _RESULTS[name]
+    if payload.get("schema_version") != 1:
+        raise ValueError(f"{name}: unsupported schema version")
+    if payload.get("kind") != expected_kind or payload.get("status") != expected_status:
+        raise ValueError(f"{name}: unexpected kind or status")
+    if payload.get("source_commit") != qualification.source_commit:
+        raise ValueError(f"{name}: source commit does not match release smoke")
+    if payload.get("miniverl_version") != qualification.miniverl_version:
+        raise ValueError(f"{name}: miniVERL version does not match release smoke")
+    hardware = payload.get("hardware") or {}
+    if hardware.get("gpu") != qualification.environment.gpu_name or hardware.get("gpu_count") != 1:
+        raise ValueError(f"{name}: hardware does not match release smoke")
+    resume = payload.get("resume") or {}
+    if resume.get("status") != "exact_match" or any(
+        resume.get(field) is not True for field in _EQUIVALENCE
+    ):
+        raise ValueError(f"{name}: uninterrupted/resume equivalence did not pass")
+    if (payload.get("resource_contract") or {}).get("peak_reserved_within_limit") is not True:
+        raise ValueError(f"{name}: VRAM resource contract did not pass")
+    if (payload.get("verl") or {}).get("distributed_execution_tested") is not False:
+        raise ValueError(f"{name}: distributed execution must remain not tested")
+    if (
+        name in {"direct", "smollm2"}
+        and (payload.get("artifacts") or {}).get("standard_peft_load_verified") is not True
+    ):
+        raise ValueError(f"{name}: standard PEFT reload was not verified")
+    if name == "smollm2":
+        scaleout = payload.get("scaleout") or {}
+        required = (
+            "artifact_bundle_complete",
+            "upstream_config_parse_passed",
+            "model_data_load_smoke_passed",
+            "launchable",
+        )
+        if any(scaleout.get(field) is not True for field in required):
+            raise ValueError("smollm2: export/materialize/load checks did not pass")
+        if scaleout.get("distributed_execution_tested") is not False:
+            raise ValueError("smollm2: distributed execution must remain not tested")
+
+
+def promote(
+    qualification_path: Path,
+    *,
+    direct: Path,
+    pg_k1: Path,
+    smollm2: Path,
+) -> GPUQualification:
+    problems = validate_qualification_file(qualification_path)
+    if problems:
+        raise ValueError("invalid release smoke: " + "; ".join(problems))
+    payload = _load(qualification_path)
+    qualification = GPUQualification.model_validate(payload)
+    if qualification.level != "release_smoke":
+        raise ValueError("only a release_smoke artifact can be promoted")
+    sources = {"direct": direct, "pg_k1": pg_k1, "smollm2": smollm2}
+    results = {name: _load(path) for name, path in sources.items()}
+    for name, result in results.items():
+        _validate_result(name, result, qualification)
+
+    root = qualification_path.parent
+    destination = root / "full"
+    destination.mkdir(parents=True, exist_ok=False)
+    smoke_copy = destination / "release-smoke.json"
+    shutil.copy2(qualification_path, smoke_copy)
+    additions = [("release_smoke_record", smoke_copy)]
+    for name, source in sources.items():
+        target = destination / f"{name}.json"
+        shutil.copy2(source, target)
+        additions.append((f"full_{name}_result", target))
+    for name, path in additions:
+        payload["artifacts"].append(
+            {
+                "name": name,
+                "path": path.relative_to(root).as_posix(),
+                "sha256": sha256_file(path),
+                "bytes": path.stat().st_size,
+            }
+        )
+    payload["level"] = "full_qualification"
+    payload["checks"]["executed"].extend(
+        [
+            "direct_gkd_resume_equivalence",
+            "sampled_k1_resume_equivalence",
+            "smollm2_resume_equivalence",
+            "export_materialize_doctor",
+        ]
+    )
+    promoted = GPUQualification.model_validate(payload)
+    write_json_atomic(qualification_path, promoted.model_dump(mode="json"))
+    final_problems = validate_qualification_file(qualification_path)
+    if final_problems:
+        raise ValueError("promoted qualification is invalid: " + "; ".join(final_problems))
+    return promoted
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--qualification", required=True, type=Path)
+    parser.add_argument("--direct", required=True, type=Path)
+    parser.add_argument("--pg-k1", required=True, type=Path)
+    parser.add_argument("--smollm2", required=True, type=Path)
+    args = parser.parse_args()
+    promoted = promote(
+        args.qualification,
+        direct=args.direct,
+        pg_k1=args.pg_k1,
+        smollm2=args.smollm2,
+    )
+    print(json.dumps(promoted.model_dump(mode="json"), sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/publish_gpu_qualification_schema.py
+++ b/scripts/publish_gpu_qualification_schema.py
@@ -1,0 +1,37 @@
+"""Generate the committed strict GPU qualification JSON Schema."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from miniverl.qualification import qualification_json_schema
+
+ROOT = Path(__file__).resolve().parents[1]
+TARGET = ROOT / "docs/generated/gpu-qualification-v1.schema.json"
+
+
+def render() -> str:
+    return json.dumps(qualification_json_schema(), indent=2, sort_keys=True) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    expected = render()
+    if args.check:
+        if not TARGET.is_file() or TARGET.read_text(encoding="utf-8") != expected:
+            print(f"stale generated schema: {TARGET.relative_to(ROOT).as_posix()}")
+            return 1
+        print("GPU qualification schema is current")
+        return 0
+    TARGET.parent.mkdir(parents=True, exist_ok=True)
+    TARGET.write_text(expected, encoding="utf-8", newline="\n")
+    print(TARGET.relative_to(ROOT).as_posix())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_gate.py
+++ b/scripts/release_gate.py
@@ -27,10 +27,12 @@ class Gate:
 
 def gate_plan(
     *,
+    candidate_dir: Path,
+    candidate_wheel: Path,
+    candidate_sdist: Path,
     qualification: Path,
     site: Path,
     screenshots: Path,
-    dist: Path,
     source_commit: str | None = None,
     known_good_sha256: str | None = None,
 ) -> list[Gate]:
@@ -46,6 +48,18 @@ def gate_plan(
         Gate(
             "qualification_schema",
             (python, "scripts/publish_gpu_qualification_schema.py", "--check"),
+        ),
+        Gate(
+            "candidate_artifact",
+            (
+                python,
+                "scripts/build_release_candidate.py",
+                "--output",
+                str(candidate_dir),
+                "--commit",
+                source_commit,
+                "--check",
+            ),
         ),
         Gate("ruff_check", (python, "-m", "ruff", "check", ".")),
         Gate("ruff_format", (python, "-m", "ruff", "format", "--check", ".")),
@@ -97,13 +111,20 @@ def gate_plan(
             ),
             3600,
         ),
-        Gate("build", (python, "-m", "build", "--outdir", str(dist))),
-        Gate("twine", (python, "-m", "twine", "check", str(dist / "*"))),
         Gate(
-            "gpu_qualification",
+            "twine",
+            (python, "-m", "twine", "check", str(candidate_wheel), str(candidate_sdist)),
+        ),
+        Gate(
+            "release_evidence_chain",
             (
                 python,
-                "scripts/validate_gpu_qualification.py",
+                "scripts/validate_release_chain.py",
+                "--candidate-dir",
+                str(candidate_dir),
+                "--candidate-manifest",
+                str(candidate_dir / "candidate-manifest.json"),
+                "--qualification",
                 str(qualification),
                 "--commit",
                 source_commit,
@@ -133,9 +154,6 @@ def _sha256(path: Path) -> str:
 def _run_gate(gate: Gate, env: dict[str, str]) -> dict[str, Any]:
     started = time.perf_counter()
     command = list(gate.command)
-    if gate.name == "twine":
-        pattern = Path(command[-1])
-        command[-1:] = [str(path) for path in sorted(pattern.parent.glob(pattern.name))]
     try:
         completed = subprocess.run(
             command,
@@ -162,9 +180,9 @@ def _run_gate(gate: Gate, env: dict[str, str]) -> dict[str, Any]:
     }
 
 
-def _base_wheel_smoke(dist: Path) -> dict[str, Any]:
+def _base_wheel_smoke(candidate_dir: Path) -> dict[str, Any]:
     started = time.perf_counter()
-    wheels = list(dist.glob("*.whl"))
+    wheels = list(candidate_dir.glob("*.whl"))
     if len(wheels) != 1:
         return {
             "name": "clean_base_wheel_install",
@@ -228,21 +246,50 @@ def _tree_clean(summary: Path) -> dict[str, Any]:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-dir", type=Path)
+    parser.add_argument("--candidate-manifest", type=Path)
     parser.add_argument("--qualification", type=Path)
     parser.add_argument("--summary", type=Path, default=ROOT / "runs/release-gate-summary.json")
     parser.add_argument("--list", action="store_true", help="Print gate names without running.")
     parser.add_argument("--fail-fast", action="store_true")
     args = parser.parse_args()
-    if not args.list and args.qualification is None:
-        parser.error("--qualification is required unless --list is used")
+    required = (args.candidate_dir, args.candidate_manifest, args.qualification)
+    if not args.list and any(value is None for value in required):
+        parser.error(
+            "--candidate-dir, --candidate-manifest and --qualification are required "
+            "unless --list is used"
+        )
     with tempfile.TemporaryDirectory(prefix="miniverl-release-gate-") as temporary:
         root = Path(temporary)
         qualification = args.qualification or root / "qualification-not-used.json"
+        candidate_dir = args.candidate_dir or root / "candidate-not-used"
+        candidate_manifest = args.candidate_manifest or candidate_dir / "candidate-manifest.json"
+        if args.list:
+            candidate_wheel = candidate_dir / "not-used.whl"
+            candidate_sdist = candidate_dir / "not-used.tar.gz"
+            wheel_sha256 = "not-used-by-list"
+            manifest_sha256 = "not-used-by-list"
+        else:
+            sys.path.insert(0, str(ROOT / "src"))
+            from miniverl.release_candidate import load_candidate_manifest
+
+            expected_manifest = candidate_dir / "candidate-manifest.json"
+            if candidate_manifest.resolve() != expected_manifest.resolve():
+                parser.error(
+                    "--candidate-manifest must name candidate-manifest.json inside --candidate-dir"
+                )
+            record = load_candidate_manifest(candidate_manifest)
+            candidate_wheel = candidate_dir / record.wheel.filename
+            candidate_sdist = candidate_dir / record.sdist.filename
+            wheel_sha256 = record.wheel.sha256
+            manifest_sha256 = _sha256(candidate_manifest)
         plan = gate_plan(
+            candidate_dir=candidate_dir.resolve(),
+            candidate_wheel=candidate_wheel.resolve(),
+            candidate_sdist=candidate_sdist.resolve(),
             qualification=qualification.resolve(),
             site=root / "site",
             screenshots=root / "screenshots",
-            dist=root / "dist",
             source_commit="not-used-by-list" if args.list else None,
             known_good_sha256="not-used-by-list" if args.list else None,
         )
@@ -259,7 +306,7 @@ def main() -> int:
             if result["status"] == "failed" and args.fail_fast:
                 break
         if all(item["status"] == "passed" for item in results) and len(results) == len(plan):
-            install = _base_wheel_smoke(root / "dist")
+            install = _base_wheel_smoke(candidate_dir)
             results.append(install)
             print(f"{install['status']}: {install['name']}")
         else:
@@ -278,6 +325,8 @@ def main() -> int:
             "kind": "miniverl_release_gate",
             "status": status,
             "source_commit": _git_head(),
+            "candidate_manifest_sha256": manifest_sha256,
+            "candidate_wheel_sha256": wheel_sha256,
             "created_at": datetime.now(timezone.utc)
             .replace(microsecond=0)
             .isoformat()

--- a/scripts/release_gate.py
+++ b/scripts/release_gate.py
@@ -25,8 +25,20 @@ class Gate:
     timeout: int = 1800
 
 
-def gate_plan(*, qualification: Path, site: Path, screenshots: Path, dist: Path) -> list[Gate]:
+def gate_plan(
+    *,
+    qualification: Path,
+    site: Path,
+    screenshots: Path,
+    dist: Path,
+    source_commit: str | None = None,
+    known_good_sha256: str | None = None,
+) -> list[Gate]:
     python = sys.executable
+    source_commit = source_commit or _git_head()
+    known_good_sha256 = known_good_sha256 or _sha256(
+        ROOT / "environments/known-good-rtx4080-cu130.json"
+    )
     return [
         Gate("release_state", (python, "scripts/release_state.py", "--check")),
         Gate("pypi_readme", (python, "scripts/build_pypi_readme.py", "--check")),
@@ -94,9 +106,9 @@ def gate_plan(*, qualification: Path, site: Path, screenshots: Path, dist: Path)
                 "scripts/validate_gpu_qualification.py",
                 str(qualification),
                 "--commit",
-                _git_head(),
+                source_commit,
                 "--known-good-sha256",
-                _sha256(ROOT / "environments/known-good-rtx4080-cu130.json"),
+                known_good_sha256,
                 "--required-gpu-name",
                 "NVIDIA GeForce RTX 4080",
             ),
@@ -231,6 +243,8 @@ def main() -> int:
             site=root / "site",
             screenshots=root / "screenshots",
             dist=root / "dist",
+            source_commit="not-used-by-list" if args.list else None,
+            known_good_sha256="not-used-by-list" if args.list else None,
         )
         if args.list:
             print(json.dumps([gate.name for gate in plan]))

--- a/scripts/release_gate.py
+++ b/scripts/release_gate.py
@@ -1,0 +1,285 @@
+"""Run the non-publishing miniVERL pre-release gate and emit a strict JSON summary."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True)
+class Gate:
+    name: str
+    command: tuple[str, ...]
+    timeout: int = 1800
+
+
+def gate_plan(*, qualification: Path, site: Path, screenshots: Path, dist: Path) -> list[Gate]:
+    python = sys.executable
+    return [
+        Gate("release_state", (python, "scripts/release_state.py", "--check")),
+        Gate("pypi_readme", (python, "scripts/build_pypi_readme.py", "--check")),
+        Gate("known_good_environment", (python, "scripts/check_known_good_environment.py")),
+        Gate(
+            "qualification_schema",
+            (python, "scripts/publish_gpu_qualification_schema.py", "--check"),
+        ),
+        Gate("ruff_check", (python, "-m", "ruff", "check", ".")),
+        Gate("ruff_format", (python, "-m", "ruff", "format", "--check", ".")),
+        Gate("mypy", (python, "-m", "mypy", "src/miniverl")),
+        Gate("actionlint", ("actionlint",)),
+        Gate("markdown_links", (python, "scripts/check_markdown_links.py")),
+        Gate("text_integrity", (python, "scripts/check_text_integrity.py")),
+        Gate(
+            "generated_alignment_lab",
+            (python, "scripts/publish_alignment_lab_artifacts.py", "--check"),
+        ),
+        Gate(
+            "generated_bridge_diagrams",
+            (python, "scripts/publish_verl_bridge_diagrams.py", "--check"),
+        ),
+        Gate(
+            "generated_compatibility",
+            (python, "scripts/publish_verl_opd_compatibility.py", "--check"),
+        ),
+        Gate(
+            "generated_hardware_schema",
+            (python, "scripts/publish_hardware_record_schema.py", "--check"),
+        ),
+        Gate(
+            "cpu_tests_coverage",
+            (
+                python,
+                "-m",
+                "pytest",
+                "-q",
+                "-m",
+                "not gpu and not network",
+                "--cov=miniverl",
+                "--cov-report=term-missing",
+                "--cov-fail-under=80",
+            ),
+            7200,
+        ),
+        Gate("docs_build", ("mkdocs", "build", "--strict", "--site-dir", str(site))),
+        Gate(
+            "docs_visual",
+            (
+                python,
+                "scripts/check_docs_visual.py",
+                "--site",
+                str(site),
+                "--screenshots",
+                str(screenshots),
+            ),
+            3600,
+        ),
+        Gate("build", (python, "-m", "build", "--outdir", str(dist))),
+        Gate("twine", (python, "-m", "twine", "check", str(dist / "*"))),
+        Gate(
+            "gpu_qualification",
+            (
+                python,
+                "scripts/validate_gpu_qualification.py",
+                str(qualification),
+                "--commit",
+                _git_head(),
+                "--known-good-sha256",
+                _sha256(ROOT / "environments/known-good-rtx4080-cu130.json"),
+                "--required-gpu-name",
+                "NVIDIA GeForce RTX 4080",
+            ),
+        ),
+    ]
+
+
+def _git_head() -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _run_gate(gate: Gate, env: dict[str, str]) -> dict[str, Any]:
+    started = time.perf_counter()
+    command = list(gate.command)
+    if gate.name == "twine":
+        pattern = Path(command[-1])
+        command[-1:] = [str(path) for path in sorted(pattern.parent.glob(pattern.name))]
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=gate.timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {
+            "name": gate.name,
+            "status": "failed",
+            "seconds": round(time.perf_counter() - started, 3),
+            "detail": str(exc),
+        }
+    output = (completed.stdout + completed.stderr).strip()
+    return {
+        "name": gate.name,
+        "status": "passed" if completed.returncode == 0 else "failed",
+        "seconds": round(time.perf_counter() - started, 3),
+        "returncode": completed.returncode,
+        "detail": output[-4000:],
+    }
+
+
+def _base_wheel_smoke(dist: Path) -> dict[str, Any]:
+    started = time.perf_counter()
+    wheels = list(dist.glob("*.whl"))
+    if len(wheels) != 1:
+        return {
+            "name": "clean_base_wheel_install",
+            "status": "failed",
+            "seconds": 0.0,
+            "detail": f"expected one wheel, found {len(wheels)}",
+        }
+    with tempfile.TemporaryDirectory(prefix="miniverl-base-wheel-") as temporary:
+        venv = Path(temporary) / "venv"
+        commands = [[sys.executable, "-m", "venv", str(venv)]]
+        python = venv / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+        commands.extend(
+            [
+                [str(python), "-m", "pip", "install", str(wheels[0])],
+                [
+                    str(python),
+                    "-c",
+                    (
+                        "import json,sys,miniverl,miniverl.cli; "
+                        "assert 'torch' not in sys.modules; "
+                        "print(json.dumps({'version':miniverl.__version__}))"
+                    ),
+                ],
+            ]
+        )
+        for command in commands:
+            completed = subprocess.run(
+                command, cwd=ROOT, capture_output=True, text=True, timeout=600
+            )
+            if completed.returncode:
+                return {
+                    "name": "clean_base_wheel_install",
+                    "status": "failed",
+                    "seconds": round(time.perf_counter() - started, 3),
+                    "detail": (completed.stdout + completed.stderr)[-4000:],
+                }
+    return {
+        "name": "clean_base_wheel_install",
+        "status": "passed",
+        "seconds": round(time.perf_counter() - started, 3),
+        "detail": "wheel imported without torch",
+    }
+
+
+def _tree_clean(summary: Path) -> dict[str, Any]:
+    completed = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    lines = [line for line in completed.stdout.splitlines() if str(summary) not in line]
+    return {
+        "name": "working_tree_clean",
+        "status": "passed" if not lines else "failed",
+        "seconds": 0.0,
+        "detail": "clean" if not lines else "\n".join(lines),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--qualification", type=Path)
+    parser.add_argument("--summary", type=Path, default=ROOT / "runs/release-gate-summary.json")
+    parser.add_argument("--list", action="store_true", help="Print gate names without running.")
+    parser.add_argument("--fail-fast", action="store_true")
+    args = parser.parse_args()
+    if not args.list and args.qualification is None:
+        parser.error("--qualification is required unless --list is used")
+    with tempfile.TemporaryDirectory(prefix="miniverl-release-gate-") as temporary:
+        root = Path(temporary)
+        qualification = args.qualification or root / "qualification-not-used.json"
+        plan = gate_plan(
+            qualification=qualification.resolve(),
+            site=root / "site",
+            screenshots=root / "screenshots",
+            dist=root / "dist",
+        )
+        if args.list:
+            print(json.dumps([gate.name for gate in plan]))
+            return 0
+        env = dict(os.environ)
+        env.update({"HF_HUB_OFFLINE": "1", "TRANSFORMERS_OFFLINE": "1"})
+        results: list[dict[str, Any]] = []
+        for gate in plan:
+            result = _run_gate(gate, env)
+            results.append(result)
+            print(f"{result['status']}: {gate.name}")
+            if result["status"] == "failed" and args.fail_fast:
+                break
+        if all(item["status"] == "passed" for item in results) and len(results) == len(plan):
+            install = _base_wheel_smoke(root / "dist")
+            results.append(install)
+            print(f"{install['status']}: {install['name']}")
+        else:
+            results.append(
+                {
+                    "name": "clean_base_wheel_install",
+                    "status": "not_run",
+                    "seconds": 0.0,
+                    "detail": "an earlier gate failed",
+                }
+            )
+        results.append(_tree_clean(args.summary))
+        status = "passed" if all(item["status"] == "passed" for item in results) else "failed"
+        payload = {
+            "schema_version": 1,
+            "kind": "miniverl_release_gate",
+            "status": status,
+            "source_commit": _git_head(),
+            "created_at": datetime.now(timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "publishes": False,
+            "checks": results,
+        }
+        args.summary.parent.mkdir(parents=True, exist_ok=True)
+        args.summary.write_text(
+            json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+        print(args.summary)
+        return 0 if status == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_state.py
+++ b/scripts/release_state.py
@@ -223,6 +223,18 @@ def rules_for(state: ReleaseState) -> tuple[list[Rule], list[Presence]]:
             expected=state.stable_released_at,
         ),
         Rule(
+            path="SECURITY.md",
+            description="supported stable line",
+            pattern=re.compile(r"The current supported stable line is `(?P<value>[^`]+)`"),
+            expected=state.stable_version,
+        ),
+        Rule(
+            path="PROJECT_STATE.md",
+            description="current development product line",
+            pattern=re.compile(r"Development `(?P<value>[^`]+)` has a closed typed profile"),
+            expected=state.development_version,
+        ),
+        Rule(
             path="CHANGELOG.md",
             description="Unreleased comparison link",
             pattern=re.compile(

--- a/scripts/run_gpu_qualification.py
+++ b/scripts/run_gpu_qualification.py
@@ -1,0 +1,386 @@
+"""Run a wheel-installed, exact-commit RTX 4080 release qualification smoke."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import importlib.metadata
+import json
+import platform
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from miniverl import __version__
+from miniverl.models.adapter_io import export_adapter
+from miniverl.qualification import GPUQualification, sha256_file
+from miniverl.utils.runs import canonical_json, read_jsonl, write_json_atomic
+
+PROFILE = "verl-opd-v0.8-single-gpu-v1"
+BUILTIN = "builtin:qwen3-0.6b-1.7b-opd"
+_PACKAGES = (
+    "torch",
+    "transformers",
+    "peft",
+    "accelerate",
+    "bitsandbytes",
+    "numpy",
+    "pyarrow",
+)
+
+
+def _package_versions() -> dict[str, str]:
+    return {name: importlib.metadata.version(name) for name in _PACKAGES}
+
+
+def _run_cli(executable: str, cwd: Path, *arguments: str) -> dict[str, Any] | None:
+    completed = subprocess.run(
+        [executable, *arguments],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=1800,
+    )
+    if "--json" not in arguments:
+        return None
+    output = completed.stdout.strip()
+    return json.loads(output) if output else None
+
+
+def _driver_version() -> str:
+    completed = subprocess.run(
+        ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return completed.stdout.splitlines()[0].strip()
+
+
+def _assert_known_good(path: Path, packages: dict[str, str], gpu_name: str) -> dict[str, Any]:
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    expected = manifest["packages"]
+    differences = {
+        name: {"expected": expected.get(name), "actual": actual}
+        for name, actual in packages.items()
+        if expected.get(name) != actual
+    }
+    if differences:
+        raise RuntimeError(
+            "installed packages do not match the known-good stack: " + canonical_json(differences)
+        )
+    if platform.python_version() != manifest["platform"]["python"]:
+        raise RuntimeError(
+            f"Python {platform.python_version()} does not match known-good "
+            f"{manifest['platform']['python']}"
+        )
+    if gpu_name != manifest["hardware"]["gpu"]:
+        raise RuntimeError(
+            f"GPU {gpu_name!r} does not match measured stack {manifest['hardware']['gpu']!r}"
+        )
+    return manifest
+
+
+def _copy_artifact(source: Path, output: Path, name: str) -> dict[str, Any]:
+    target = output / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+    return {
+        "name": name.replace("/", "_"),
+        "path": name,
+        "sha256": sha256_file(target),
+        "bytes": target.stat().st_size,
+    }
+
+
+def _reload_peft_adapter(model_id: str, revision: str, adapter: Path, *, offline: bool) -> None:
+    import torch
+    from peft import PeftModel
+    from transformers import AutoModelForCausalLM
+
+    base = AutoModelForCausalLM.from_pretrained(
+        model_id,
+        revision=revision,
+        dtype=torch.float16,
+        device_map={"": "cpu"},
+        local_files_only=offline,
+        trust_remote_code=False,
+    )
+    loaded = PeftModel.from_pretrained(base, adapter, is_trainable=False)
+    if not loaded.peft_config:
+        raise RuntimeError("standard PEFT reload produced no adapter configuration")
+    del loaded, base
+    gc.collect()
+
+
+def run(args: argparse.Namespace) -> GPUQualification:
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("GPU qualification requires torch.cuda.is_available()")
+    if torch.cuda.device_count() != 1:
+        raise RuntimeError("GPU qualification requires exactly one visible CUDA GPU")
+    if not args.wheel.is_file() or args.wheel.suffix != ".whl":
+        raise RuntimeError(f"wheel not found: {args.wheel}")
+    if args.output.exists() and any(args.output.iterdir()):
+        existing = {path.resolve() for path in args.output.iterdir()}
+        if args.wheel.resolve() not in existing or len(existing) != 1:
+            raise RuntimeError("qualification output must be empty except for the wheel")
+    args.output.mkdir(parents=True, exist_ok=True)
+    args.work.mkdir(parents=True, exist_ok=False)
+
+    props = torch.cuda.get_device_properties(torch.cuda.current_device())
+    packages = _package_versions()
+    _assert_known_good(args.known_good, packages, props.name)
+    known_good_sha256 = sha256_file(args.known_good)
+    baseline_allocated = int(torch.cuda.memory_allocated())
+    tolerance = max(2 * 1024**2, int(baseline_allocated * 0.02))
+
+    executable = shutil.which("miniverl")
+    if executable is None:
+        raise RuntimeError("installed miniverl console script was not found")
+    version = subprocess.run(
+        [executable, "--version"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    ).stdout.strip()
+    if version != f"miniverl {__version__}":
+        raise RuntimeError(f"unexpected installed version output: {version!r}")
+    doctor = _run_cli(executable, args.work, "doctor", "--json")
+    if not doctor or doctor["verdict"]["gpu_training"] is not True:
+        raise RuntimeError("doctor did not qualify GPU training")
+
+    _run_cli(
+        executable,
+        args.work,
+        "data",
+        "sample",
+        "--format",
+        "verl-parquet",
+        "--rows",
+        "4",
+        "--out",
+        "prompts.parquet",
+    )
+    overrides = [
+        'data.train_files=["prompts.parquet"]',
+        "data.train_batch_size=1",
+        "data.max_prompt_length=128",
+        "data.max_response_length=16",
+        "actor_rollout_ref.actor.ppo_mini_batch_size=1",
+        "actor_rollout_ref.actor.ppo_max_token_len_per_gpu=192",
+        "actor_rollout_ref.rollout.max_model_len=144",
+        "actor_rollout_ref.rollout.max_num_batched_tokens=192",
+        "actor_rollout_ref.rollout.max_num_seqs=1",
+        "distillation.distillation_loss.topk=32",
+        "trainer.experiment_name=exact-commit-release-smoke",
+        "trainer.save_freq=1",
+        "trainer.total_training_steps=1",
+        "miniverl.batching.rollout_batch_size=1",
+        "miniverl.batching.teacher_score_batch_size=1",
+        "miniverl.batching.update_trajectory_batch_size=1",
+    ]
+    plan_command = [
+        "plan",
+        "--profile",
+        PROFILE,
+        "--config",
+        BUILTIN,
+        "--out",
+        "plan.json",
+        "--json",
+    ]
+    for override in overrides:
+        plan_command.extend(("--set", override))
+    _run_cli(executable, args.work, *plan_command)
+    _run_cli(
+        executable,
+        args.work,
+        "run",
+        "--profile",
+        PROFILE,
+        "--plan",
+        "plan.json",
+        "--dry-run",
+        "--json",
+    )
+
+    from miniverl.bridge.opd_plan import load_and_verify_immutable_opd_plan
+    from miniverl.models.adapter_io import digest_tree
+    from miniverl.trainer import OPDTrainer
+
+    plan, native = load_and_verify_immutable_opd_plan(args.work / "plan.json")
+    trainer = OPDTrainer.from_config(
+        native,
+        output_dir=args.work / "runs",
+        run_id="qualification-smoke",
+        local_files_only=args.offline,
+    )
+    with trainer:
+        result = trainer.train()
+        run_dir = result.run_dir
+    adapter_manifest, adapter_dir = export_adapter(
+        run_dir,
+        run_dir / "checkpoints/final",
+        args.work / "peft-adapter",
+        local_files_only=args.offline,
+    )
+    _reload_peft_adapter(
+        native.models.student.model_id,
+        str(native.models.student.revision),
+        adapter_dir,
+        offline=args.offline,
+    )
+    del trainer
+    gc.collect()
+    torch.cuda.empty_cache()
+    torch.cuda.synchronize()
+    after_teardown = int(torch.cuda.memory_allocated())
+    if after_teardown > baseline_allocated + tolerance:
+        raise RuntimeError(
+            f"CUDA teardown left {after_teardown} bytes allocated; baseline "
+            f"{baseline_allocated}, tolerance {tolerance}"
+        )
+
+    metrics = read_jsonl(run_dir / "metrics.jsonl")
+    cycles = [row for row in metrics if row.get("phase") == "opd_cycle"]
+    updates = [row for row in metrics if row.get("phase") == "opd"]
+    if not cycles or not updates or result.global_step < 1:
+        raise RuntimeError("qualification did not record rollout, teacher scoring and update")
+    run_manifest_path = run_dir / "manifest.json"
+    run_summary = {
+        "schema_version": 1,
+        "status": "completed",
+        "run_manifest_sha256": sha256_file(run_manifest_path),
+        "execution_plan_digest": plan.plan_digest,
+        "optimizer_updates": result.global_step,
+        "trajectory_sha256": sha256_file(run_dir / "trajectories.jsonl"),
+        "checkpoint_digest": digest_tree(run_dir / "checkpoints/final"),
+    }
+    run_summary_path = args.output / "run-summary.json"
+    write_json_atomic(run_summary_path, run_summary)
+    artifacts = [
+        {
+            "name": "run_summary",
+            "path": run_summary_path.name,
+            "sha256": sha256_file(run_summary_path),
+            "bytes": run_summary_path.stat().st_size,
+        },
+        _copy_artifact(args.work / "prompts.parquet", args.output, "inputs/prompts.parquet"),
+        _copy_artifact(
+            adapter_dir / "adapter_model.safetensors",
+            args.output,
+            "adapter/adapter_model.safetensors",
+        ),
+        _copy_artifact(
+            adapter_dir / "adapter_config.json", args.output, "adapter/adapter_config.json"
+        ),
+        _copy_artifact(
+            adapter_dir / "miniverl_adapter_manifest.json",
+            args.output,
+            "adapter/miniverl_adapter_manifest.json",
+        ),
+    ]
+    record = GPUQualification(
+        level="release_smoke",
+        status="passed",
+        measured_at=datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        source_commit=args.commit,
+        miniverl_version=__version__,
+        wheel={"filename": args.wheel.name, "sha256": sha256_file(args.wheel)},
+        profile={
+            "name": plan.profile,
+            "identity_digest": plan.profile_identity["digest"],
+            "upstream_tag": plan.profile_identity["upstream_tag"],
+            "upstream_commit": plan.profile_identity["upstream_commit"],
+        },
+        environment={
+            "known_good_manifest_sha256": known_good_sha256,
+            "gpu_name": props.name,
+            "gpu_count": 1,
+            "vram_gib": round(int(props.total_memory) / 1024**3, 3),
+            "driver": _driver_version(),
+            "cuda_runtime": str(torch.version.cuda),
+            "python": platform.python_version(),
+            "packages": packages,
+        },
+        models=[
+            {
+                "role": "actor",
+                "model_id": plan.models["student"]["model_id"],
+                "revision": plan.models["student"]["revision"],
+            },
+            {
+                "role": "teacher",
+                "model_id": plan.models["teacher"]["model_id"],
+                "revision": plan.models["teacher"]["revision"],
+            },
+        ],
+        execution={
+            "rollout_completed": True,
+            "teacher_scoring_completed": float(cycles[0]["teacher_scoring_seconds"]) >= 0,
+            "optimizer_updates": result.global_step,
+            "peft_adapter_exported": bool(adapter_manifest["checksums"]),
+            "peft_adapter_reload_verified": True,
+            "cuda_allocated_before_bytes": baseline_allocated,
+            "cuda_allocated_after_teardown_bytes": after_teardown,
+            "cuda_teardown_tolerance_bytes": tolerance,
+        },
+        inputs={
+            "config_sha256": plan.source_config["sha256"],
+            "plan_sha256": sha256_file(args.work / "plan.json"),
+            "parquet_sha256": sha256_file(args.work / "prompts.parquet"),
+        },
+        artifacts=artifacts,
+        checks={
+            "executed": [
+                "wheel_install",
+                "doctor",
+                "plan",
+                "run_dry_run",
+                "real_actor_teacher_update",
+                "peft_reload",
+                "cuda_teardown",
+            ],
+            "skipped": [],
+            "not_applicable": ["distributed_verl_execution"],
+        },
+        scientific_scope={
+            "runtime_correctness_only": True,
+            "task_quality_evaluated": False,
+            "alignment_quality_evaluated": False,
+            "distributed_execution_tested": False,
+            "other_hardware_measured": False,
+        },
+    )
+    write_json_atomic(args.output / "qualification.json", record.model_dump(mode="json"))
+    return record
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--wheel", required=True, type=Path)
+    parser.add_argument("--known-good", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--work", required=True, type=Path)
+    parser.add_argument("--offline", action="store_true")
+    args = parser.parse_args()
+    if len(args.commit) != 40 or any(char not in "0123456789abcdef" for char in args.commit):
+        parser.error("--commit must be a full lowercase 40-hex Git SHA")
+    record = run(args)
+    print(json.dumps(record.model_dump(mode="json"), sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_gpu_qualification.py
+++ b/scripts/run_gpu_qualification.py
@@ -6,16 +6,21 @@ import argparse
 import gc
 import importlib.metadata
 import json
+import os
 import platform
 import shutil
 import subprocess
+import sys
+import sysconfig
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+import miniverl
 from miniverl import __version__
 from miniverl.models.adapter_io import export_adapter
 from miniverl.qualification import GPUQualification, sha256_file
+from miniverl.release_candidate import load_candidate_manifest, validate_candidate_directory
 from miniverl.utils.runs import canonical_json, read_jsonl, write_json_atomic
 
 PROFILE = "verl-opd-v0.8-single-gpu-v1"
@@ -28,6 +33,7 @@ _PACKAGES = (
     "bitsandbytes",
     "numpy",
     "pyarrow",
+    "safetensors",
 )
 
 
@@ -63,7 +69,7 @@ def _driver_version() -> str:
 
 def _assert_known_good(path: Path, packages: dict[str, str], gpu_name: str) -> dict[str, Any]:
     manifest = json.loads(path.read_text(encoding="utf-8"))
-    expected = manifest["packages"]
+    expected = manifest["required"]["packages"]
     differences = {
         name: {"expected": expected.get(name), "actual": actual}
         for name, actual in packages.items()
@@ -73,16 +79,31 @@ def _assert_known_good(path: Path, packages: dict[str, str], gpu_name: str) -> d
         raise RuntimeError(
             "installed packages do not match the known-good stack: " + canonical_json(differences)
         )
-    if platform.python_version() != manifest["platform"]["python"]:
+    if platform.python_version() != manifest["required"]["python"]:
         raise RuntimeError(
             f"Python {platform.python_version()} does not match known-good "
-            f"{manifest['platform']['python']}"
+            f"{manifest['required']['python']}"
         )
-    if gpu_name != manifest["hardware"]["gpu"]:
+    if gpu_name != manifest["required"]["gpu_name"]:
         raise RuntimeError(
-            f"GPU {gpu_name!r} does not match measured stack {manifest['hardware']['gpu']!r}"
+            f"GPU {gpu_name!r} does not match measured stack {manifest['required']['gpu_name']!r}"
         )
     return manifest
+
+
+def _verify_install_origin(import_file: str, executable: str) -> None:
+    if sys.prefix == sys.base_prefix:
+        raise RuntimeError("qualification must run inside a dedicated virtual environment")
+    site_packages = Path(sysconfig.get_paths()["purelib"]).resolve(strict=True)
+    imported = Path(import_file).resolve(strict=True)
+    cli = Path(executable).resolve(strict=True)
+    try:
+        imported.relative_to(site_packages)
+        cli.relative_to(Path(sys.prefix).resolve(strict=True))
+    except ValueError as exc:
+        raise RuntimeError(
+            "miniVERL import or CLI did not originate in the qualification venv"
+        ) from exc
 
 
 def _copy_artifact(source: Path, output: Path, name: str) -> dict[str, Any]:
@@ -166,6 +187,39 @@ def run(args: argparse.Namespace) -> GPUQualification:
         raise RuntimeError("GPU qualification requires exactly one visible CUDA GPU")
     if not args.wheel.is_file() or args.wheel.suffix != ".whl":
         raise RuntimeError(f"wheel not found: {args.wheel}")
+    if any(os.environ.get(name) for name in ("PYTHONPATH", "PYTHONHOME")):
+        raise RuntimeError("qualification requires empty PYTHONPATH and PYTHONHOME")
+    candidate_problems = validate_candidate_directory(
+        args.candidate_manifest.parent,
+        manifest_path=args.candidate_manifest,
+        expected_commit=args.commit,
+        expected_version=__version__,
+    )
+    if candidate_problems:
+        raise RuntimeError("candidate validation failed: " + "; ".join(candidate_problems))
+    candidate = load_candidate_manifest(args.candidate_manifest)
+    if (
+        args.wheel.name != candidate.wheel.filename
+        or sha256_file(args.wheel) != candidate.wheel.sha256
+    ):
+        raise RuntimeError("qualification wheel does not match candidate manifest")
+    if candidate.workflow.kind == "github_actions":
+        actual = {
+            "repository": os.environ.get("GITHUB_REPOSITORY"),
+            "workflow_path": os.environ.get("GITHUB_WORKFLOW_REF", "")
+            .split("@", 1)[0]
+            .split("/", 2)[-1],
+            "run_id": int(os.environ.get("GITHUB_RUN_ID", "0")),
+            "run_attempt": int(os.environ.get("GITHUB_RUN_ATTEMPT", "0")),
+        }
+        expected = {
+            "repository": candidate.workflow.repository,
+            "workflow_path": candidate.workflow.workflow_path,
+            "run_id": candidate.workflow.run_id,
+            "run_attempt": candidate.workflow.run_attempt,
+        }
+        if actual != expected:
+            raise RuntimeError("candidate and qualification workflow identities differ")
     if args.output.exists() and any(args.output.iterdir()):
         existing = {path.resolve() for path in args.output.iterdir()}
         if args.wheel.resolve() not in existing or len(existing) != 1:
@@ -183,6 +237,7 @@ def run(args: argparse.Namespace) -> GPUQualification:
     executable = shutil.which("miniverl")
     if executable is None:
         raise RuntimeError("installed miniverl console script was not found")
+    _verify_install_origin(miniverl.__file__, executable)
     version = subprocess.run(
         [executable, "--version"],
         check=True,
@@ -328,6 +383,7 @@ def run(args: argparse.Namespace) -> GPUQualification:
             args.output,
             "adapter/miniverl_adapter_manifest.json",
         ),
+        _copy_artifact(args.candidate_manifest, args.output, "candidate-manifest.json"),
     ]
     record = GPUQualification(
         level="release_smoke",
@@ -339,6 +395,18 @@ def run(args: argparse.Namespace) -> GPUQualification:
         source_commit=args.commit,
         miniverl_version=__version__,
         wheel={"filename": args.wheel.name, "sha256": sha256_file(args.wheel)},
+        candidate={
+            "manifest_sha256": sha256_file(args.candidate_manifest),
+            "artifact_name": candidate.artifact_name,
+            "workflow_repository": candidate.workflow.repository,
+            "workflow_path": candidate.workflow.workflow_path,
+            "workflow_run_id": candidate.workflow.run_id,
+            "workflow_run_attempt": candidate.workflow.run_attempt,
+            "installed_from_candidate": True,
+            "import_origin_verified": True,
+            "cli_origin_verified": True,
+            "import_origin": "qualification_venv_site_packages",
+        },
         profile={
             "name": plan.profile,
             "identity_digest": plan.profile_identity["digest"],
@@ -412,6 +480,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--commit", required=True)
     parser.add_argument("--wheel", required=True, type=Path)
+    parser.add_argument("--candidate-manifest", required=True, type=Path)
     parser.add_argument("--known-good", required=True, type=Path)
     parser.add_argument("--output", required=True, type=Path)
     parser.add_argument("--work", required=True, type=Path)

--- a/scripts/run_gpu_qualification.py
+++ b/scripts/run_gpu_qualification.py
@@ -117,6 +117,46 @@ def _reload_peft_adapter(model_id: str, revision: str, adapter: Path, *, offline
     gc.collect()
 
 
+def _live_cuda_tensor_summary() -> list[dict[str, Any]]:
+    """Return bounded diagnostics for tensors that make teardown fail closed."""
+    import torch
+
+    summary: list[dict[str, Any]] = []
+    for candidate in gc.get_objects():
+        try:
+            if torch.is_tensor(candidate) and candidate.is_cuda:
+                summary.append(
+                    {
+                        "shape": list(candidate.shape),
+                        "dtype": str(candidate.dtype),
+                        "bytes": candidate.numel() * candidate.element_size(),
+                    }
+                )
+        except (ReferenceError, RuntimeError):
+            continue
+        if len(summary) >= 16:
+            break
+    return summary
+
+
+def _clear_process_global_cuda_caches(
+    torch_module: Any | None = None, bnb_functional: Any | None = None
+) -> None:
+    """Release third-party device caches when qualifying whole-process teardown."""
+    if torch_module is None:
+        import torch as torch_module
+    if bnb_functional is None:
+        import bitsandbytes.functional as bnb_functional
+
+    # bitsandbytes 0.50 retains its 8-bit dynamic map on the first CUDA device
+    # in a module-global dictionary. It is not trainer state, but qualification
+    # models process shutdown and therefore clears this documented cache.
+    bnb_functional.name2qmap.clear()
+    # cuBLAS workspaces are allocator-owned rather than live tensors. Clear the
+    # process-global pool so the final measurement represents user allocations.
+    torch_module._C._cuda_clearCublasWorkspaces()
+
+
 def run(args: argparse.Namespace) -> GPUQualification:
     import torch
 
@@ -238,6 +278,7 @@ def run(args: argparse.Namespace) -> GPUQualification:
         offline=args.offline,
     )
     del trainer
+    _clear_process_global_cuda_caches()
     gc.collect()
     torch.cuda.empty_cache()
     torch.cuda.synchronize()
@@ -245,7 +286,8 @@ def run(args: argparse.Namespace) -> GPUQualification:
     if after_teardown > baseline_allocated + tolerance:
         raise RuntimeError(
             f"CUDA teardown left {after_teardown} bytes allocated; baseline "
-            f"{baseline_allocated}, tolerance {tolerance}"
+            f"{baseline_allocated}, tolerance {tolerance}; live tensors "
+            f"{canonical_json(_live_cuda_tensor_summary())}"
         )
 
     metrics = read_jsonl(run_dir / "metrics.jsonl")

--- a/scripts/run_verl_opd_reference_workload.py
+++ b/scripts/run_verl_opd_reference_workload.py
@@ -141,6 +141,7 @@ def _overrides(dataset: Path) -> list[str]:
         "actor_rollout_ref.rollout.max_model_len=192",
         "actor_rollout_ref.rollout.max_num_batched_tokens=768",
         "actor_rollout_ref.rollout.max_num_seqs=4",
+        "distillation.teacher_models.teacher_model.inference.max_model_len=192",
         f"distillation.distillation_loss.topk={TOP_K}",
         "trainer.experiment_name=qwen3-opd-developer-workload",
         "trainer.save_freq=4",

--- a/scripts/validate_gpu_qualification.py
+++ b/scripts/validate_gpu_qualification.py
@@ -14,6 +14,7 @@ def main() -> int:
     parser.add_argument("qualification", type=Path)
     parser.add_argument("--commit")
     parser.add_argument("--wheel-sha256")
+    parser.add_argument("--candidate-manifest-sha256")
     parser.add_argument("--known-good-sha256")
     parser.add_argument("--required-gpu-name")
     parser.add_argument("--json", action="store_true")
@@ -22,6 +23,7 @@ def main() -> int:
         args.qualification,
         expected_commit=args.commit,
         expected_wheel_sha256=args.wheel_sha256,
+        expected_candidate_manifest_sha256=args.candidate_manifest_sha256,
         expected_known_good_sha256=args.known_good_sha256,
         required_gpu_name=args.required_gpu_name,
     )

--- a/scripts/validate_gpu_qualification.py
+++ b/scripts/validate_gpu_qualification.py
@@ -1,0 +1,41 @@
+"""Validate one GPU qualification artifact without importing torch."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from miniverl.qualification import validate_qualification_file
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("qualification", type=Path)
+    parser.add_argument("--commit")
+    parser.add_argument("--wheel-sha256")
+    parser.add_argument("--known-good-sha256")
+    parser.add_argument("--required-gpu-name")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    problems = validate_qualification_file(
+        args.qualification,
+        expected_commit=args.commit,
+        expected_wheel_sha256=args.wheel_sha256,
+        expected_known_good_sha256=args.known_good_sha256,
+        required_gpu_name=args.required_gpu_name,
+    )
+    payload = {"valid": not problems, "problems": problems}
+    if args.json:
+        print(json.dumps(payload, sort_keys=True))
+    elif problems:
+        print("GPU qualification is invalid:")
+        for problem in problems:
+            print(f"  - {problem}")
+    else:
+        print("GPU qualification is valid and artifact-bound")
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_release_chain.py
+++ b/scripts/validate_release_chain.py
@@ -1,0 +1,41 @@
+"""Validate the exact candidate-to-qualification release evidence chain."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from miniverl.release_chain import validate_release_chain  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-dir", type=Path, required=True)
+    parser.add_argument("--candidate-manifest", type=Path, required=True)
+    parser.add_argument("--qualification", type=Path, required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--known-good-sha256", required=True)
+    parser.add_argument("--required-gpu-name", required=True)
+    args = parser.parse_args()
+    problems = validate_release_chain(
+        args.candidate_dir,
+        args.candidate_manifest,
+        args.qualification,
+        expected_commit=args.commit,
+        expected_known_good_sha256=args.known_good_sha256,
+        required_gpu_name=args.required_gpu_name,
+    )
+    if problems:
+        for problem in problems:
+            print(problem, file=sys.stderr)
+        return 1
+    print("release candidate and GPU qualification form one exact byte-identity chain")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_release_qualification.py
+++ b/scripts/verify_release_qualification.py
@@ -9,6 +9,7 @@ import shutil
 import stat
 import tempfile
 import urllib.error
+import urllib.parse
 import urllib.request
 import zipfile
 from pathlib import Path, PurePosixPath
@@ -20,6 +21,45 @@ from miniverl.release_chain import validate_release_chain
 
 _MAX_FILES = 128
 _MAX_UNCOMPRESSED_BYTES = 1024 * 1024 * 1024
+_SENSITIVE_REDIRECT_HEADERS = frozenset({"authorization", "proxy-authorization", "cookie"})
+
+
+def _origin(url: str) -> tuple[str, str, int | None]:
+    parsed = urllib.parse.urlsplit(url)
+    port = parsed.port
+    if port is None:
+        port = {"http": 80, "https": 443}.get(parsed.scheme.lower())
+    return parsed.scheme.lower(), (parsed.hostname or "").lower(), port
+
+
+class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Follow redirects without forwarding credentials to another origin."""
+
+    http_error_308 = urllib.request.HTTPRedirectHandler.http_error_302
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        redirected = super().redirect_request(
+            req, fp, 307 if code == 308 else code, msg, headers, newurl
+        )
+        if redirected is None or _origin(req.full_url) == _origin(newurl):
+            return redirected
+        for mapping in (redirected.headers, redirected.unredirected_hdrs):
+            for name in list(mapping):
+                if name.lower() in _SENSITIVE_REDIRECT_HEADERS:
+                    del mapping[name]
+        return redirected
+
+
+_URL_OPENER = urllib.request.build_opener(_SafeRedirectHandler())
+
+
+def _open_url(request: urllib.request.Request, *, timeout: int):
+    try:
+        return _URL_OPENER.open(request, timeout=timeout)
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"GitHub artifact request failed with HTTP {exc.code}") from None
+    except urllib.error.URLError:
+        raise RuntimeError("GitHub artifact request failed") from None
 
 
 def _request_json(url: str, token: str) -> dict[str, Any]:
@@ -32,7 +72,7 @@ def _request_json(url: str, token: str) -> dict[str, Any]:
             "User-Agent": "miniVERL-release-qualification",
         },
     )
-    with urllib.request.urlopen(request, timeout=60) as response:
+    with _open_url(request, timeout=60) as response:
         return json.load(response)
 
 
@@ -46,7 +86,7 @@ def _download(url: str, token: str, destination: Path) -> None:
             "User-Agent": "miniVERL-release-qualification",
         },
     )
-    with urllib.request.urlopen(request, timeout=180) as response, destination.open("wb") as out:
+    with _open_url(request, timeout=180) as response, destination.open("wb") as out:
         shutil.copyfileobj(response, out)
 
 
@@ -135,6 +175,7 @@ def fetch_and_validate(
     candidate_artifact_name: str,
     token: str,
     required_gpu_name: str,
+    required_level: str | None = None,
     known_good: Path,
     output: Path,
 ) -> dict[str, Any]:
@@ -216,6 +257,10 @@ def fetch_and_validate(
                 qualification = GPUQualification.model_validate(
                     json.loads(qualification_path.read_text(encoding="utf-8"))
                 )
+                if required_level is not None and qualification.level != required_level:
+                    raise ValueError(
+                        f"qualification level {qualification.level!r} is not {required_level!r}"
+                    )
                 if qualification.miniverl_version != manifest.miniverl_version:
                     raise ValueError("candidate and qualification versions differ")
                 binding = qualification.candidate
@@ -268,6 +313,10 @@ def main() -> int:
     parser.add_argument("--qualification-artifact-name", default="gpu-release-smoke")
     parser.add_argument("--candidate-artifact-name", default="candidate-distributions")
     parser.add_argument("--required-gpu-name", default="NVIDIA GeForce RTX 4080")
+    parser.add_argument(
+        "--required-level",
+        choices=("release_smoke", "full_qualification"),
+    )
     parser.add_argument("--known-good", required=True, type=Path)
     parser.add_argument("--output", required=True, type=Path)
     parser.add_argument("--token-env", default="GITHUB_TOKEN")
@@ -284,6 +333,7 @@ def main() -> int:
             candidate_artifact_name=args.candidate_artifact_name,
             token=token,
             required_gpu_name=args.required_gpu_name,
+            required_level=args.required_level,
             known_good=args.known_good,
             output=args.output,
         )

--- a/scripts/verify_release_qualification.py
+++ b/scripts/verify_release_qualification.py
@@ -1,0 +1,183 @@
+"""Fetch and validate a successful exact-SHA GPU qualification workflow artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import stat
+import tempfile
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from miniverl.qualification import sha256_file, validate_qualification_file
+
+_MAX_FILES = 128
+_MAX_UNCOMPRESSED_BYTES = 1024 * 1024 * 1024
+
+
+def _request_json(url: str, token: str) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "miniVERL-release-qualification",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return json.load(response)
+
+
+def _download(url: str, token: str, destination: Path) -> None:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "miniVERL-release-qualification",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=180) as response, destination.open("wb") as out:
+        shutil.copyfileobj(response, out)
+
+
+def _safe_extract(archive: Path, destination: Path) -> None:
+    with zipfile.ZipFile(archive) as bundle:
+        members = bundle.infolist()
+        if len(members) > _MAX_FILES:
+            raise ValueError(f"qualification artifact has too many files: {len(members)}")
+        total = sum(member.file_size for member in members)
+        if total > _MAX_UNCOMPRESSED_BYTES:
+            raise ValueError(f"qualification artifact expands to too many bytes: {total}")
+        for member in members:
+            pure = PurePosixPath(member.filename.replace("\\", "/"))
+            if pure.is_absolute() or ".." in pure.parts:
+                raise ValueError(f"unsafe qualification archive member: {member.filename!r}")
+            mode = member.external_attr >> 16
+            if stat.S_ISLNK(mode):
+                raise ValueError(f"qualification archive contains a symlink: {member.filename!r}")
+            target = destination.joinpath(*pure.parts)
+            target.resolve().relative_to(destination.resolve())
+            if member.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with bundle.open(member) as source, target.open("wb") as out:
+                shutil.copyfileobj(source, out)
+
+
+def fetch_and_validate(
+    *,
+    repository: str,
+    workflow: str,
+    commit: str,
+    artifact_name: str,
+    token: str,
+    required_gpu_name: str,
+    known_good: Path,
+    output: Path,
+) -> dict[str, Any]:
+    api = f"https://api.github.com/repos/{repository}"
+    query = (
+        f"{api}/actions/workflows/{workflow}/runs?head_sha={commit}&status=completed&per_page=100"
+    )
+    runs = _request_json(query, token).get("workflow_runs") or []
+    candidates = [
+        run
+        for run in runs
+        if run.get("head_sha") == commit
+        and run.get("conclusion") == "success"
+        and run.get("event") == "workflow_dispatch"
+    ]
+    candidates.sort(key=lambda item: str(item.get("created_at", "")), reverse=True)
+    if not candidates:
+        raise RuntimeError(f"no successful {workflow} workflow_dispatch run exists for {commit}")
+    known_good_sha = sha256_file(known_good)
+    failures: list[str] = []
+    for run in candidates:
+        artifacts = (
+            _request_json(f"{api}/actions/runs/{run['id']}/artifacts", token).get("artifacts") or []
+        )
+        matches = [
+            item
+            for item in artifacts
+            if item.get("name") == artifact_name and not item.get("expired", False)
+        ]
+        for artifact in matches:
+            with tempfile.TemporaryDirectory(prefix="miniverl-qualification-") as temporary:
+                temporary_path = Path(temporary)
+                archive = temporary_path / "artifact.zip"
+                extracted = temporary_path / "extracted"
+                extracted.mkdir()
+                try:
+                    _download(str(artifact["archive_download_url"]), token, archive)
+                    _safe_extract(archive, extracted)
+                    qualification = extracted / "qualification.json"
+                    problems = validate_qualification_file(
+                        qualification,
+                        expected_commit=commit,
+                        expected_known_good_sha256=known_good_sha,
+                        required_gpu_name=required_gpu_name,
+                    )
+                    if problems:
+                        failures.extend(f"run {run['id']}: {problem}" for problem in problems)
+                        continue
+                    if output.exists():
+                        raise RuntimeError(f"output already exists: {output}")
+                    shutil.copytree(extracted, output)
+                    return {
+                        "valid": True,
+                        "source_commit": commit,
+                        "workflow_run_id": run["id"],
+                        "workflow_run_url": run["html_url"],
+                        "artifact_id": artifact["id"],
+                        "artifact_name": artifact_name,
+                        "qualification_sha256": sha256_file(output / "qualification.json"),
+                    }
+                except (OSError, ValueError, zipfile.BadZipFile) as exc:
+                    failures.append(f"run {run['id']}: {exc}")
+    detail = "; ".join(failures) if failures else "matching artifact was not found"
+    raise RuntimeError(f"no valid exact-SHA GPU qualification artifact: {detail}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--workflow", default="gpu.yml")
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--artifact-name", default="gpu-release-smoke")
+    parser.add_argument("--required-gpu-name", default="NVIDIA GeForce RTX 4080")
+    parser.add_argument("--known-good", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--token-env", default="GITHUB_TOKEN")
+    args = parser.parse_args()
+    token = os.environ.get(args.token_env)
+    if not token:
+        parser.error(f"environment variable {args.token_env} is required")
+    try:
+        result = fetch_and_validate(
+            repository=args.repository,
+            workflow=args.workflow,
+            commit=args.commit,
+            artifact_name=args.artifact_name,
+            token=token,
+            required_gpu_name=args.required_gpu_name,
+            known_good=args.known_good,
+            output=args.output,
+        )
+    except (RuntimeError, urllib.error.URLError) as exc:
+        print(json.dumps({"valid": False, "error": str(exc)}, sort_keys=True))
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_release_qualification.py
+++ b/scripts/verify_release_qualification.py
@@ -1,4 +1,4 @@
-"""Fetch and validate a successful exact-SHA GPU qualification workflow artifact."""
+"""Fetch one same-run candidate and exact-SHA GPU qualification pair."""
 
 from __future__ import annotations
 
@@ -14,7 +14,9 @@ import zipfile
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-from miniverl.qualification import sha256_file, validate_qualification_file
+from miniverl.qualification import GPUQualification, sha256_file
+from miniverl.release_candidate import load_candidate_manifest, validate_candidate_directory
+from miniverl.release_chain import validate_release_chain
 
 _MAX_FILES = 128
 _MAX_UNCOMPRESSED_BYTES = 1024 * 1024 * 1024
@@ -52,25 +54,76 @@ def _safe_extract(archive: Path, destination: Path) -> None:
     with zipfile.ZipFile(archive) as bundle:
         members = bundle.infolist()
         if len(members) > _MAX_FILES:
-            raise ValueError(f"qualification artifact has too many files: {len(members)}")
+            raise ValueError(f"artifact has too many files: {len(members)}")
         total = sum(member.file_size for member in members)
         if total > _MAX_UNCOMPRESSED_BYTES:
-            raise ValueError(f"qualification artifact expands to too many bytes: {total}")
+            raise ValueError(f"artifact expands to too many bytes: {total}")
+        seen: set[str] = set()
         for member in members:
             pure = PurePosixPath(member.filename.replace("\\", "/"))
-            if pure.is_absolute() or ".." in pure.parts:
-                raise ValueError(f"unsafe qualification archive member: {member.filename!r}")
+            normalized = pure.as_posix().rstrip("/")
+            if (
+                not normalized
+                or pure.is_absolute()
+                or ".." in pure.parts
+                or any(part in {"", "."} for part in pure.parts)
+            ):
+                raise ValueError(f"unsafe artifact member: {member.filename!r}")
+            if normalized in seen:
+                raise ValueError(f"duplicate artifact member: {normalized!r}")
+            seen.add(normalized)
             mode = member.external_attr >> 16
             if stat.S_ISLNK(mode):
-                raise ValueError(f"qualification archive contains a symlink: {member.filename!r}")
+                raise ValueError(f"artifact contains a symlink: {member.filename!r}")
             target = destination.joinpath(*pure.parts)
             target.resolve().relative_to(destination.resolve())
             if member.is_dir():
                 target.mkdir(parents=True, exist_ok=True)
                 continue
             target.parent.mkdir(parents=True, exist_ok=True)
-            with bundle.open(member) as source, target.open("wb") as out:
+            with bundle.open(member) as source, target.open("xb") as out:
                 shutil.copyfileobj(source, out)
+
+
+def _artifact(artifacts: list[dict[str, Any]], name: str) -> dict[str, Any]:
+    matches = [item for item in artifacts if item.get("name") == name]
+    if len(matches) != 1:
+        raise ValueError(f"expected one unambiguous {name!r} artifact, found {len(matches)}")
+    artifact = matches[0]
+    if artifact.get("expired") is not False:
+        raise ValueError(f"artifact {name!r} is expired")
+    if not artifact.get("archive_download_url"):
+        raise ValueError(f"artifact {name!r} has no download URL")
+    return artifact
+
+
+def _check_api_digest(artifact: dict[str, Any], archive: Path) -> None:
+    digest = artifact.get("digest")
+    if digest is None:
+        return
+    if not isinstance(digest, str) or not digest.startswith("sha256:"):
+        raise ValueError("artifact API digest has an unsupported format")
+    if sha256_file(archive) != digest.removeprefix("sha256:"):
+        raise ValueError(f"artifact API digest mismatch for {artifact.get('name')!r}")
+
+
+def _run_is_exact(
+    run: dict[str, Any],
+    *,
+    repository: str,
+    workflow_id: int,
+    workflow_path: str,
+    commit: str,
+) -> bool:
+    return (
+        run.get("head_sha") == commit
+        and run.get("conclusion") == "success"
+        and run.get("event") == "workflow_dispatch"
+        and run.get("workflow_id") == workflow_id
+        and run.get("path") == workflow_path
+        and (run.get("repository") or {}).get("full_name") == repository
+        and (run.get("head_repository") or {}).get("full_name") == repository
+    )
 
 
 def fetch_and_validate(
@@ -78,13 +131,17 @@ def fetch_and_validate(
     repository: str,
     workflow: str,
     commit: str,
-    artifact_name: str,
+    qualification_artifact_name: str,
+    candidate_artifact_name: str,
     token: str,
     required_gpu_name: str,
     known_good: Path,
     output: Path,
 ) -> dict[str, Any]:
     api = f"https://api.github.com/repos/{repository}"
+    workflow_data = _request_json(f"{api}/actions/workflows/{workflow}", token)
+    workflow_id = int(workflow_data["id"])
+    workflow_path = str(workflow_data["path"])
     query = (
         f"{api}/actions/workflows/{workflow}/runs?head_sha={commit}&status=completed&per_page=100"
     )
@@ -92,59 +149,115 @@ def fetch_and_validate(
     candidates = [
         run
         for run in runs
-        if run.get("head_sha") == commit
-        and run.get("conclusion") == "success"
-        and run.get("event") == "workflow_dispatch"
+        if _run_is_exact(
+            run,
+            repository=repository,
+            workflow_id=workflow_id,
+            workflow_path=workflow_path,
+            commit=commit,
+        )
     ]
     candidates.sort(key=lambda item: str(item.get("created_at", "")), reverse=True)
     if not candidates:
-        raise RuntimeError(f"no successful {workflow} workflow_dispatch run exists for {commit}")
+        raise RuntimeError(f"no successful exact-repository {workflow} run exists for {commit}")
     known_good_sha = sha256_file(known_good)
     failures: list[str] = []
     for run in candidates:
-        artifacts = (
-            _request_json(f"{api}/actions/runs/{run['id']}/artifacts", token).get("artifacts") or []
-        )
-        matches = [
-            item
-            for item in artifacts
-            if item.get("name") == artifact_name and not item.get("expired", False)
-        ]
-        for artifact in matches:
-            with tempfile.TemporaryDirectory(prefix="miniverl-qualification-") as temporary:
+        run_id = int(run["id"])
+        try:
+            artifacts = (
+                _request_json(f"{api}/actions/runs/{run_id}/artifacts", token).get("artifacts")
+                or []
+            )
+            candidate_artifact = _artifact(artifacts, candidate_artifact_name)
+            qualification_artifact = _artifact(artifacts, qualification_artifact_name)
+            with tempfile.TemporaryDirectory(prefix="miniverl-qualified-candidate-") as temporary:
                 temporary_path = Path(temporary)
-                archive = temporary_path / "artifact.zip"
-                extracted = temporary_path / "extracted"
-                extracted.mkdir()
-                try:
-                    _download(str(artifact["archive_download_url"]), token, archive)
-                    _safe_extract(archive, extracted)
-                    qualification = extracted / "qualification.json"
-                    problems = validate_qualification_file(
-                        qualification,
-                        expected_commit=commit,
-                        expected_known_good_sha256=known_good_sha,
-                        required_gpu_name=required_gpu_name,
-                    )
-                    if problems:
-                        failures.extend(f"run {run['id']}: {problem}" for problem in problems)
-                        continue
-                    if output.exists():
-                        raise RuntimeError(f"output already exists: {output}")
-                    shutil.copytree(extracted, output)
-                    return {
-                        "valid": True,
-                        "source_commit": commit,
-                        "workflow_run_id": run["id"],
-                        "workflow_run_url": run["html_url"],
-                        "artifact_id": artifact["id"],
-                        "artifact_name": artifact_name,
-                        "qualification_sha256": sha256_file(output / "qualification.json"),
-                    }
-                except (OSError, ValueError, zipfile.BadZipFile) as exc:
-                    failures.append(f"run {run['id']}: {exc}")
-    detail = "; ".join(failures) if failures else "matching artifact was not found"
-    raise RuntimeError(f"no valid exact-SHA GPU qualification artifact: {detail}")
+                candidate_zip = temporary_path / "candidate.zip"
+                qualification_zip = temporary_path / "qualification.zip"
+                candidate_root = temporary_path / "candidate"
+                qualification_root = temporary_path / "qualification"
+                candidate_root.mkdir()
+                qualification_root.mkdir()
+                _download(str(candidate_artifact["archive_download_url"]), token, candidate_zip)
+                _download(
+                    str(qualification_artifact["archive_download_url"]),
+                    token,
+                    qualification_zip,
+                )
+                _check_api_digest(candidate_artifact, candidate_zip)
+                _check_api_digest(qualification_artifact, qualification_zip)
+                _safe_extract(candidate_zip, candidate_root)
+                _safe_extract(qualification_zip, qualification_root)
+                candidate_problems = validate_candidate_directory(
+                    candidate_root,
+                    expected_commit=commit,
+                    expected_repository=repository,
+                    expected_workflow_path=workflow_path,
+                    expected_run_id=run_id,
+                    expected_run_attempt=int(run["run_attempt"]),
+                )
+                if candidate_problems:
+                    raise ValueError("; ".join(candidate_problems))
+                manifest_path = candidate_root / "candidate-manifest.json"
+                manifest = load_candidate_manifest(manifest_path)
+                manifest_sha = sha256_file(manifest_path)
+                qualification_path = qualification_root / "qualification.json"
+                qualification_problems = validate_release_chain(
+                    candidate_root,
+                    manifest_path,
+                    qualification_path,
+                    expected_commit=commit,
+                    expected_known_good_sha256=known_good_sha,
+                    required_gpu_name=required_gpu_name,
+                )
+                if qualification_problems:
+                    raise ValueError("; ".join(qualification_problems))
+                qualification = GPUQualification.model_validate(
+                    json.loads(qualification_path.read_text(encoding="utf-8"))
+                )
+                if qualification.miniverl_version != manifest.miniverl_version:
+                    raise ValueError("candidate and qualification versions differ")
+                binding = qualification.candidate
+                if (
+                    binding.workflow_repository != repository
+                    or binding.workflow_path != workflow_path
+                    or binding.workflow_run_id != run_id
+                    or binding.workflow_run_attempt != run.get("run_attempt")
+                ):
+                    raise ValueError("qualification is not bound to the selected workflow run")
+                if output.exists():
+                    raise RuntimeError(f"output already exists: {output}")
+                output.mkdir(parents=True)
+                shutil.copytree(candidate_root, output / "candidate")
+                shutil.copytree(qualification_root, output / "qualification")
+                result = {
+                    "valid": True,
+                    "repository": repository,
+                    "workflow_id": workflow_id,
+                    "workflow_path": workflow_path,
+                    "workflow_run_id": run_id,
+                    "workflow_run_attempt": run.get("run_attempt"),
+                    "workflow_run_url": run["html_url"],
+                    "source_commit": commit,
+                    "candidate_artifact_id": candidate_artifact["id"],
+                    "qualification_artifact_id": qualification_artifact["id"],
+                    "candidate_manifest_sha256": manifest_sha,
+                    "candidate_wheel_sha256": manifest.wheel.sha256,
+                    "candidate_sdist_sha256": manifest.sdist.sha256,
+                    "qualification_sha256": sha256_file(
+                        output / "qualification/qualification.json"
+                    ),
+                }
+                (output / "verification.json").write_text(
+                    json.dumps(result, indent=2, sort_keys=True, allow_nan=False) + "\n",
+                    encoding="utf-8",
+                    newline="\n",
+                )
+                return result
+        except (OSError, ValueError, zipfile.BadZipFile) as exc:
+            failures.append(f"run {run_id}: {exc}")
+    raise RuntimeError("no valid same-run candidate/qualification pair: " + "; ".join(failures))
 
 
 def main() -> int:
@@ -152,7 +265,8 @@ def main() -> int:
     parser.add_argument("--repository", required=True)
     parser.add_argument("--workflow", default="gpu.yml")
     parser.add_argument("--commit", required=True)
-    parser.add_argument("--artifact-name", default="gpu-release-smoke")
+    parser.add_argument("--qualification-artifact-name", default="gpu-release-smoke")
+    parser.add_argument("--candidate-artifact-name", default="candidate-distributions")
     parser.add_argument("--required-gpu-name", default="NVIDIA GeForce RTX 4080")
     parser.add_argument("--known-good", required=True, type=Path)
     parser.add_argument("--output", required=True, type=Path)
@@ -166,7 +280,8 @@ def main() -> int:
             repository=args.repository,
             workflow=args.workflow,
             commit=args.commit,
-            artifact_name=args.artifact_name,
+            qualification_artifact_name=args.qualification_artifact_name,
+            candidate_artifact_name=args.candidate_artifact_name,
             token=token,
             required_gpu_name=args.required_gpu_name,
             known_good=args.known_good,

--- a/src/miniverl/cli.py
+++ b/src/miniverl/cli.py
@@ -26,6 +26,7 @@ from rich.table import Table
 from miniverl import __version__
 from miniverl.commands.compat import compat_app, profiles_app
 from miniverl.commands.evidence import hardware_app
+from miniverl.commands.qualification import qualification_app
 from miniverl.errors import ConfigError, MiniVerlError
 from miniverl.utils.runs import make_run_id
 
@@ -63,6 +64,7 @@ app.add_typer(data_app, name="data")
 app.add_typer(profiles_app, name="profiles")
 app.add_typer(compat_app, name="compat")
 app.add_typer(hardware_app, name="hardware")
+app.add_typer(qualification_app, name="qualification")
 
 console = Console()
 err_console = Console(stderr=True)

--- a/src/miniverl/commands/qualification.py
+++ b/src/miniverl/commands/qualification.py
@@ -1,0 +1,54 @@
+"""Torch-free exact-commit GPU qualification inspection commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.markup import escape
+
+qualification_app = typer.Typer(
+    help="Validate exact-commit GPU qualification artifacts.",
+    no_args_is_help=True,
+)
+console = Console()
+err_console = Console(stderr=True)
+
+
+@qualification_app.command("validate")
+def qualification_validate_command(
+    path: Path = typer.Argument(..., help="qualification.json from a GPU workflow artifact."),
+    commit: str | None = typer.Option(None, "--commit", help="Required exact source SHA."),
+    wheel_sha256: str | None = typer.Option(
+        None, "--wheel-sha256", help="Required release-wheel SHA-256."
+    ),
+    known_good_sha256: str | None = typer.Option(
+        None, "--known-good-sha256", help="Required known-good manifest SHA-256."
+    ),
+    required_gpu_name: str | None = typer.Option(
+        None, "--required-gpu-name", help="Required measured GPU name."
+    ),
+    as_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
+) -> None:
+    """Validate schema, privacy, hashes and optional release bindings."""
+    from miniverl.qualification import validate_qualification_file
+
+    problems = validate_qualification_file(
+        path,
+        expected_commit=commit,
+        expected_wheel_sha256=wheel_sha256,
+        expected_known_good_sha256=known_good_sha256,
+        required_gpu_name=required_gpu_name,
+    )
+    payload = {"valid": not problems, "problems": problems}
+    if as_json:
+        console.print_json(json.dumps(payload, allow_nan=False))
+    elif problems:
+        for problem in problems:
+            err_console.print(f"[red]invalid[/red] {escape(problem)}")
+    else:
+        console.print("[green]valid[/green] exact-commit GPU qualification")
+    if problems:
+        raise typer.Exit(1)

--- a/src/miniverl/qualification.py
+++ b/src/miniverl/qualification.py
@@ -301,11 +301,11 @@ def validate_qualification_payload(
     if artifact_root is None:
         return problems
     root = Path(artifact_root).resolve(strict=True)
-    candidates = [(record.wheel.filename, record.wheel.sha256)] + [
-        (item.path, item.sha256) for item in record.artifacts
+    candidates = [(record.wheel.filename, record.wheel.sha256, None)] + [
+        (item.path, item.sha256, item.bytes) for item in record.artifacts
     ]
-    referenced = {Path(relative).as_posix() for relative, _ in candidates}
-    for relative, expected in candidates:
+    referenced = {Path(relative).as_posix() for relative, _, _ in candidates}
+    for relative, expected, expected_bytes in candidates:
         path = root / relative
         try:
             resolved = path.resolve(strict=True)
@@ -316,6 +316,12 @@ def validate_qualification_payload(
         if resolved.is_symlink() or not resolved.is_file():
             problems.append(f"artifact: {relative!r} must be a regular file")
             continue
+        actual_bytes = resolved.stat().st_size
+        if expected_bytes is not None and actual_bytes != expected_bytes:
+            problems.append(
+                f"artifact size mismatch for {relative}: "
+                f"expected {expected_bytes}, got {actual_bytes}"
+            )
         actual = sha256_file(resolved)
         if actual != expected:
             problems.append(

--- a/src/miniverl/qualification.py
+++ b/src/miniverl/qualification.py
@@ -35,6 +35,31 @@ class WheelEvidence(_Strict):
     sha256: str = Field(pattern=_SHA256)
 
 
+class CandidateBinding(_Strict):
+    manifest_sha256: str = Field(pattern=_SHA256)
+    artifact_name: Literal["candidate-distributions"]
+    workflow_repository: str | None = None
+    workflow_path: str | None = None
+    workflow_run_id: int | None = Field(default=None, gt=0)
+    workflow_run_attempt: int | None = Field(default=None, gt=0)
+    installed_from_candidate: Literal[True]
+    import_origin_verified: Literal[True]
+    cli_origin_verified: Literal[True]
+    import_origin: Literal["qualification_venv_site_packages"]
+
+    @model_validator(mode="after")
+    def _workflow_binding_is_complete_or_local(self) -> CandidateBinding:
+        values = (
+            self.workflow_repository,
+            self.workflow_path,
+            self.workflow_run_id,
+            self.workflow_run_attempt,
+        )
+        if any(value is None for value in values) and any(value is not None for value in values):
+            raise ValueError("candidate workflow identity must be complete or entirely local")
+        return self
+
+
 class ProfileEvidence(_Strict):
     name: str = Field(min_length=1)
     identity_digest: str = Field(pattern=_SHA256)
@@ -62,6 +87,7 @@ class EnvironmentEvidence(_Strict):
             "bitsandbytes",
             "numpy",
             "pyarrow",
+            "safetensors",
         }
         missing = sorted(required - self.packages.keys())
         if missing:
@@ -165,6 +191,7 @@ class GPUQualification(_Strict):
     source_commit: str = Field(pattern=_SHA1)
     miniverl_version: str = Field(min_length=1)
     wheel: WheelEvidence
+    candidate: CandidateBinding
     profile: ProfileEvidence
     environment: EnvironmentEvidence
     models: list[ModelEvidence] = Field(min_length=2, max_length=2)
@@ -189,6 +216,19 @@ class GPUQualification(_Strict):
             if missing:
                 raise ValueError(
                     "full qualification checks were not executed: " + ", ".join(missing)
+                )
+            required_artifacts = {
+                "release_smoke_record",
+                "full_direct_result",
+                "full_pg_k1_result",
+                "full_smollm2_result",
+            }
+            missing_artifacts = sorted(
+                required_artifacts - {artifact.name for artifact in self.artifacts}
+            )
+            if missing_artifacts:
+                raise ValueError(
+                    "full qualification evidence is missing: " + ", ".join(missing_artifacts)
                 )
         return self
 
@@ -221,6 +261,7 @@ def validate_qualification_payload(
     artifact_root: str | Path | None = None,
     expected_commit: str | None = None,
     expected_wheel_sha256: str | None = None,
+    expected_candidate_manifest_sha256: str | None = None,
     expected_known_good_sha256: str | None = None,
     required_gpu_name: str | None = None,
 ) -> list[str]:
@@ -244,6 +285,11 @@ def validate_qualification_payload(
     if expected_wheel_sha256 is not None and record.wheel.sha256 != expected_wheel_sha256:
         problems.append("binding: wheel checksum does not match the expected release wheel")
     if (
+        expected_candidate_manifest_sha256 is not None
+        and record.candidate.manifest_sha256 != expected_candidate_manifest_sha256
+    ):
+        problems.append("binding: candidate manifest checksum does not match")
+    if (
         expected_known_good_sha256 is not None
         and record.environment.known_good_manifest_sha256 != expected_known_good_sha256
     ):
@@ -258,6 +304,7 @@ def validate_qualification_payload(
     candidates = [(record.wheel.filename, record.wheel.sha256)] + [
         (item.path, item.sha256) for item in record.artifacts
     ]
+    referenced = {Path(relative).as_posix() for relative, _ in candidates}
     for relative, expected in candidates:
         path = root / relative
         try:
@@ -274,6 +321,14 @@ def validate_qualification_payload(
             problems.append(
                 f"artifact checksum mismatch for {relative}: expected {expected}, got {actual}"
             )
+    actual_files = {
+        path.relative_to(root).as_posix()
+        for path in root.rglob("*")
+        if path.is_file() or path.is_symlink()
+    }
+    unreferenced = sorted(actual_files - referenced - {"qualification.json"})
+    if unreferenced:
+        problems.append("artifact: unreferenced files are not allowed: " + ", ".join(unreferenced))
     return problems
 
 

--- a/src/miniverl/qualification.py
+++ b/src/miniverl/qualification.py
@@ -1,0 +1,292 @@
+"""Torch-free validation for exact-commit single-GPU qualification evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from pathlib import Path, PurePosixPath
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from miniverl.utils.privacy import portable_text
+
+__all__ = [
+    "GPUQualification",
+    "qualification_json_schema",
+    "sha256_file",
+    "validate_qualification_file",
+    "validate_qualification_payload",
+]
+
+_SHA256 = r"^[0-9a-f]{64}$"
+_SHA1 = r"^[0-9a-f]{40}$"
+_PRIVATE_PATH = re.compile(r"(?i)(?:[a-z]:\\users\\|/home/|/users/|onedrive)")
+
+
+class _Strict(BaseModel):
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
+
+
+class WheelEvidence(_Strict):
+    filename: str = Field(min_length=1, pattern=r"^[^/\\]+\.whl$")
+    sha256: str = Field(pattern=_SHA256)
+
+
+class ProfileEvidence(_Strict):
+    name: str = Field(min_length=1)
+    identity_digest: str = Field(pattern=_SHA256)
+    upstream_tag: str = Field(min_length=1)
+    upstream_commit: str = Field(pattern=_SHA1)
+
+
+class EnvironmentEvidence(_Strict):
+    known_good_manifest_sha256: str = Field(pattern=_SHA256)
+    gpu_name: str = Field(min_length=1)
+    gpu_count: Literal[1]
+    vram_gib: float = Field(gt=0)
+    driver: str = Field(min_length=1)
+    cuda_runtime: str = Field(min_length=1)
+    python: str = Field(min_length=1)
+    packages: dict[str, str]
+
+    @model_validator(mode="after")
+    def _required_packages_are_present(self) -> EnvironmentEvidence:
+        required = {
+            "torch",
+            "transformers",
+            "peft",
+            "accelerate",
+            "bitsandbytes",
+            "numpy",
+            "pyarrow",
+        }
+        missing = sorted(required - self.packages.keys())
+        if missing:
+            raise ValueError("environment packages missing: " + ", ".join(missing))
+        if any(not value for value in self.packages.values()):
+            raise ValueError("environment package versions must be non-empty")
+        return self
+
+
+class ModelEvidence(_Strict):
+    role: Literal["actor", "teacher"]
+    model_id: str = Field(min_length=1)
+    revision: str = Field(pattern=_SHA1)
+
+
+class ExecutionEvidence(_Strict):
+    rollout_completed: Literal[True]
+    teacher_scoring_completed: Literal[True]
+    optimizer_updates: int = Field(ge=1)
+    peft_adapter_exported: Literal[True]
+    peft_adapter_reload_verified: Literal[True]
+    cuda_allocated_before_bytes: int = Field(ge=0)
+    cuda_allocated_after_teardown_bytes: int = Field(ge=0)
+    cuda_teardown_tolerance_bytes: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def _teardown_returns_to_baseline(self) -> ExecutionEvidence:
+        ceiling = self.cuda_allocated_before_bytes + self.cuda_teardown_tolerance_bytes
+        if self.cuda_allocated_after_teardown_bytes > ceiling:
+            raise ValueError(
+                "CUDA teardown left live allocations above the measured baseline tolerance"
+            )
+        return self
+
+
+class InputEvidence(_Strict):
+    config_sha256: str = Field(pattern=_SHA256)
+    plan_sha256: str = Field(pattern=_SHA256)
+    parquet_sha256: str = Field(pattern=_SHA256)
+
+
+class ArtifactEvidence(_Strict):
+    name: str = Field(min_length=1)
+    path: str = Field(min_length=1)
+    sha256: str = Field(pattern=_SHA256)
+    bytes: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def _portable_relative_path(self) -> ArtifactEvidence:
+        path = PurePosixPath(self.path.replace("\\", "/"))
+        if path.is_absolute() or ".." in path.parts or self.path.startswith(("~", "\\")):
+            raise ValueError("artifact path must be a portable relative path")
+        if any(part in {"", "."} for part in path.parts):
+            raise ValueError("artifact path must be normalized")
+        return self
+
+
+class CheckEvidence(_Strict):
+    executed: list[str]
+    skipped: list[str]
+    not_applicable: list[str]
+
+    @model_validator(mode="after")
+    def _states_are_disjoint(self) -> CheckEvidence:
+        groups = [set(self.executed), set(self.skipped), set(self.not_applicable)]
+        if any(groups[i] & groups[j] for i in range(3) for j in range(i + 1, 3)):
+            raise ValueError("check states must be disjoint")
+        required = {
+            "wheel_install",
+            "doctor",
+            "plan",
+            "run_dry_run",
+            "real_actor_teacher_update",
+            "peft_reload",
+            "cuda_teardown",
+        }
+        missing = sorted(required - groups[0])
+        if missing:
+            raise ValueError(
+                "required release-smoke checks were not executed: " + ", ".join(missing)
+            )
+        return self
+
+
+class ScientificScope(_Strict):
+    runtime_correctness_only: Literal[True]
+    task_quality_evaluated: Literal[False]
+    alignment_quality_evaluated: Literal[False]
+    distributed_execution_tested: Literal[False]
+    other_hardware_measured: Literal[False]
+
+
+class GPUQualification(_Strict):
+    """Strict version-1 exact-commit qualification record."""
+
+    schema_version: Literal[1] = 1
+    kind: Literal["miniverl_gpu_qualification"] = "miniverl_gpu_qualification"
+    level: Literal["release_smoke", "full_qualification"]
+    status: Literal["passed"]
+    measured_at: str = Field(pattern=r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+    source_commit: str = Field(pattern=_SHA1)
+    miniverl_version: str = Field(min_length=1)
+    wheel: WheelEvidence
+    profile: ProfileEvidence
+    environment: EnvironmentEvidence
+    models: list[ModelEvidence] = Field(min_length=2, max_length=2)
+    execution: ExecutionEvidence
+    inputs: InputEvidence
+    artifacts: list[ArtifactEvidence] = Field(min_length=1)
+    checks: CheckEvidence
+    scientific_scope: ScientificScope
+
+    @model_validator(mode="after")
+    def _roles_and_gpu_are_exact(self) -> GPUQualification:
+        if [model.role for model in self.models] != ["actor", "teacher"]:
+            raise ValueError("models must contain actor then teacher")
+        if self.level == "full_qualification":
+            required = {
+                "direct_gkd_resume_equivalence",
+                "sampled_k1_resume_equivalence",
+                "smollm2_resume_equivalence",
+                "export_materialize_doctor",
+            }
+            missing = sorted(required - set(self.checks.executed))
+            if missing:
+                raise ValueError(
+                    "full qualification checks were not executed: " + ", ".join(missing)
+                )
+        return self
+
+
+def sha256_file(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def qualification_json_schema() -> dict[str, Any]:
+    return GPUQualification.model_json_schema()
+
+
+def _finite(value: Any) -> bool:
+    if isinstance(value, float):
+        return math.isfinite(value)
+    if isinstance(value, dict):
+        return all(_finite(item) for item in value.values())
+    if isinstance(value, list):
+        return all(_finite(item) for item in value)
+    return True
+
+
+def validate_qualification_payload(
+    payload: Any,
+    *,
+    artifact_root: str | Path | None = None,
+    expected_commit: str | None = None,
+    expected_wheel_sha256: str | None = None,
+    expected_known_good_sha256: str | None = None,
+    required_gpu_name: str | None = None,
+) -> list[str]:
+    """Validate evidence without importing torch; empty means schema-valid and bound."""
+    if not _finite(payload):
+        return ["schema: qualification JSON contains NaN or infinity"]
+    try:
+        record = GPUQualification.model_validate(payload)
+    except Exception as exc:
+        return [f"schema: {exc}"]
+    serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True, allow_nan=False)
+    if portable_text(serialized) != serialized or _PRIVATE_PATH.search(serialized):
+        return [
+            "privacy: qualification contains a local path, credential, or environment reference"
+        ]
+    problems: list[str] = []
+    if expected_commit is not None and record.source_commit != expected_commit:
+        problems.append(
+            f"binding: source commit {record.source_commit} does not match {expected_commit}"
+        )
+    if expected_wheel_sha256 is not None and record.wheel.sha256 != expected_wheel_sha256:
+        problems.append("binding: wheel checksum does not match the expected release wheel")
+    if (
+        expected_known_good_sha256 is not None
+        and record.environment.known_good_manifest_sha256 != expected_known_good_sha256
+    ):
+        problems.append("binding: known-good environment checksum does not match")
+    if required_gpu_name is not None and record.environment.gpu_name != required_gpu_name:
+        problems.append(
+            f"binding: GPU {record.environment.gpu_name!r} is not required {required_gpu_name!r}"
+        )
+    if artifact_root is None:
+        return problems
+    root = Path(artifact_root).resolve(strict=True)
+    candidates = [(record.wheel.filename, record.wheel.sha256)] + [
+        (item.path, item.sha256) for item in record.artifacts
+    ]
+    for relative, expected in candidates:
+        path = root / relative
+        try:
+            resolved = path.resolve(strict=True)
+            resolved.relative_to(root)
+        except (OSError, ValueError):
+            problems.append(f"artifact: unsafe or missing path {relative!r}")
+            continue
+        if resolved.is_symlink() or not resolved.is_file():
+            problems.append(f"artifact: {relative!r} must be a regular file")
+            continue
+        actual = sha256_file(resolved)
+        if actual != expected:
+            problems.append(
+                f"artifact checksum mismatch for {relative}: expected {expected}, got {actual}"
+            )
+    return problems
+
+
+def validate_qualification_file(
+    path: str | Path,
+    **kwargs: Any,
+) -> list[str]:
+    target = Path(path)
+    try:
+        payload = json.loads(
+            target.read_text(encoding="utf-8"),
+            parse_constant=lambda x: (_ for _ in ()).throw(ValueError(x)),
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+        return [f"json: {exc}"]
+    return validate_qualification_payload(payload, artifact_root=target.parent, **kwargs)

--- a/src/miniverl/release_candidate.py
+++ b/src/miniverl/release_candidate.py
@@ -1,0 +1,313 @@
+"""Torch-free release-candidate construction and byte-identity validation."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import json
+import math
+import os
+import platform
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from miniverl import __version__
+from miniverl.utils.privacy import portable_text
+
+__all__ = [
+    "CandidateManifest",
+    "PINNED_BUILD_TOOLS",
+    "build_release_candidate",
+    "candidate_manifest_sha256",
+    "load_candidate_manifest",
+    "sha256_file",
+    "validate_candidate_directory",
+]
+
+PINNED_BUILD_TOOLS = {"build": "1.5.0", "hatchling": "1.32.0", "twine": "7.0.0"}
+_SHA1 = r"^[0-9a-f]{40}$"
+_SHA256 = r"^[0-9a-f]{64}$"
+_PRIVATE = re.compile(
+    r"(?i)(?:[a-z]:[\\/](?:users|documents)[\\/]|/home/|/users/|onedrive|"
+    r"(?:token|credential|password|secret)\s*[:=])"
+)
+
+
+class _Strict(BaseModel):
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
+
+
+class DistributionRecord(_Strict):
+    filename: str = Field(min_length=1, pattern=r"^[^/\\]+$")
+    bytes: int = Field(gt=0)
+    sha256: str = Field(pattern=_SHA256)
+
+
+class BuildEnvironment(_Strict):
+    os: str = Field(min_length=1)
+    python: str = Field(min_length=1)
+    tools: dict[str, str]
+
+    @model_validator(mode="after")
+    def _tools_are_exact(self) -> BuildEnvironment:
+        if self.tools != PINNED_BUILD_TOOLS:
+            raise ValueError("build tools do not match the pinned candidate toolchain")
+        return self
+
+
+class WorkflowContext(_Strict):
+    kind: Literal["local", "github_actions"]
+    repository: str | None = None
+    workflow_path: str | None = None
+    run_id: int | None = Field(default=None, gt=0)
+    run_attempt: int | None = Field(default=None, gt=0)
+
+    @model_validator(mode="after")
+    def _github_context_is_complete(self) -> WorkflowContext:
+        values = (self.repository, self.workflow_path, self.run_id, self.run_attempt)
+        if self.kind == "github_actions" and any(value is None for value in values):
+            raise ValueError("GitHub Actions candidate context is incomplete")
+        if self.kind == "local" and any(value is not None for value in values):
+            raise ValueError("local candidate context must not claim workflow identity")
+        return self
+
+
+class CandidateManifest(_Strict):
+    schema_version: Literal[1] = 1
+    kind: Literal["miniverl_release_candidate"] = "miniverl_release_candidate"
+    source_commit: str = Field(pattern=_SHA1)
+    miniverl_version: str = Field(min_length=1)
+    created_at: str = Field(pattern=r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+    artifact_name: Literal["candidate-distributions"] = "candidate-distributions"
+    workflow: WorkflowContext
+    build: BuildEnvironment
+    wheel: DistributionRecord
+    sdist: DistributionRecord
+
+    @model_validator(mode="after")
+    def _distribution_names_are_unambiguous(self) -> CandidateManifest:
+        if not self.wheel.filename.endswith(".whl"):
+            raise ValueError("candidate wheel filename must end in .whl")
+        if not self.sdist.filename.endswith(".tar.gz"):
+            raise ValueError("candidate sdist filename must end in .tar.gz")
+        if self.wheel.filename == self.sdist.filename:
+            raise ValueError("candidate distribution filenames must differ")
+        return self
+
+
+def sha256_file(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def candidate_manifest_sha256(path: str | Path) -> str:
+    return sha256_file(path)
+
+
+def _finite(value: Any) -> bool:
+    if isinstance(value, float):
+        return math.isfinite(value)
+    if isinstance(value, dict):
+        return all(_finite(item) for item in value.values())
+    if isinstance(value, list):
+        return all(_finite(item) for item in value)
+    return True
+
+
+def _json(path: Path) -> Any:
+    return json.loads(
+        path.read_text(encoding="utf-8"),
+        parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)),
+    )
+
+
+def load_candidate_manifest(path: str | Path) -> CandidateManifest:
+    payload = _json(Path(path))
+    if not _finite(payload):
+        raise ValueError("candidate manifest contains NaN or infinity")
+    text = json.dumps(payload, ensure_ascii=False, sort_keys=True, allow_nan=False)
+    if portable_text(text) != text or _PRIVATE.search(text):
+        raise ValueError("candidate manifest contains private or non-portable text")
+    return CandidateManifest.model_validate(payload)
+
+
+def _expected_sums(record: CandidateManifest) -> str:
+    return "".join(f"{item.sha256}  {item.filename}\n" for item in (record.wheel, record.sdist))
+
+
+def validate_candidate_directory(
+    directory: str | Path,
+    *,
+    manifest_path: str | Path | None = None,
+    expected_commit: str | None = None,
+    expected_version: str | None = None,
+    expected_repository: str | None = None,
+    expected_workflow_path: str | None = None,
+    expected_run_id: int | None = None,
+    expected_run_attempt: int | None = None,
+) -> list[str]:
+    """Validate one closed candidate directory; return an empty list on success."""
+    root = Path(directory)
+    try:
+        resolved_root = root.resolve(strict=True)
+    except OSError as exc:
+        return [f"candidate: {exc}"]
+    manifest = Path(manifest_path) if manifest_path else root / "candidate-manifest.json"
+    try:
+        resolved_manifest = manifest.resolve(strict=True)
+        resolved_manifest.relative_to(resolved_root)
+        record = load_candidate_manifest(resolved_manifest)
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+        return [f"manifest: {exc}"]
+    expected_names = {
+        "candidate-manifest.json",
+        "SHA256SUMS",
+        record.wheel.filename,
+        record.sdist.filename,
+    }
+    problems: list[str] = []
+    try:
+        entries = list(root.iterdir())
+    except OSError as exc:
+        return [f"candidate: {exc}"]
+    actual_names = {entry.name for entry in entries}
+    if actual_names != expected_names:
+        problems.append(
+            f"candidate: expected exactly {sorted(expected_names)}, got {sorted(actual_names)}"
+        )
+    for entry in entries:
+        if entry.is_symlink() or not entry.is_file():
+            problems.append(f"candidate: {entry.name!r} must be a regular non-symlink file")
+    if resolved_manifest.name != "candidate-manifest.json":
+        problems.append("manifest: filename must be candidate-manifest.json")
+    bindings = (
+        (expected_commit, record.source_commit, "source commit"),
+        (expected_version, record.miniverl_version, "version"),
+        (expected_repository, record.workflow.repository, "repository"),
+        (expected_workflow_path, record.workflow.workflow_path, "workflow path"),
+        (expected_run_id, record.workflow.run_id, "workflow run id"),
+        (expected_run_attempt, record.workflow.run_attempt, "workflow run attempt"),
+    )
+    for expected, actual, label in bindings:
+        if expected is not None and actual != expected:
+            problems.append(f"binding: candidate {label} {actual!r} does not match {expected!r}")
+    for item in (record.wheel, record.sdist):
+        path = root / item.filename
+        try:
+            resolved = path.resolve(strict=True)
+            resolved.relative_to(resolved_root)
+            if resolved.is_symlink() or not resolved.is_file():
+                raise ValueError("not a regular file")
+            if resolved.stat().st_size != item.bytes:
+                problems.append(f"candidate: size mismatch for {item.filename}")
+            actual = sha256_file(resolved)
+            if actual != item.sha256:
+                problems.append(f"candidate: checksum mismatch for {item.filename}")
+        except (OSError, ValueError) as exc:
+            problems.append(f"candidate: unsafe or missing {item.filename!r}: {exc}")
+    sums = root / "SHA256SUMS"
+    try:
+        if sums.is_symlink() or sums.read_text(encoding="utf-8") != _expected_sums(record):
+            problems.append("candidate: SHA256SUMS is not canonical")
+    except (OSError, UnicodeError) as exc:
+        problems.append(f"candidate: SHA256SUMS cannot be read: {exc}")
+    return problems
+
+
+def _workflow_context(env: dict[str, str]) -> WorkflowContext:
+    if not env.get("GITHUB_ACTIONS"):
+        return WorkflowContext(kind="local")
+    workflow_ref = env.get("GITHUB_WORKFLOW_REF", "")
+    workflow_path = workflow_ref.split("@", 1)[0].split("/", 2)[-1]
+    return WorkflowContext(
+        kind="github_actions",
+        repository=env.get("GITHUB_REPOSITORY"),
+        workflow_path=workflow_path,
+        run_id=int(env["GITHUB_RUN_ID"]),
+        run_attempt=int(env["GITHUB_RUN_ATTEMPT"]),
+    )
+
+
+def _tool_versions() -> dict[str, str]:
+    versions = {name: importlib.metadata.version(name) for name in PINNED_BUILD_TOOLS}
+    if versions != PINNED_BUILD_TOOLS:
+        raise RuntimeError(f"candidate build tool mismatch: {versions!r}")
+    return versions
+
+
+def build_release_candidate(
+    output: str | Path,
+    *,
+    source_commit: str,
+    project_root: str | Path,
+    env: dict[str, str] | None = None,
+) -> CandidateManifest:
+    """Build wheel+sdist once and close the output as a validated candidate."""
+    root = Path(project_root).resolve(strict=True)
+    destination = Path(output)
+    if destination.exists() and any(destination.iterdir()):
+        raise ValueError("candidate output directory must be empty")
+    destination.mkdir(parents=True, exist_ok=True)
+    if destination.is_symlink():
+        raise ValueError("candidate output directory must not be a symlink")
+    if not re.fullmatch(_SHA1[1:-1], source_commit):
+        raise ValueError("source commit must be a full lowercase Git SHA")
+    tools = _tool_versions()
+    subprocess.run(
+        [sys.executable, "-m", "build", "--no-isolation", "--outdir", str(destination)],
+        cwd=root,
+        check=True,
+    )
+    files = [entry for entry in destination.iterdir() if entry.is_file()]
+    wheels = [entry for entry in files if entry.suffix == ".whl"]
+    sdists = [entry for entry in files if entry.name.endswith(".tar.gz")]
+    if len(files) != 2 or len(wheels) != 1 or len(sdists) != 1:
+        raise RuntimeError("candidate build must produce exactly one wheel and one sdist")
+    subprocess.run(
+        [sys.executable, "-m", "twine", "check", str(wheels[0]), str(sdists[0])],
+        cwd=root,
+        check=True,
+    )
+    record = CandidateManifest(
+        source_commit=source_commit,
+        miniverl_version=__version__,
+        created_at=datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        workflow=_workflow_context(dict(os.environ) if env is None else env),
+        build=BuildEnvironment(os=platform.system(), python=platform.python_version(), tools=tools),
+        wheel=DistributionRecord(
+            filename=wheels[0].name,
+            bytes=wheels[0].stat().st_size,
+            sha256=sha256_file(wheels[0]),
+        ),
+        sdist=DistributionRecord(
+            filename=sdists[0].name,
+            bytes=sdists[0].stat().st_size,
+            sha256=sha256_file(sdists[0]),
+        ),
+    )
+    manifest = destination / "candidate-manifest.json"
+    manifest.write_text(
+        json.dumps(record.model_dump(mode="json"), indent=2, sort_keys=True, allow_nan=False)
+        + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    (destination / "SHA256SUMS").write_text(_expected_sums(record), encoding="utf-8", newline="\n")
+    problems = validate_candidate_directory(
+        destination, expected_commit=source_commit, expected_version=__version__
+    )
+    if problems:
+        raise RuntimeError("built candidate failed validation: " + "; ".join(problems))
+    return record

--- a/src/miniverl/release_chain.py
+++ b/src/miniverl/release_chain.py
@@ -1,0 +1,98 @@
+"""Torch-free validation for one exact release candidate and its qualification."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from miniverl.qualification import GPUQualification, validate_qualification_file
+from miniverl.release_candidate import (
+    CandidateManifest,
+    load_candidate_manifest,
+    sha256_file,
+    validate_candidate_directory,
+)
+
+__all__ = ["validate_release_chain"]
+
+
+def validate_release_chain(
+    candidate_dir: str | Path,
+    candidate_manifest: str | Path,
+    qualification: str | Path,
+    *,
+    expected_commit: str,
+    expected_known_good_sha256: str,
+    required_gpu_name: str,
+) -> list[str]:
+    """Return all byte-identity and provenance errors for a release evidence chain."""
+    directory = Path(candidate_dir)
+    manifest_path = Path(candidate_manifest)
+    qualification_path = Path(qualification)
+    problems = validate_candidate_directory(
+        directory,
+        manifest_path=manifest_path,
+        expected_commit=expected_commit,
+    )
+    if problems:
+        return problems
+    try:
+        candidate = load_candidate_manifest(manifest_path)
+    except (OSError, UnicodeError, ValueError) as exc:
+        return [f"manifest: {exc}"]
+    problems.extend(
+        validate_qualification_file(
+            qualification_path,
+            expected_commit=expected_commit,
+            expected_wheel_sha256=candidate.wheel.sha256,
+            expected_candidate_manifest_sha256=sha256_file(manifest_path),
+            expected_known_good_sha256=expected_known_good_sha256,
+            required_gpu_name=required_gpu_name,
+        )
+    )
+    if problems:
+        return problems
+    try:
+        payload = json.loads(qualification_path.read_text(encoding="utf-8"))
+        evidence = GPUQualification.model_validate(payload)
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+        return [f"qualification: {exc}"]
+    return _cross_record_bindings(candidate, evidence)
+
+
+def _cross_record_bindings(candidate: CandidateManifest, evidence: GPUQualification) -> list[str]:
+    problems: list[str] = []
+    bindings = (
+        (candidate.source_commit, evidence.source_commit, "source commit"),
+        (candidate.miniverl_version, evidence.miniverl_version, "miniVERL version"),
+        (candidate.artifact_name, evidence.candidate.artifact_name, "artifact name"),
+        (
+            candidate.workflow.repository,
+            evidence.candidate.workflow_repository,
+            "workflow repository",
+        ),
+        (
+            candidate.workflow.workflow_path,
+            evidence.candidate.workflow_path,
+            "workflow path",
+        ),
+        (
+            candidate.workflow.run_id,
+            evidence.candidate.workflow_run_id,
+            "workflow run id",
+        ),
+        (
+            candidate.workflow.run_attempt,
+            evidence.candidate.workflow_run_attempt,
+            "workflow run attempt",
+        ),
+    )
+    for candidate_value, evidence_value, label in bindings:
+        if candidate_value != evidence_value:
+            problems.append(
+                f"binding: candidate {label} {candidate_value!r} does not match "
+                f"qualification {evidence_value!r}"
+            )
+    if candidate.wheel.filename != evidence.wheel.filename:
+        problems.append("binding: candidate wheel filename does not match qualification")
+    return problems

--- a/src/miniverl/training/artifacts.py
+++ b/src/miniverl/training/artifacts.py
@@ -1,0 +1,160 @@
+"""Transactional run-manifest publication behind the trainer facade."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from miniverl.cache.store import sha256_file
+from miniverl.training.checkpoint import latest_checkpoint, validate_checkpoint
+from miniverl.utils.runs import RunPaths, utc_now, write_json_atomic
+
+__all__ = ["ManifestFinalization", "RunArtifactRecorder"]
+
+
+@dataclass(frozen=True)
+class ManifestFinalization:
+    """Explicit state copied from the trainer at one terminal boundary."""
+
+    status: Literal["completed", "failed", "interrupted"]
+    global_step: int
+    parameter_version: int
+    policy_version: int
+    cycles_completed: int
+    rollout_policy_version: int
+    projection_chunk_size: int
+    chunk_size_history: tuple[int, ...]
+    oom_retries: int
+    final_memory: dict[str, Any]
+    offline_dataset_digest: str | None
+    resumed_from: dict[str, Any] | None
+    require_offline_dataset: bool
+    result: dict[str, Any] | None = None
+    error: BaseException | None = None
+
+
+class RunArtifactRecorder:
+    """Own atomic manifest transitions; it never owns models or training state."""
+
+    def __init__(self, paths: RunPaths, *, started_at: str) -> None:
+        self.paths = paths
+        self.started_at = started_at
+
+    def mark_running(self) -> None:
+        manifest = json.loads(self.paths.manifest.read_text(encoding="utf-8"))
+        manifest["status"] = "running"
+        manifest["started_at"] = self.started_at
+        for key in (
+            "completed_at",
+            "failed_at",
+            "interrupted_at",
+            "closed_at",
+            "failure",
+        ):
+            manifest.pop(key, None)
+        write_json_atomic(self.paths.manifest, manifest)
+
+    def finalize(
+        self,
+        finalization: ManifestFinalization,
+        *,
+        fallback_manifest: dict[str, Any],
+    ) -> None:
+        """Publish one complete terminal manifest after deriving artifact integrity."""
+        if self.paths.manifest_start.is_file():
+            manifest = json.loads(self.paths.manifest_start.read_text(encoding="utf-8"))
+            startup_digest = hashlib.sha256(self.paths.manifest_start.read_bytes()).hexdigest()
+        else:
+            manifest = fallback_manifest
+            startup_digest = None
+        manifest.update(
+            {
+                "status": finalization.status,
+                "started_at": self.started_at,
+                "global_step": finalization.global_step,
+                "global_optimizer_step": finalization.global_step,
+                "parameter_version": finalization.parameter_version,
+                "policy_version": finalization.policy_version,
+                "rollout_iteration": finalization.cycles_completed,
+                "rollout_policy_version": finalization.rollout_policy_version,
+                "cycles_completed": finalization.cycles_completed,
+                "actual_optimizer_updates": finalization.global_step,
+                "final_projection_chunk_size": finalization.projection_chunk_size,
+                "chunk_size_history": list(finalization.chunk_size_history),
+                "oom_retries": finalization.oom_retries,
+                "final_memory": finalization.final_memory,
+                "offline_dataset": (
+                    {"digest": finalization.offline_dataset_digest}
+                    if finalization.offline_dataset_digest
+                    else None
+                ),
+                "resumed_from": finalization.resumed_from,
+                "startup_manifest_digest": startup_digest,
+            }
+        )
+        for key in ("completed_at", "failed_at", "interrupted_at", "failure"):
+            manifest.pop(key, None)
+        now = utc_now()
+        if finalization.status == "completed":
+            manifest["completed_at"] = now
+        elif finalization.status == "interrupted":
+            manifest["interrupted_at"] = now
+        else:
+            manifest["failed_at"] = now
+        if finalization.error is not None:
+            manifest["failure"] = {
+                "type": type(finalization.error).__name__,
+                "message": str(finalization.error),
+            }
+
+        checkpoint_payload = None
+        selected = latest_checkpoint(self.paths.checkpoints)
+        if selected is not None:
+            validated = validate_checkpoint(selected)
+            checkpoint_payload = {
+                "directory": selected.name,
+                "global_step": validated.state.global_step,
+                "digest": validated.content_digest,
+                "integrity": validated.integrity,
+            }
+        manifest["final_checkpoint"] = checkpoint_payload
+
+        eval_payload = None
+        if self.paths.eval_json.is_file():
+            digest, size = sha256_file(self.paths.eval_json)
+            eval_payload = {
+                "file": self.paths.eval_json.name,
+                "digest": digest,
+                "bytes": size,
+            }
+        manifest["final_evaluation"] = eval_payload
+
+        required = [
+            self.paths.config_original,
+            self.paths.config_validated,
+            self.paths.config_resolved,
+            self.paths.environment,
+            self.paths.manifest_start,
+        ]
+        if finalization.status == "completed":
+            required.extend([self.paths.eval_json])
+            if checkpoint_payload is None:
+                required.append(self.paths.checkpoints / "final")
+            if finalization.require_offline_dataset:
+                required.extend(
+                    [
+                        self.paths.offline_dataset_manifest,
+                        self.paths.offline_dataset_trajectories,
+                    ]
+                )
+        manifest["expected_artifacts"] = {path.name: path.exists() for path in required}
+        manifest["all_expected_artifacts_complete"] = (
+            finalization.status == "completed"
+            and all(manifest["expected_artifacts"].values())
+            and checkpoint_payload is not None
+        )
+        if finalization.result is not None:
+            manifest["result"] = finalization.result
+        write_json_atomic(self.paths.manifest, manifest)

--- a/src/miniverl/training/trainer.py
+++ b/src/miniverl/training/trainer.py
@@ -30,7 +30,7 @@ import time
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from miniverl import __version__
 from miniverl.agent.loop import RolloutRunner, RolloutStats
@@ -76,6 +76,7 @@ from miniverl.selection.selectors import (
     aggregate_selection_stats,
     select_positions,
 )
+from miniverl.training.artifacts import ManifestFinalization, RunArtifactRecorder
 from miniverl.training.checkpoint import CheckpointState, load_checkpoint, save_checkpoint
 from miniverl.training.memory import (
     MemoryPlan,
@@ -820,20 +821,7 @@ class OPDTrainer:
 
     def _transition_manifest_to_running(self) -> None:
         """Atomically publish RUNNING immediately before training emits events."""
-        import json
-
-        manifest = json.loads(self.paths.manifest.read_text(encoding="utf-8"))
-        manifest["status"] = "running"
-        manifest["started_at"] = self._started_at
-        for key in (
-            "completed_at",
-            "failed_at",
-            "interrupted_at",
-            "closed_at",
-            "failure",
-        ):
-            manifest.pop(key, None)
-        write_json_atomic(self.paths.manifest, manifest)
+        RunArtifactRecorder(self.paths, started_at=self._started_at).mark_running()
 
     def build_manifest(self) -> dict[str, Any]:
         """Full provenance record for the run."""
@@ -1018,112 +1006,39 @@ class OPDTrainer:
     def _finalize_manifest(
         self,
         *,
-        status: str,
+        status: Literal["completed", "failed", "interrupted"],
         result: TrainResult | None = None,
         error: BaseException | None = None,
     ) -> None:
         """Atomically combine immutable startup provenance with final run state."""
-        import json
-
-        from miniverl.cache.store import sha256_file
-        from miniverl.training.checkpoint import latest_checkpoint, validate_checkpoint
-
-        if self.paths.manifest_start.is_file():
-            manifest = json.loads(self.paths.manifest_start.read_text(encoding="utf-8"))
-            startup_digest = hashlib.sha256(self.paths.manifest_start.read_bytes()).hexdigest()
-        else:
-            # Backward-compatible finalization for a legacy run directory.
-            manifest = self.build_manifest()
-            startup_digest = None
-        now = utc_now()
-        manifest.update(
-            {
-                "status": status,
-                "started_at": self._started_at,
-                "global_step": self.global_step,
-                "global_optimizer_step": self.global_step,
-                "parameter_version": self.parameter_version,
-                "policy_version": self.policy_version,
-                "rollout_iteration": self._cycles_completed,
-                "rollout_policy_version": self._last_rollout_policy_version,
-                "cycles_completed": self._cycles_completed,
-                "actual_optimizer_updates": self.global_step,
-                "final_projection_chunk_size": self.plan.chunk_size,
-                "chunk_size_history": list(self.plan.chunk_size_history),
-                "oom_retries": self.plan.oom_retries_used,
-                "final_memory": self.plan.to_dict(),
-                "offline_dataset": (
-                    {"digest": self.offline_dataset_digest} if self.offline_dataset_digest else None
-                ),
-                "resumed_from": self._resumed_from,
-                "startup_manifest_digest": startup_digest,
-            }
-        )
-        for key in ("completed_at", "failed_at", "interrupted_at", "failure"):
-            manifest.pop(key, None)
-        if status == "completed":
-            manifest["completed_at"] = now
-        elif status == "interrupted":
-            manifest["interrupted_at"] = now
-        else:
-            manifest["failed_at"] = now
-        if error is not None:
-            manifest["failure"] = {
-                "type": type(error).__name__,
-                "message": str(error),
-            }
-
-        checkpoint_payload = None
-        selected = latest_checkpoint(self.paths.checkpoints)
-        if selected is not None:
-            validated = validate_checkpoint(selected)
-            checkpoint_payload = {
-                "directory": selected.name,
-                "global_step": validated.state.global_step,
-                "digest": validated.content_digest,
-                "integrity": validated.integrity,
-            }
-        manifest["final_checkpoint"] = checkpoint_payload
-
-        eval_payload = None
-        if self.paths.eval_json.is_file():
-            digest, size = sha256_file(self.paths.eval_json)
-            eval_payload = {
-                "file": self.paths.eval_json.name,
-                "digest": digest,
-                "bytes": size,
-            }
-        manifest["final_evaluation"] = eval_payload
-
-        required = [
-            self.paths.config_original,
-            self.paths.config_validated,
-            self.paths.config_resolved,
-            self.paths.environment,
-            self.paths.manifest_start,
-        ]
-        if status == "completed":
-            required.extend([self.paths.eval_json])
-            if checkpoint_payload is None:
-                required.append(self.paths.checkpoints / "final")
-            if self.config.run.mode is TrainingMode.OFFLINE_KD and self.config.train.cycles > 0:
-                required.extend(
-                    [
-                        self.paths.offline_dataset_manifest,
-                        self.paths.offline_dataset_trajectories,
-                    ]
-                )
-        manifest["expected_artifacts"] = {path.name: path.exists() for path in required}
-        manifest["all_expected_artifacts_complete"] = (
-            status == "completed"
-            and all(manifest["expected_artifacts"].values())
-            and checkpoint_payload is not None
-        )
+        result_payload = None
         if result is not None:
             result_payload = result.to_dict()
             result_payload["run_dir"] = self.paths.root.name
-            manifest["result"] = result_payload
-        write_json_atomic(self.paths.manifest, manifest)
+        RunArtifactRecorder(self.paths, started_at=self._started_at).finalize(
+            ManifestFinalization(
+                status=status,
+                global_step=self.global_step,
+                parameter_version=self.parameter_version,
+                policy_version=self.policy_version,
+                cycles_completed=self._cycles_completed,
+                rollout_policy_version=self._last_rollout_policy_version,
+                projection_chunk_size=self.plan.chunk_size,
+                chunk_size_history=tuple(self.plan.chunk_size_history),
+                oom_retries=self.plan.oom_retries_used,
+                final_memory=self.plan.to_dict(),
+                offline_dataset_digest=self.offline_dataset_digest,
+                resumed_from=self._resumed_from,
+                require_offline_dataset=(
+                    self.config.run.mode is TrainingMode.OFFLINE_KD and self.config.train.cycles > 0
+                ),
+                result=result_payload,
+                error=error,
+            ),
+            fallback_manifest=(
+                {} if self.paths.manifest_start.is_file() else self.build_manifest()
+            ),
+        )
 
     # -- task sampling --------------------------------------------------------
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -46,6 +46,7 @@ EXPECTED_COMMANDS = {
     "compat check",
     "hardware record",
     "hardware validate",
+    "qualification validate",
     "data sample",
     "align",
     "alignment-suite prepare",

--- a/tests/cli/test_qualification_cli.py
+++ b/tests/cli/test_qualification_cli.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from miniverl.cli import app
+from tests.unit.test_gpu_qualification import _payload
+
+
+def test_qualification_command_has_help_and_validates_json(tmp_path: Path) -> None:
+    runner = CliRunner()
+    help_result = runner.invoke(app, ["qualification", "validate", "--help"])
+    assert help_result.exit_code == 0
+    assert "exact source SHA" in help_result.output
+
+    payload, root = _payload(tmp_path)
+    path = root / "qualification.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "qualification",
+            "validate",
+            str(path),
+            "--commit",
+            "a" * 40,
+            "--required-gpu-name",
+            "NVIDIA GeForce RTX 4080",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {"valid": True, "problems": []}
+
+
+def test_qualification_command_fails_closed_on_wrong_commit(tmp_path: Path) -> None:
+    payload, root = _payload(tmp_path)
+    path = root / "qualification.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    result = CliRunner().invoke(
+        app,
+        ["qualification", "validate", str(path), "--commit", "f" * 40, "--json"],
+    )
+    assert result.exit_code == 1
+    body = json.loads(result.stdout)
+    assert body["valid"] is False
+    assert body["problems"][0].startswith("binding:")

--- a/tests/unit/test_gpu_qualification.py
+++ b/tests/unit/test_gpu_qualification.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import json
 import shutil
+import urllib.error
+import urllib.request
 import zipfile
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from threading import Thread
 from types import SimpleNamespace
 
 import pytest
@@ -167,6 +171,24 @@ def test_qualification_rejects_private_paths_and_hash_mismatch(tmp_path: Path) -
     )
 
 
+@pytest.mark.parametrize("replacement", [b"run", b'{"status":"completed"}\nextra'])
+def test_qualification_rejects_artifact_size_drift_even_with_updated_hash(
+    tmp_path: Path, replacement: bytes
+) -> None:
+    from miniverl.qualification import sha256_file, validate_qualification_payload
+
+    payload, root = _payload(tmp_path)
+    artifact = root / "run-manifest.json"
+    declared_bytes = payload["artifacts"][0]["bytes"]  # type: ignore[index]
+    artifact.write_bytes(replacement)
+    assert artifact.stat().st_size != declared_bytes
+    payload["artifacts"][0]["sha256"] = sha256_file(artifact)  # type: ignore[index]
+    assert any(
+        "size mismatch" in problem
+        for problem in validate_qualification_payload(payload, artifact_root=root)
+    )
+
+
 def _full_result(name: str) -> dict[str, object]:
     kinds = {
         "direct": ("single_gpu_opd_developer_workload", "measured"),
@@ -206,7 +228,7 @@ def _full_result(name: str) -> dict[str, object]:
 
 
 def test_full_qualification_promotion_binds_all_canonical_results(tmp_path: Path) -> None:
-    from miniverl.qualification import validate_qualification_file
+    from miniverl.qualification import sha256_file, validate_qualification_file
     from scripts.promote_full_gpu_qualification import promote
 
     payload, root = _payload(tmp_path)
@@ -243,6 +265,16 @@ def test_full_qualification_promotion_binds_all_canonical_results(tmp_path: Path
     assert any(
         "full qualification evidence is missing" in problem
         for problem in validate_qualification_payload(incomplete, artifact_root=root)
+    )
+
+    complete = promoted.model_dump(mode="json")
+    full_result = root / "full/direct.json"
+    evidence = next(item for item in complete["artifacts"] if item["path"] == "full/direct.json")
+    full_result.write_bytes(full_result.read_bytes() + b"\n")
+    evidence["sha256"] = sha256_file(full_result)
+    assert any(
+        "size mismatch" in problem
+        for problem in validate_qualification_payload(complete, artifact_root=root)
     )
 
 
@@ -364,7 +396,13 @@ def _zip_tree(source: Path, destination: Path) -> None:
                 archive.write(path, path.relative_to(source).as_posix())
 
 
-def _remote_pair(tmp_path: Path, *, candidate_run_id: int = 42) -> tuple[Path, Path, Path]:
+def _remote_pair(
+    tmp_path: Path,
+    *,
+    candidate_run_id: int = 42,
+    candidate_run_attempt: int = 1,
+    qualification_run_attempt: int = 1,
+) -> tuple[Path, Path, Path]:
     from miniverl.qualification import sha256_file
     from miniverl.release_candidate import PINNED_BUILD_TOOLS
 
@@ -386,7 +424,7 @@ def _remote_pair(tmp_path: Path, *, candidate_run_id: int = 42) -> tuple[Path, P
             "repository": "DaoyuanLi2816/mini-verl",
             "workflow_path": ".github/workflows/gpu.yml",
             "run_id": candidate_run_id,
-            "run_attempt": 1,
+            "run_attempt": candidate_run_attempt,
         },
         "build": {"os": "Linux", "python": "3.12.0", "tools": PINNED_BUILD_TOOLS},
         "wheel": {
@@ -413,7 +451,7 @@ def _remote_pair(tmp_path: Path, *, candidate_run_id: int = 42) -> tuple[Path, P
         "workflow_repository": "DaoyuanLi2816/mini-verl",
         "workflow_path": ".github/workflows/gpu.yml",
         "workflow_run_id": 42,
-        "workflow_run_attempt": 1,
+        "workflow_run_attempt": qualification_run_attempt,
         "installed_from_candidate": True,
         "import_origin_verified": True,
         "cli_origin_verified": True,
@@ -561,6 +599,183 @@ def test_release_verifier_rejects_cross_run_candidate(
             known_good=known_good,
             output=tmp_path / "rejected",
         )
+
+
+def test_release_verifier_rejects_cross_attempt_pair(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    known_good = tmp_path / "known-good.json"
+    known_good.write_text("{}", encoding="utf-8")
+    candidate_zip, qualification_zip, _ = _remote_pair(
+        tmp_path,
+        candidate_run_attempt=1,
+        qualification_run_attempt=2,
+    )
+    from scripts import verify_release_qualification as verifier
+
+    run = {
+        "id": 42,
+        "head_sha": "a" * 40,
+        "conclusion": "success",
+        "event": "workflow_dispatch",
+        "workflow_id": 7,
+        "path": ".github/workflows/gpu.yml",
+        "repository": {"full_name": "DaoyuanLi2816/mini-verl"},
+        "head_repository": {"full_name": "DaoyuanLi2816/mini-verl"},
+        "run_attempt": 2,
+        "created_at": "2026-08-15T12:00:00Z",
+        "html_url": "https://example.invalid/run/42",
+    }
+    monkeypatch.setattr(
+        verifier,
+        "_request_json",
+        lambda url, token: (
+            {"id": 7, "path": ".github/workflows/gpu.yml"}
+            if url.endswith("/actions/workflows/gpu.yml")
+            else {"workflow_runs": [run]}
+            if "/runs?" in url
+            else {
+                "artifacts": [
+                    {
+                        "id": 1,
+                        "name": "candidate-distributions",
+                        "expired": False,
+                        "archive_download_url": "candidate",
+                    },
+                    {
+                        "id": 2,
+                        "name": "gpu-full-qualification",
+                        "expired": False,
+                        "archive_download_url": "qualification",
+                    },
+                ]
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        verifier,
+        "_download",
+        lambda url, token, destination: shutil.copy2(
+            candidate_zip if url == "candidate" else qualification_zip, destination
+        ),
+    )
+    with pytest.raises(RuntimeError, match="same-run"):
+        verifier.fetch_and_validate(
+            repository="DaoyuanLi2816/mini-verl",
+            workflow="gpu.yml",
+            commit="a" * 40,
+            qualification_artifact_name="gpu-full-qualification",
+            candidate_artifact_name="candidate-distributions",
+            token="token",
+            required_gpu_name="NVIDIA GeForce RTX 4080",
+            known_good=known_good,
+            output=tmp_path / "rejected-attempt",
+        )
+
+
+@pytest.mark.parametrize("status", [301, 302, 303, 307, 308])
+def test_cross_origin_redirect_strips_sensitive_headers(status: int) -> None:
+    from scripts.verify_release_qualification import _SafeRedirectHandler
+
+    request = urllib.request.Request(
+        "https://api.github.com/repos/org/repo/actions/artifacts/1/zip",
+        headers={
+            "Authorization": "Bearer top-secret",
+            "Proxy-Authorization": "Basic also-secret",
+            "Cookie": "session=secret",
+            "Accept": "application/octet-stream",
+            "User-Agent": "miniVERL-test",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    redirected = _SafeRedirectHandler().redirect_request(
+        request,
+        None,
+        status,
+        "redirect",
+        {},
+        "https://objects.githubusercontent.com/artifact.zip",
+    )
+    assert redirected is not None
+    lowered = {name.lower(): value for name, value in redirected.header_items()}
+    assert "authorization" not in lowered
+    assert "proxy-authorization" not in lowered
+    assert "cookie" not in lowered
+    assert lowered["accept"] == "application/octet-stream"
+    assert lowered["user-agent"] == "miniVERL-test"
+    assert lowered["x-github-api-version"] == "2022-11-28"
+
+
+def test_same_origin_redirect_preserves_authorization() -> None:
+    from scripts.verify_release_qualification import _SafeRedirectHandler
+
+    request = urllib.request.Request(
+        "https://api.github.com/old",
+        headers={"Authorization": "Bearer top-secret"},
+    )
+    redirected = _SafeRedirectHandler().redirect_request(
+        request, None, 302, "redirect", {}, "https://api.github.com/new"
+    )
+    assert redirected is not None
+    assert redirected.get_header("Authorization") == "Bearer top-secret"
+
+
+def test_download_redirect_does_not_send_token_to_another_origin() -> None:
+    from scripts.verify_release_qualification import _request_json
+
+    class TargetHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            payload = json.dumps(dict(self.headers.items())).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, format, *args) -> None:
+            del format, args
+
+    target = ThreadingHTTPServer(("127.0.0.1", 0), TargetHandler)
+
+    class RedirectHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(302)
+            self.send_header("Location", f"http://127.0.0.1:{target.server_port}/artifact")
+            self.end_headers()
+
+        def log_message(self, format, *args) -> None:
+            del format, args
+
+    redirect = ThreadingHTTPServer(("127.0.0.1", 0), RedirectHandler)
+    threads = [Thread(target=server.serve_forever, daemon=True) for server in (target, redirect)]
+    for thread in threads:
+        thread.start()
+    try:
+        received = _request_json(f"http://127.0.0.1:{redirect.server_port}/start", "top-secret")
+    finally:
+        redirect.shutdown()
+        target.shutdown()
+        redirect.server_close()
+        target.server_close()
+    lowered = {name.lower(): value for name, value in received.items()}
+    assert "authorization" not in lowered
+    assert lowered["accept"] == "application/vnd.github+json"
+    assert lowered["user-agent"] == "miniVERL-release-qualification"
+    assert lowered["x-github-api-version"] == "2022-11-28"
+
+
+def test_network_errors_never_expose_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import verify_release_qualification as verifier
+
+    class BrokenOpener:
+        def open(self, request, timeout):
+            del request, timeout
+            raise urllib.error.URLError("Bearer top-secret")
+
+    monkeypatch.setattr(verifier, "_URL_OPENER", BrokenOpener())
+    with pytest.raises(RuntimeError) as error:
+        verifier._request_json("https://api.github.com/example", "top-secret")
+    assert "top-secret" not in str(error.value)
 
 
 def test_release_chain_binds_exact_candidate_bytes(tmp_path: Path) -> None:

--- a/tests/unit/test_gpu_qualification.py
+++ b/tests/unit/test_gpu_qualification.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+def _payload(tmp_path: Path) -> tuple[dict[str, object], Path]:
+    artifact_root = tmp_path / "artifact"
+    artifact_root.mkdir(parents=True)
+    wheel = artifact_root / "miniverl-0.10.1.dev0-py3-none-any.whl"
+    wheel.write_bytes(b"wheel")
+    run_manifest = artifact_root / "run-manifest.json"
+    run_manifest.write_text('{"status":"completed"}\n', encoding="utf-8")
+
+    from miniverl.qualification import sha256_file
+
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "kind": "miniverl_gpu_qualification",
+        "level": "release_smoke",
+        "status": "passed",
+        "measured_at": "2026-08-14T12:00:00Z",
+        "source_commit": "a" * 40,
+        "miniverl_version": "0.10.1.dev0",
+        "wheel": {
+            "filename": wheel.name,
+            "sha256": sha256_file(wheel),
+        },
+        "profile": {
+            "name": "verl-opd-v0.8-single-gpu-v1",
+            "identity_digest": "b" * 64,
+            "upstream_tag": "v0.8.0",
+            "upstream_commit": "c" * 40,
+        },
+        "environment": {
+            "known_good_manifest_sha256": "d" * 64,
+            "gpu_name": "NVIDIA GeForce RTX 4080",
+            "gpu_count": 1,
+            "vram_gib": 15.99,
+            "driver": "596.49",
+            "cuda_runtime": "13.0",
+            "python": "3.10.11",
+            "packages": {
+                "torch": "2.13.0+cu130",
+                "transformers": "5.14.1",
+                "peft": "0.18.0",
+                "accelerate": "1.14.0",
+                "bitsandbytes": "0.50.0",
+                "numpy": "2.2.6",
+                "pyarrow": "25.0.0",
+            },
+        },
+        "models": [
+            {"role": "actor", "model_id": "org/actor", "revision": "e" * 40},
+            {"role": "teacher", "model_id": "org/teacher", "revision": "f" * 40},
+        ],
+        "execution": {
+            "rollout_completed": True,
+            "teacher_scoring_completed": True,
+            "optimizer_updates": 1,
+            "peft_adapter_exported": True,
+            "peft_adapter_reload_verified": True,
+            "cuda_allocated_before_bytes": 0,
+            "cuda_allocated_after_teardown_bytes": 0,
+            "cuda_teardown_tolerance_bytes": 2097152,
+        },
+        "inputs": {
+            "config_sha256": "1" * 64,
+            "plan_sha256": "2" * 64,
+            "parquet_sha256": "3" * 64,
+        },
+        "artifacts": [
+            {
+                "name": "run_manifest",
+                "path": run_manifest.name,
+                "sha256": sha256_file(run_manifest),
+                "bytes": run_manifest.stat().st_size,
+            }
+        ],
+        "checks": {
+            "executed": [
+                "wheel_install",
+                "doctor",
+                "plan",
+                "run_dry_run",
+                "real_actor_teacher_update",
+                "peft_reload",
+                "cuda_teardown",
+            ],
+            "skipped": [],
+            "not_applicable": ["distributed_verl_execution"],
+        },
+        "scientific_scope": {
+            "runtime_correctness_only": True,
+            "task_quality_evaluated": False,
+            "alignment_quality_evaluated": False,
+            "distributed_execution_tested": False,
+            "other_hardware_measured": False,
+        },
+    }
+    return payload, artifact_root
+
+
+def test_strict_qualification_round_trip_and_artifact_hashes(tmp_path: Path) -> None:
+    from miniverl.qualification import validate_qualification_payload
+
+    payload, root = _payload(tmp_path / "private")
+    assert validate_qualification_payload(payload, artifact_root=root) == []
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected"),
+    [
+        (lambda p: p.update(extra="invented"), "schema"),
+        (lambda p: p["execution"].update(optimizer_updates=0), "schema"),  # type: ignore[union-attr]
+        (lambda p: p["environment"].update(vram_gib=float("nan")), "schema"),  # type: ignore[union-attr]
+        (lambda p: p.update(status="passed", source_commit="short"), "schema"),
+    ],
+)
+def test_qualification_rejects_invalid_or_invented_fields(
+    tmp_path: Path, mutation, expected: str
+) -> None:
+    from miniverl.qualification import validate_qualification_payload
+
+    payload, root = _payload(tmp_path / "checksum")
+    mutation(payload)
+    assert validate_qualification_payload(payload, artifact_root=root)[0].startswith(expected)
+
+
+def test_qualification_rejects_private_paths_and_hash_mismatch(tmp_path: Path) -> None:
+    from miniverl.qualification import validate_qualification_payload
+
+    payload, root = _payload(tmp_path / "private")
+    payload["artifacts"][0]["path"] = "C:\\Users\\someone\\secret.json"  # type: ignore[index]
+    assert validate_qualification_payload(payload, artifact_root=root)[0].startswith("privacy")
+
+    payload, root = _payload(tmp_path / "checksum")
+    payload["artifacts"][0]["sha256"] = "0" * 64  # type: ignore[index]
+    assert any(
+        "checksum" in problem
+        for problem in validate_qualification_payload(payload, artifact_root=root)
+    )
+
+
+def _full_result(name: str) -> dict[str, object]:
+    kinds = {
+        "direct": ("single_gpu_opd_developer_workload", "measured"),
+        "pg_k1": ("single_gpu_verl_pg_k1_systems_workload", "measured"),
+        "smollm2": (
+            "single_gpu_smollm2_direct_gkd_developer_workload",
+            "maintainer_measured",
+        ),
+    }
+    kind, status = kinds[name]
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "kind": kind,
+        "status": status,
+        "source_commit": "a" * 40,
+        "miniverl_version": "0.10.1.dev0",
+        "hardware": {"gpu": "NVIDIA GeForce RTX 4080", "gpu_count": 1},
+        "resume": {
+            "status": "exact_match",
+            "adapter_and_optimizer_byte_identical": True,
+            "training_state_fields_identical": True,
+            "trajectories_byte_identical": True,
+        },
+        "resource_contract": {"peak_reserved_within_limit": True},
+        "verl": {"distributed_execution_tested": False},
+        "artifacts": {"standard_peft_load_verified": name != "pg_k1"},
+    }
+    if name == "smollm2":
+        payload["scaleout"] = {
+            "artifact_bundle_complete": True,
+            "upstream_config_parse_passed": True,
+            "model_data_load_smoke_passed": True,
+            "launchable": True,
+            "distributed_execution_tested": False,
+        }
+    return payload
+
+
+def test_full_qualification_promotion_binds_all_canonical_results(tmp_path: Path) -> None:
+    from miniverl.qualification import validate_qualification_file
+    from scripts.promote_full_gpu_qualification import promote
+
+    payload, root = _payload(tmp_path)
+    qualification = root / "qualification.json"
+    qualification.write_text(json.dumps(payload), encoding="utf-8")
+    results: dict[str, Path] = {}
+    for name in ("direct", "pg_k1", "smollm2"):
+        path = tmp_path / f"{name}.json"
+        path.write_text(json.dumps(_full_result(name)), encoding="utf-8")
+        results[name] = path
+
+    promoted = promote(
+        qualification,
+        direct=results["direct"],
+        pg_k1=results["pg_k1"],
+        smollm2=results["smollm2"],
+    )
+
+    assert promoted.level == "full_qualification"
+    assert validate_qualification_file(qualification) == []
+    assert {item.name for item in promoted.artifacts} >= {
+        "release_smoke_record",
+        "full_direct_result",
+        "full_pg_k1_result",
+        "full_smollm2_result",
+    }
+
+
+def test_full_qualification_rejects_failed_resume_equivalence(tmp_path: Path) -> None:
+    from scripts.promote_full_gpu_qualification import promote
+
+    payload, root = _payload(tmp_path)
+    qualification = root / "qualification.json"
+    qualification.write_text(json.dumps(payload), encoding="utf-8")
+    results: dict[str, Path] = {}
+    for name in ("direct", "pg_k1", "smollm2"):
+        result = _full_result(name)
+        if name == "pg_k1":
+            result["resume"]["trajectories_byte_identical"] = False  # type: ignore[index]
+        path = tmp_path / f"{name}.json"
+        path.write_text(json.dumps(result), encoding="utf-8")
+        results[name] = path
+    with pytest.raises(ValueError, match="equivalence"):
+        promote(
+            qualification,
+            direct=results["direct"],
+            pg_k1=results["pg_k1"],
+            smollm2=results["smollm2"],
+        )
+
+
+def test_committed_schema_is_generated_from_the_strict_model() -> None:
+    from miniverl.qualification import qualification_json_schema
+
+    committed = json.loads(
+        Path("docs/generated/gpu-qualification-v1.schema.json").read_text(encoding="utf-8")
+    )
+    assert committed == qualification_json_schema()
+
+
+def test_release_artifact_extraction_rejects_traversal_and_symlinks(tmp_path: Path) -> None:
+    from scripts.verify_release_qualification import _safe_extract
+
+    traversal = tmp_path / "traversal.zip"
+    with zipfile.ZipFile(traversal, "w") as archive:
+        archive.writestr("../escape.json", "{}")
+    with pytest.raises(ValueError, match="unsafe"):
+        _safe_extract(traversal, tmp_path / "out-traversal")
+
+    symlink = tmp_path / "symlink.zip"
+    info = zipfile.ZipInfo("qualification.json")
+    info.create_system = 3
+    info.external_attr = 0o120777 << 16
+    with zipfile.ZipFile(symlink, "w") as archive:
+        archive.writestr(info, "target")
+    with pytest.raises(ValueError, match="symlink"):
+        _safe_extract(symlink, tmp_path / "out-symlink")

--- a/tests/unit/test_gpu_qualification.py
+++ b/tests/unit/test_gpu_qualification.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import zipfile
 from pathlib import Path
 from types import SimpleNamespace
@@ -30,6 +31,18 @@ def _payload(tmp_path: Path) -> tuple[dict[str, object], Path]:
             "filename": wheel.name,
             "sha256": sha256_file(wheel),
         },
+        "candidate": {
+            "manifest_sha256": "9" * 64,
+            "artifact_name": "candidate-distributions",
+            "workflow_repository": None,
+            "workflow_path": None,
+            "workflow_run_id": None,
+            "workflow_run_attempt": None,
+            "installed_from_candidate": True,
+            "import_origin_verified": True,
+            "cli_origin_verified": True,
+            "import_origin": "qualification_venv_site_packages",
+        },
         "profile": {
             "name": "verl-opd-v0.8-single-gpu-v1",
             "identity_digest": "b" * 64,
@@ -52,6 +65,7 @@ def _payload(tmp_path: Path) -> tuple[dict[str, object], Path]:
                 "bitsandbytes": "0.50.0",
                 "numpy": "2.2.6",
                 "pyarrow": "25.0.0",
+                "safetensors": "0.8.0",
             },
         },
         "models": [
@@ -145,6 +159,13 @@ def test_qualification_rejects_private_paths_and_hash_mismatch(tmp_path: Path) -
         for problem in validate_qualification_payload(payload, artifact_root=root)
     )
 
+    payload, root = _payload(tmp_path / "extra")
+    (root / "unreferenced.bin").write_bytes(b"not declared")
+    assert any(
+        "unreferenced files" in problem
+        for problem in validate_qualification_payload(payload, artifact_root=root)
+    )
+
 
 def _full_result(name: str) -> dict[str, object]:
     kinds = {
@@ -213,6 +234,17 @@ def test_full_qualification_promotion_binds_all_canonical_results(tmp_path: Path
         "full_smollm2_result",
     }
 
+    incomplete = promoted.model_dump(mode="json")
+    incomplete["artifacts"] = [
+        item for item in incomplete["artifacts"] if item["name"] != "full_smollm2_result"
+    ]
+    from miniverl.qualification import validate_qualification_payload
+
+    assert any(
+        "full qualification evidence is missing" in problem
+        for problem in validate_qualification_payload(incomplete, artifact_root=root)
+    )
+
 
 def test_full_qualification_rejects_failed_resume_equivalence(tmp_path: Path) -> None:
     from scripts.promote_full_gpu_qualification import promote
@@ -250,6 +282,43 @@ def test_process_teardown_clears_bnb_and_cublas_caches() -> None:
     assert calls == ["cublas"]
 
 
+def test_qualification_rejects_candidate_manifest_mismatch(tmp_path: Path) -> None:
+    from miniverl.qualification import validate_qualification_payload
+
+    payload, root = _payload(tmp_path)
+    problems = validate_qualification_payload(
+        payload,
+        artifact_root=root,
+        expected_candidate_manifest_sha256="8" * 64,
+    )
+    assert any("candidate manifest" in problem for problem in problems)
+
+
+def test_install_origin_must_be_inside_qualification_venv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from scripts.run_gpu_qualification import _verify_install_origin
+
+    venv = tmp_path / "venv"
+    site = venv / "Lib/site-packages"
+    scripts = venv / "Scripts"
+    site.mkdir(parents=True)
+    scripts.mkdir()
+    imported = site / "miniverl/__init__.py"
+    imported.parent.mkdir()
+    imported.write_text("", encoding="utf-8")
+    cli = scripts / "miniverl.exe"
+    cli.write_bytes(b"exe")
+    monkeypatch.setattr("sys.prefix", str(venv))
+    monkeypatch.setattr("sys.base_prefix", str(tmp_path / "base"))
+    monkeypatch.setattr("sysconfig.get_paths", lambda: {"purelib": str(site)})
+    _verify_install_origin(str(imported), str(cli))
+    outside = tmp_path / "outside.py"
+    outside.write_text("", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="did not originate"):
+        _verify_install_origin(str(outside), str(cli))
+
+
 def test_committed_schema_is_generated_from_the_strict_model() -> None:
     from miniverl.qualification import qualification_json_schema
 
@@ -276,3 +345,294 @@ def test_release_artifact_extraction_rejects_traversal_and_symlinks(tmp_path: Pa
         archive.writestr(info, "target")
     with pytest.raises(ValueError, match="symlink"):
         _safe_extract(symlink, tmp_path / "out-symlink")
+
+    duplicate = tmp_path / "duplicate.zip"
+    with (
+        pytest.warns(UserWarning, match="Duplicate name"),
+        zipfile.ZipFile(duplicate, "w") as archive,
+    ):
+        archive.writestr("qualification.json", "{}")
+        archive.writestr("qualification.json", "{}")
+    with pytest.raises(ValueError, match="duplicate"):
+        _safe_extract(duplicate, tmp_path / "out-duplicate")
+
+
+def _zip_tree(source: Path, destination: Path) -> None:
+    with zipfile.ZipFile(destination, "w") as archive:
+        for path in sorted(source.rglob("*")):
+            if path.is_file():
+                archive.write(path, path.relative_to(source).as_posix())
+
+
+def _remote_pair(tmp_path: Path, *, candidate_run_id: int = 42) -> tuple[Path, Path, Path]:
+    from miniverl.qualification import sha256_file
+    from miniverl.release_candidate import PINNED_BUILD_TOOLS
+
+    candidate = tmp_path / "candidate"
+    candidate.mkdir()
+    wheel = candidate / "miniverl-0.10.1.dev0-py3-none-any.whl"
+    sdist = candidate / "miniverl-0.10.1.dev0.tar.gz"
+    wheel.write_bytes(b"wheel")
+    sdist.write_bytes(b"sdist")
+    manifest = {
+        "schema_version": 1,
+        "kind": "miniverl_release_candidate",
+        "source_commit": "a" * 40,
+        "miniverl_version": "0.10.1.dev0",
+        "created_at": "2026-08-15T12:00:00Z",
+        "artifact_name": "candidate-distributions",
+        "workflow": {
+            "kind": "github_actions",
+            "repository": "DaoyuanLi2816/mini-verl",
+            "workflow_path": ".github/workflows/gpu.yml",
+            "run_id": candidate_run_id,
+            "run_attempt": 1,
+        },
+        "build": {"os": "Linux", "python": "3.12.0", "tools": PINNED_BUILD_TOOLS},
+        "wheel": {
+            "filename": wheel.name,
+            "bytes": wheel.stat().st_size,
+            "sha256": sha256_file(wheel),
+        },
+        "sdist": {
+            "filename": sdist.name,
+            "bytes": sdist.stat().st_size,
+            "sha256": sha256_file(sdist),
+        },
+    }
+    manifest_path = candidate / "candidate-manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    (candidate / "SHA256SUMS").write_text(
+        f"{sha256_file(wheel)}  {wheel.name}\n{sha256_file(sdist)}  {sdist.name}\n",
+        encoding="utf-8",
+    )
+    payload, qualification = _payload(tmp_path / "qualification-source")
+    payload["candidate"] = {
+        "manifest_sha256": sha256_file(manifest_path),
+        "artifact_name": "candidate-distributions",
+        "workflow_repository": "DaoyuanLi2816/mini-verl",
+        "workflow_path": ".github/workflows/gpu.yml",
+        "workflow_run_id": 42,
+        "workflow_run_attempt": 1,
+        "installed_from_candidate": True,
+        "import_origin_verified": True,
+        "cli_origin_verified": True,
+        "import_origin": "qualification_venv_site_packages",
+    }
+    payload["environment"]["known_good_manifest_sha256"] = sha256_file(  # type: ignore[index]
+        tmp_path / "known-good.json"
+    )
+    (qualification / "qualification.json").write_text(json.dumps(payload), encoding="utf-8")
+    candidate_zip = tmp_path / "candidate.zip"
+    qualification_zip = tmp_path / "qualification.zip"
+    _zip_tree(candidate, candidate_zip)
+    _zip_tree(qualification, qualification_zip)
+    return candidate_zip, qualification_zip, tmp_path / "known-good.json"
+
+
+def test_release_verifier_accepts_only_same_run_pair(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    known_good = tmp_path / "known-good.json"
+    known_good.write_text("{}", encoding="utf-8")
+    candidate_zip, qualification_zip, _ = _remote_pair(tmp_path)
+    from scripts import verify_release_qualification as verifier
+
+    run = {
+        "id": 42,
+        "head_sha": "a" * 40,
+        "conclusion": "success",
+        "event": "workflow_dispatch",
+        "workflow_id": 7,
+        "path": ".github/workflows/gpu.yml",
+        "repository": {"full_name": "DaoyuanLi2816/mini-verl"},
+        "head_repository": {"full_name": "DaoyuanLi2816/mini-verl"},
+        "run_attempt": 1,
+        "created_at": "2026-08-15T12:00:00Z",
+        "html_url": "https://example.invalid/run/42",
+    }
+
+    def request(url: str, token: str):
+        del token
+        if url.endswith("/actions/workflows/gpu.yml"):
+            return {"id": 7, "path": ".github/workflows/gpu.yml"}
+        if "/runs?" in url:
+            return {"workflow_runs": [run]}
+        return {
+            "artifacts": [
+                {
+                    "id": 1,
+                    "name": "candidate-distributions",
+                    "expired": False,
+                    "archive_download_url": "candidate",
+                },
+                {
+                    "id": 2,
+                    "name": "gpu-release-smoke",
+                    "expired": False,
+                    "archive_download_url": "qualification",
+                },
+            ]
+        }
+
+    def download(url: str, token: str, destination: Path) -> None:
+        del token
+        shutil.copy2(candidate_zip if url == "candidate" else qualification_zip, destination)
+
+    monkeypatch.setattr(verifier, "_request_json", request)
+    monkeypatch.setattr(verifier, "_download", download)
+    result = verifier.fetch_and_validate(
+        repository="DaoyuanLi2816/mini-verl",
+        workflow="gpu.yml",
+        commit="a" * 40,
+        qualification_artifact_name="gpu-release-smoke",
+        candidate_artifact_name="candidate-distributions",
+        token="token",
+        required_gpu_name="NVIDIA GeForce RTX 4080",
+        known_good=known_good,
+        output=tmp_path / "accepted",
+    )
+    assert result["workflow_run_id"] == 42
+
+
+def test_release_verifier_rejects_cross_run_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    known_good = tmp_path / "known-good.json"
+    known_good.write_text("{}", encoding="utf-8")
+    candidate_zip, qualification_zip, _ = _remote_pair(tmp_path, candidate_run_id=41)
+    from scripts import verify_release_qualification as verifier
+
+    run = {
+        "id": 42,
+        "head_sha": "a" * 40,
+        "conclusion": "success",
+        "event": "workflow_dispatch",
+        "workflow_id": 7,
+        "path": ".github/workflows/gpu.yml",
+        "repository": {"full_name": "DaoyuanLi2816/mini-verl"},
+        "head_repository": {"full_name": "DaoyuanLi2816/mini-verl"},
+        "run_attempt": 1,
+        "created_at": "2026-08-15T12:00:00Z",
+        "html_url": "https://example.invalid/run/42",
+    }
+    monkeypatch.setattr(
+        verifier,
+        "_request_json",
+        lambda url, token: (
+            {"id": 7, "path": ".github/workflows/gpu.yml"}
+            if url.endswith("/actions/workflows/gpu.yml")
+            else {"workflow_runs": [run]}
+            if "/runs?" in url
+            else {
+                "artifacts": [
+                    {
+                        "id": 1,
+                        "name": "candidate-distributions",
+                        "expired": False,
+                        "archive_download_url": "candidate",
+                    },
+                    {
+                        "id": 2,
+                        "name": "gpu-release-smoke",
+                        "expired": False,
+                        "archive_download_url": "qualification",
+                    },
+                ]
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        verifier,
+        "_download",
+        lambda url, token, destination: shutil.copy2(
+            candidate_zip if url == "candidate" else qualification_zip, destination
+        ),
+    )
+    with pytest.raises(RuntimeError, match="same-run"):
+        verifier.fetch_and_validate(
+            repository="DaoyuanLi2816/mini-verl",
+            workflow="gpu.yml",
+            commit="a" * 40,
+            qualification_artifact_name="gpu-release-smoke",
+            candidate_artifact_name="candidate-distributions",
+            token="token",
+            required_gpu_name="NVIDIA GeForce RTX 4080",
+            known_good=known_good,
+            output=tmp_path / "rejected",
+        )
+
+
+def test_release_chain_binds_exact_candidate_bytes(tmp_path: Path) -> None:
+    from miniverl.qualification import sha256_file
+    from miniverl.release_candidate import load_candidate_manifest
+    from miniverl.release_chain import validate_release_chain
+
+    known_good = tmp_path / "known-good.json"
+    known_good.write_text("{}", encoding="utf-8")
+    candidate_zip, qualification_zip, _ = _remote_pair(tmp_path)
+    candidate = tmp_path / "candidate-unpacked"
+    qualification = tmp_path / "qualification-unpacked"
+    with zipfile.ZipFile(candidate_zip) as archive:
+        archive.extractall(candidate)
+    with zipfile.ZipFile(qualification_zip) as archive:
+        archive.extractall(qualification)
+    manifest_path = candidate / "candidate-manifest.json"
+    qualification_path = qualification / "qualification.json"
+    expected = {
+        "expected_commit": "a" * 40,
+        "expected_known_good_sha256": sha256_file(known_good),
+        "required_gpu_name": "NVIDIA GeForce RTX 4080",
+    }
+    assert validate_release_chain(candidate, manifest_path, qualification_path, **expected) == []
+
+    record = load_candidate_manifest(manifest_path)
+    wheel = candidate / record.wheel.filename
+    wheel.write_bytes(b"different wheel from the same source commit")
+    payload = record.model_dump(mode="json")
+    payload["wheel"]["bytes"] = wheel.stat().st_size
+    payload["wheel"]["sha256"] = sha256_file(wheel)
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    (candidate / "SHA256SUMS").write_text(
+        f"{payload['wheel']['sha256']}  {record.wheel.filename}\n"
+        f"{record.sdist.sha256}  {record.sdist.filename}\n",
+        encoding="utf-8",
+    )
+    problems = validate_release_chain(candidate, manifest_path, qualification_path, **expected)
+    assert any("wheel checksum" in problem for problem in problems)
+    assert any("candidate manifest checksum" in problem for problem in problems)
+
+
+def test_release_verifier_rejects_expired_or_wrong_workflow_artifacts() -> None:
+    from scripts.verify_release_qualification import _artifact, _run_is_exact
+
+    with pytest.raises(ValueError, match="expired"):
+        _artifact(
+            [{"name": "candidate-distributions", "expired": True}],
+            "candidate-distributions",
+        )
+    base = {
+        "head_sha": "a" * 40,
+        "conclusion": "success",
+        "event": "workflow_dispatch",
+        "workflow_id": 7,
+        "path": ".github/workflows/other.yml",
+        "repository": {"full_name": "DaoyuanLi2816/mini-verl"},
+        "head_repository": {"full_name": "DaoyuanLi2816/mini-verl"},
+    }
+    assert not _run_is_exact(
+        base,
+        repository="DaoyuanLi2816/mini-verl",
+        workflow_id=7,
+        workflow_path=".github/workflows/gpu.yml",
+        commit="a" * 40,
+    )
+    base["path"] = ".github/workflows/gpu.yml"
+    base["head_repository"] = {"full_name": "someone/fork"}
+    assert not _run_is_exact(
+        base,
+        repository="DaoyuanLi2816/mini-verl",
+        workflow_id=7,
+        workflow_path=".github/workflows/gpu.yml",
+        commit="a" * 40,
+    )

--- a/tests/unit/test_gpu_qualification.py
+++ b/tests/unit/test_gpu_qualification.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -234,6 +235,19 @@ def test_full_qualification_rejects_failed_resume_equivalence(tmp_path: Path) ->
             pg_k1=results["pg_k1"],
             smollm2=results["smollm2"],
         )
+
+
+def test_process_teardown_clears_bnb_and_cublas_caches() -> None:
+    from scripts.run_gpu_qualification import _clear_process_global_cuda_caches
+
+    calls: list[str] = []
+    torch_module = SimpleNamespace(
+        _C=SimpleNamespace(_cuda_clearCublasWorkspaces=lambda: calls.append("cublas"))
+    )
+    bnb_functional = SimpleNamespace(name2qmap={"dynamic": object()})
+    _clear_process_global_cuda_caches(torch_module, bnb_functional)
+    assert bnb_functional.name2qmap == {}
+    assert calls == ["cublas"]
 
 
 def test_committed_schema_is_generated_from_the_strict_model() -> None:

--- a/tests/unit/test_known_good_environment.py
+++ b/tests/unit/test_known_good_environment.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_known_good_environment_is_machine_readable_and_consistent() -> None:
+    from scripts.check_known_good_environment import check_known_good_environment
+
+    assert check_known_good_environment(ROOT) == []
+
+
+def test_known_good_environment_is_scoped_to_one_measured_stack() -> None:
+    payload = json.loads(
+        (ROOT / "environments/known-good-rtx4080-cu130.json").read_text(encoding="utf-8")
+    )
+    assert payload["schema_version"] == 1
+    assert payload["status"] == "maintainer_measured"
+    assert payload["hardware"]["gpu"] == "NVIDIA GeForce RTX 4080"
+    assert payload["scope"]["other_hardware"] == "unmeasured"
+    assert payload["pytorch"]["index_url"].startswith("https://download.pytorch.org/whl/")
+    assert "+cu" in payload["packages"]["torch"]

--- a/tests/unit/test_known_good_environment.py
+++ b/tests/unit/test_known_good_environment.py
@@ -18,7 +18,8 @@ def test_known_good_environment_is_scoped_to_one_measured_stack() -> None:
     )
     assert payload["schema_version"] == 1
     assert payload["status"] == "maintainer_measured"
-    assert payload["hardware"]["gpu"] == "NVIDIA GeForce RTX 4080"
+    assert payload["required"]["gpu_name"] == "NVIDIA GeForce RTX 4080"
     assert payload["scope"]["other_hardware"] == "unmeasured"
     assert payload["pytorch"]["index_url"].startswith("https://download.pytorch.org/whl/")
-    assert "+cu" in payload["packages"]["torch"]
+    assert "+cu" in payload["required"]["packages"]["torch"]
+    assert payload["observed"]["driver"] == "596.49"

--- a/tests/unit/test_opd_reference_workload.py
+++ b/tests/unit/test_opd_reference_workload.py
@@ -47,6 +47,23 @@ def test_resume_equivalence_excludes_only_the_run_specific_resolved_digest() -> 
     assert report["excluded_run_identity_field"] == "resolved_config_digest"
 
 
+def test_reference_workload_context_limits_remain_in_sync(tmp_path: Path) -> None:
+    script = _script()
+    overrides = script._overrides(tmp_path / "reference.parquet")
+    total = script.PROMPT_LIMIT + script.RESPONSE_LIMIT
+    assert f"actor_rollout_ref.rollout.max_model_len={total}" in overrides
+    assert f"distillation.teacher_models.teacher_model.inference.max_model_len={total}" in overrides
+
+    from miniverl.bridge.opd_v08 import load_verl_opd_v08_source
+
+    compiled = load_verl_opd_v08_source(
+        script.BUILTIN,
+        overrides=overrides,
+        accept_local_reinterpretations=True,
+    )
+    assert compiled.executable is True
+
+
 def test_measured_reference_workload_is_scoped_complete_and_frozen() -> None:
     path = Path("benchmarks/results/rtx4080-verl-opd-developer-v1.json")
     assert hashlib.sha256(path.read_bytes()).hexdigest() == (

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -68,6 +68,7 @@ TORCH_FREE_MODULES = (
     "miniverl.bridge.profiles",
     "miniverl.commands",
     "miniverl.commands.compat",
+    "miniverl.commands.qualification",
     "miniverl.cli",
     "miniverl.config",
     "miniverl.config.models",
@@ -111,6 +112,7 @@ TORCH_FREE_MODULES = (
     "miniverl.utils.seeding",
     "miniverl.evaluation.schema",
     "miniverl.models.tokenizers",
+    "miniverl.qualification",
 )
 
 

--- a/tests/unit/test_pypi_publish_state.py
+++ b/tests/unit/test_pypi_publish_state.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _manifest(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    expected = {
+        "miniverl-0.10.1-py3-none-any.whl": "a" * 64,
+        "miniverl-0.10.1.tar.gz": "b" * 64,
+    }
+    payload = {
+        "kind": "miniverl_release_candidate",
+        "miniverl_version": "0.10.1",
+        "wheel": {"filename": next(iter(expected)), "sha256": "a" * 64},
+        "sdist": {"filename": list(expected)[1], "sha256": "b" * 64},
+    }
+    path = tmp_path / "candidate-manifest.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path, expected
+
+
+def _response(files: dict[str, str]) -> dict[str, object]:
+    return {
+        "urls": [
+            {"filename": filename, "digests": {"sha256": digest}}
+            for filename, digest in files.items()
+        ]
+    }
+
+
+def test_absent_pypi_version_needs_publication(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from scripts import check_pypi_publish_state as state
+
+    manifest, _ = _manifest(tmp_path)
+    monkeypatch.setattr(state, "_request_version", lambda *args, **kwargs: None)
+    assert state.publish_needed(manifest, project="miniverl") is True
+
+
+def test_exact_existing_pypi_version_is_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from scripts import check_pypi_publish_state as state
+
+    manifest, expected = _manifest(tmp_path)
+    monkeypatch.setattr(state, "_request_version", lambda *args, **kwargs: _response(expected))
+    assert state.publish_needed(manifest, project="miniverl") is False
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda files: files.pop("miniverl-0.10.1.tar.gz"),
+        lambda files: files.update({"extra.zip": "c" * 64}),
+        lambda files: files.update({"miniverl-0.10.1.tar.gz": "c" * 64}),
+    ],
+)
+def test_existing_partial_extra_or_mismatched_version_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mutation
+) -> None:
+    from scripts import check_pypi_publish_state as state
+
+    manifest, expected = _manifest(tmp_path)
+    mutation(expected)
+    monkeypatch.setattr(state, "_request_version", lambda *args, **kwargs: _response(expected))
+    with pytest.raises(ValueError, match="does not match"):
+        state.publish_needed(manifest, project="miniverl")

--- a/tests/unit/test_release_candidate.py
+++ b/tests/unit/test_release_candidate.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _candidate(tmp_path: Path) -> tuple[Path, dict[str, object]]:
+    from miniverl.release_candidate import PINNED_BUILD_TOOLS, sha256_file
+
+    root = tmp_path / "candidate"
+    root.mkdir()
+    wheel = root / "miniverl-0.10.1.dev0-py3-none-any.whl"
+    sdist = root / "miniverl-0.10.1.dev0.tar.gz"
+    wheel.write_bytes(b"wheel-one")
+    sdist.write_bytes(b"sdist-one")
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "kind": "miniverl_release_candidate",
+        "source_commit": "a" * 40,
+        "miniverl_version": "0.10.1.dev0",
+        "created_at": "2026-08-15T12:00:00Z",
+        "artifact_name": "candidate-distributions",
+        "workflow": {
+            "kind": "github_actions",
+            "repository": "DaoyuanLi2816/mini-verl",
+            "workflow_path": ".github/workflows/gpu.yml",
+            "run_id": 42,
+            "run_attempt": 1,
+        },
+        "build": {"os": "Linux", "python": "3.12.0", "tools": PINNED_BUILD_TOOLS},
+        "wheel": {
+            "filename": wheel.name,
+            "bytes": wheel.stat().st_size,
+            "sha256": sha256_file(wheel),
+        },
+        "sdist": {
+            "filename": sdist.name,
+            "bytes": sdist.stat().st_size,
+            "sha256": sha256_file(sdist),
+        },
+    }
+    (root / "candidate-manifest.json").write_text(
+        json.dumps(payload, sort_keys=True), encoding="utf-8"
+    )
+    (root / "SHA256SUMS").write_text(
+        f"{payload['wheel']['sha256']}  {wheel.name}\n"  # type: ignore[index]
+        f"{payload['sdist']['sha256']}  {sdist.name}\n",  # type: ignore[index]
+        encoding="utf-8",
+    )
+    return root, payload
+
+
+def test_candidate_directory_is_exact_and_bound(tmp_path: Path) -> None:
+    from miniverl.release_candidate import validate_candidate_directory
+
+    root, _ = _candidate(tmp_path)
+    assert (
+        validate_candidate_directory(
+            root,
+            expected_commit="a" * 40,
+            expected_version="0.10.1.dev0",
+            expected_repository="DaoyuanLi2816/mini-verl",
+            expected_workflow_path=".github/workflows/gpu.yml",
+            expected_run_id=42,
+            expected_run_attempt=1,
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize("mutation", ["wheel", "extra", "sums", "private", "nan"])
+def test_candidate_rejects_tampering_extra_files_and_private_data(
+    tmp_path: Path, mutation: str
+) -> None:
+    from miniverl.release_candidate import validate_candidate_directory
+
+    root, payload = _candidate(tmp_path)
+    if mutation == "wheel":
+        (root / payload["wheel"]["filename"]).write_bytes(b"different")  # type: ignore[index]
+    elif mutation == "extra":
+        (root / "old.whl").write_bytes(b"old")
+    elif mutation == "sums":
+        (root / "SHA256SUMS").write_text("wrong\n", encoding="utf-8")
+    else:
+        if mutation == "private":
+            payload["build"]["os"] = "C:\\Users\\maintainer\\OneDrive"  # type: ignore[index]
+        else:
+            payload["build"]["python"] = float("nan")  # type: ignore[index]
+        (root / "candidate-manifest.json").write_text(
+            json.dumps(payload, allow_nan=True), encoding="utf-8"
+        )
+    assert validate_candidate_directory(root)
+
+
+def test_candidate_rejects_wrong_workflow_attempt(tmp_path: Path) -> None:
+    from miniverl.release_candidate import validate_candidate_directory
+
+    root, _ = _candidate(tmp_path)
+    problems = validate_candidate_directory(root, expected_run_attempt=2)
+    assert any("workflow run attempt" in problem for problem in problems)
+
+
+def test_candidate_rejects_wrong_source_version_and_path_escape(tmp_path: Path) -> None:
+    from miniverl.release_candidate import validate_candidate_directory
+
+    root, payload = _candidate(tmp_path)
+    problems = validate_candidate_directory(
+        root, expected_commit="b" * 40, expected_version="0.10.1"
+    )
+    assert any("source commit" in problem for problem in problems)
+    assert any("version" in problem for problem in problems)
+    payload["wheel"]["filename"] = "../escape.whl"  # type: ignore[index]
+    (root / "candidate-manifest.json").write_text(json.dumps(payload), encoding="utf-8")
+    assert validate_candidate_directory(root)
+
+
+def test_candidate_rejects_symlink_when_supported(tmp_path: Path) -> None:
+    from miniverl.release_candidate import validate_candidate_directory
+
+    root, payload = _candidate(tmp_path)
+    wheel = root / payload["wheel"]["filename"]  # type: ignore[index]
+    target = root / "outside"
+    target.write_bytes(wheel.read_bytes())
+    wheel.unlink()
+    try:
+        wheel.symlink_to(target)
+    except OSError:
+        pytest.skip("symlink creation needs privileges")
+    assert validate_candidate_directory(root)
+
+
+def test_candidate_builder_refuses_nonempty_output(tmp_path: Path) -> None:
+    from miniverl.release_candidate import build_release_candidate
+
+    output = tmp_path / "candidate"
+    output.mkdir()
+    (output / "old.whl").write_bytes(b"old")
+    with pytest.raises(ValueError, match="empty"):
+        build_release_candidate(output, source_commit="a" * 40, project_root=Path.cwd())

--- a/tests/unit/test_release_gate.py
+++ b/tests/unit/test_release_gate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -36,6 +37,22 @@ def test_release_gate_lists_the_product_checks_without_publishing(tmp_path: Path
     assert "gh release create" not in text
     assert "git tag" not in text
     assert "twine upload" not in text
+
+
+def test_release_gate_list_does_not_require_a_git_checkout(tmp_path: Path) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    shutil.copy2("scripts/release_gate.py", scripts / "release_gate.py")
+
+    completed = subprocess.run(
+        [sys.executable, "scripts/release_gate.py", "--list"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "gpu_qualification" in json.loads(completed.stdout)
 
 
 def test_release_gate_requires_qualification_when_running() -> None:

--- a/tests/unit/test_release_gate.py
+++ b/tests/unit/test_release_gate.py
@@ -28,9 +28,9 @@ def test_release_gate_lists_the_product_checks_without_publishing(tmp_path: Path
         "cpu_tests_coverage",
         "docs_build",
         "docs_visual",
-        "build",
+        "candidate_artifact",
         "twine",
-        "gpu_qualification",
+        "release_evidence_chain",
     ):
         assert required in names
     text = Path("scripts/release_gate.py").read_text(encoding="utf-8")
@@ -52,7 +52,7 @@ def test_release_gate_list_does_not_require_a_git_checkout(tmp_path: Path) -> No
     )
 
     assert completed.returncode == 0, completed.stderr
-    assert "gpu_qualification" in json.loads(completed.stdout)
+    assert "release_evidence_chain" in json.loads(completed.stdout)
 
 
 def test_release_gate_requires_qualification_when_running() -> None:
@@ -62,4 +62,5 @@ def test_release_gate_requires_qualification_when_running() -> None:
         text=True,
     )
     assert completed.returncode == 2
-    assert "--qualification is required unless --list is used" in completed.stderr
+    assert "--candidate-dir, --candidate-manifest and --qualification" in completed.stderr
+    assert "required unless --list is used" in completed.stderr

--- a/tests/unit/test_release_gate.py
+++ b/tests/unit/test_release_gate.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_release_gate_lists_the_product_checks_without_publishing(tmp_path: Path) -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/release_gate.py",
+            "--list",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    names = json.loads(completed.stdout)
+    for required in (
+        "release_state",
+        "known_good_environment",
+        "ruff_check",
+        "mypy",
+        "actionlint",
+        "cpu_tests_coverage",
+        "docs_build",
+        "docs_visual",
+        "build",
+        "twine",
+        "gpu_qualification",
+    ):
+        assert required in names
+    text = Path("scripts/release_gate.py").read_text(encoding="utf-8")
+    assert "gh release create" not in text
+    assert "git tag" not in text
+    assert "twine upload" not in text
+
+
+def test_release_gate_requires_qualification_when_running() -> None:
+    completed = subprocess.run(
+        [sys.executable, "scripts/release_gate.py", "--fail-fast"],
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 2
+    assert "--qualification is required unless --list is used" in completed.stderr

--- a/tests/unit/test_release_state.py
+++ b/tests/unit/test_release_state.py
@@ -35,6 +35,7 @@ TRACKED = (
     "PYPI.md",
     "docs/overrides/main.html",
     "CITATION.cff",
+    "SECURITY.md",
     "CHANGELOG.md",
     "docs/release-checklist.md",
     "PROJECT_STATE.md",
@@ -68,6 +69,14 @@ def test_quality_record_floor_names_its_own_release() -> None:
         (REPO_ROOT / "docs" / "generated" / "quality.json").read_text(encoding="utf-8")
     )
     assert f"v{record['release']}" in record["quality_floor"]
+
+
+def test_security_and_current_product_prose_follow_the_canonical_state() -> None:
+    state = load_release_state(REPO_ROOT)
+    security = (REPO_ROOT / "SECURITY.md").read_text(encoding="utf-8")
+    project = (REPO_ROOT / "PROJECT_STATE.md").read_text(encoding="utf-8")
+    assert f"supported stable line is `{state.stable_version}`" in security
+    assert f"Development `{state.development_version}` has a closed typed profile" in project
 
 
 # --------------------------------------------------------------- validation
@@ -172,7 +181,8 @@ def test_transition_still_demands_the_human_written_sections(tmp_path: Path) -> 
     state_file = root / "PROJECT_STATE.md"
     state_file.write_text(
         "# PROJECT_STATE\n\nCanonical release state: stable `v0.6.4` "
-        f"(`{'b' * 40}`), development `0.6.5.dev0`.\n",
+        f"(`{'b' * 40}`), development `0.6.5.dev0`.\n\n"
+        "Development `0.6.5.dev0` has a closed typed profile registry.\n",
         encoding="utf-8",
     )
     record = root / "docs" / "generated" / "quality.json"

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "release.yml"
+GPU_WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "gpu.yml"
 
 
 def _workflow_text() -> str:
@@ -83,3 +84,14 @@ def test_release_requires_exact_sha_rtx4080_qualification_before_build() -> None
     assert '--required-gpu-name "NVIDIA GeForce RTX 4080"' in qualification
     assert "needs: verify-gpu-qualification" in validation
     assert "needs: validate-and-test" in build
+
+
+def test_full_gpu_qualification_installs_only_the_exact_pinned_verl_source() -> None:
+    text = GPU_WORKFLOW.read_text(encoding="utf-8")
+    requirement = (
+        "git+https://github.com/verl-project/verl.git@7aed6b230776f963fa09509c10d9c3a767d1102c"
+    )
+    assert "qualification_level == 'full'" in text
+    assert "pip install --no-deps" in text
+    assert requirement in text
+    assert "scripts/promote_full_gpu_qualification.py" in text

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -69,3 +69,17 @@ def test_every_action_is_pinned_to_a_full_commit_sha() -> None:
     assert uses
     for action in uses:
         assert re.fullmatch(r"[^@]+@[0-9a-f]{40}", action), action
+
+
+def test_release_requires_exact_sha_rtx4080_qualification_before_build() -> None:
+    text = _workflow_text()
+    qualification = _job(text, "verify-gpu-qualification", "validate-and-test")
+    validation = _job(text, "validate-and-test", "build-distributions")
+    build = _job(text, "build-distributions", "publish-pypi")
+
+    assert "permissions:" in qualification and "actions: read" in qualification
+    assert "scripts/verify_release_qualification.py" in qualification
+    assert '--commit "$GITHUB_SHA"' in qualification
+    assert '--required-gpu-name "NVIDIA GeForce RTX 4080"' in qualification
+    assert "needs: verify-gpu-qualification" in validation
+    assert "needs: validate-and-test" in build

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -9,6 +9,9 @@ import pytest
 
 WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "release.yml"
 GPU_WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "gpu.yml"
+EXISTING_RELEASE_WORKFLOW = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "verify-existing-release.yml"
+)
 
 
 def _workflow_text() -> str:
@@ -55,10 +58,14 @@ def test_release_consumes_qualified_candidate_without_rebuild() -> None:
     assert "copy the identical candidate bytes" in prepare
     assert "candidate-manifest.json" in prepare
     assert "qualification.json" in prepare
+    assert "qualification-full-SHA256SUMS" in prepare
     assert "actions/upload-artifact@" in prepare
     assert "actions/download-artifact@" in publish
     assert "python -m build" not in publish
-    assert "actions/checkout@" not in publish
+    assert "actions/checkout@" in publish
+    assert "scripts/check_pypi_publish_state.py" in publish
+    assert "skip-existing" not in publish
+    assert "steps.pypi-state.outputs.publish_needed == 'true'" in publish
     assert "actions/download-artifact@" in verify
     assert "actions/download-artifact@" in release
     assert text.count("name: release-distributions") == 4
@@ -66,7 +73,11 @@ def test_release_consumes_qualified_candidate_without_rebuild() -> None:
 
 
 def test_every_action_is_pinned_to_a_full_commit_sha() -> None:
-    text = _workflow_text() + GPU_WORKFLOW.read_text(encoding="utf-8")
+    text = (
+        _workflow_text()
+        + GPU_WORKFLOW.read_text(encoding="utf-8")
+        + EXISTING_RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    )
     uses = re.findall(r"^\s*-\s+uses:\s+([^\s#]+)", text, flags=re.MULTILINE)
     assert uses
     for action in uses:
@@ -83,7 +94,8 @@ def test_release_requires_same_run_exact_sha_candidate_and_qualification() -> No
     assert "scripts/verify_release_qualification.py" in qualification
     assert '--commit "$GITHUB_SHA"' in qualification
     assert "--candidate-artifact-name candidate-distributions" in qualification
-    assert "--qualification-artifact-name gpu-release-smoke" in qualification
+    assert "--qualification-artifact-name gpu-full-qualification" in qualification
+    assert "--required-level full_qualification" in qualification
     assert '--required-gpu-name "NVIDIA GeForce RTX 4080"' in qualification
     assert "needs: verify-qualified-candidate" in validation
     assert "needs: [verify-qualified-candidate, validate-and-test]" in prepare
@@ -103,6 +115,17 @@ def test_gpu_workflow_builds_candidate_only_on_hosted_job() -> None:
     assert 'PYTHONPATH: ""' in qualify and 'PYTHONHOME: ""' in qualify
 
 
+def test_gpu_workflow_refuses_rerun_attempts_and_separates_smoke_from_full() -> None:
+    text = GPU_WORKFLOW.read_text(encoding="utf-8")
+    assert text.count("GITHUB_RUN_ATTEMPT") >= 2
+    assert text.count("start a new workflow_dispatch run") == 2
+    smoke_upload = text.index("name: gpu-release-smoke")
+    promotion = text.index("scripts/promote_full_gpu_qualification.py")
+    full_upload = text.index("name: gpu-full-qualification")
+    assert smoke_upload < promotion < full_upload
+    assert "always() && inputs.qualification_level == 'full'" not in text
+
+
 def test_full_gpu_qualification_installs_only_the_exact_pinned_verl_source() -> None:
     text = GPU_WORKFLOW.read_text(encoding="utf-8")
     requirement = (
@@ -112,3 +135,10 @@ def test_full_gpu_qualification_installs_only_the_exact_pinned_verl_source() -> 
     assert "pip install --no-deps" in text
     assert requirement in text
     assert "scripts/promote_full_gpu_qualification.py" in text
+
+
+def test_release_recovery_preserves_full_qualification_evidence() -> None:
+    text = EXISTING_RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    assert "release-artifacts/dist" in text
+    assert text.count("qualification-full-SHA256SUMS") >= 3
+    assert "release-artifacts/qualification-evidence/*" in text

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -44,18 +44,18 @@ def test_publish_eligibility_is_tag_push_only(
         assert text.count(condition) == 3
 
 
-def test_distributions_are_built_once_and_consumed_without_rebuild() -> None:
+def test_release_consumes_qualified_candidate_without_rebuild() -> None:
     text = _workflow_text()
-    assert text.count("python -m build") == 1
-    build = _job(text, "build-distributions", "publish-pypi")
+    assert "python -m build" not in text
+    prepare = _job(text, "prepare-verified-distributions", "publish-pypi")
     publish = _job(text, "publish-pypi", "verify-pypi")
     verify = _job(text, "verify-pypi", "create-github-release")
     release = _job(text, "create-github-release", None)
 
-    assert "python -m build" in build
-    assert "twine check" in build
-    assert "SHA256SUMS" in build
-    assert "actions/upload-artifact@" in build
+    assert "copy the identical candidate bytes" in prepare
+    assert "candidate-manifest.json" in prepare
+    assert "qualification.json" in prepare
+    assert "actions/upload-artifact@" in prepare
     assert "actions/download-artifact@" in publish
     assert "python -m build" not in publish
     assert "actions/checkout@" not in publish
@@ -66,24 +66,41 @@ def test_distributions_are_built_once_and_consumed_without_rebuild() -> None:
 
 
 def test_every_action_is_pinned_to_a_full_commit_sha() -> None:
-    uses = re.findall(r"^\s*-\s+uses:\s+([^\s#]+)", _workflow_text(), flags=re.MULTILINE)
+    text = _workflow_text() + GPU_WORKFLOW.read_text(encoding="utf-8")
+    uses = re.findall(r"^\s*-\s+uses:\s+([^\s#]+)", text, flags=re.MULTILINE)
     assert uses
     for action in uses:
         assert re.fullmatch(r"[^@]+@[0-9a-f]{40}", action), action
 
 
-def test_release_requires_exact_sha_rtx4080_qualification_before_build() -> None:
+def test_release_requires_same_run_exact_sha_candidate_and_qualification() -> None:
     text = _workflow_text()
-    qualification = _job(text, "verify-gpu-qualification", "validate-and-test")
-    validation = _job(text, "validate-and-test", "build-distributions")
-    build = _job(text, "build-distributions", "publish-pypi")
+    qualification = _job(text, "verify-qualified-candidate", "validate-and-test")
+    validation = _job(text, "validate-and-test", "prepare-verified-distributions")
+    prepare = _job(text, "prepare-verified-distributions", "publish-pypi")
 
     assert "permissions:" in qualification and "actions: read" in qualification
     assert "scripts/verify_release_qualification.py" in qualification
     assert '--commit "$GITHUB_SHA"' in qualification
+    assert "--candidate-artifact-name candidate-distributions" in qualification
+    assert "--qualification-artifact-name gpu-release-smoke" in qualification
     assert '--required-gpu-name "NVIDIA GeForce RTX 4080"' in qualification
-    assert "needs: verify-gpu-qualification" in validation
-    assert "needs: validate-and-test" in build
+    assert "needs: verify-qualified-candidate" in validation
+    assert "needs: [verify-qualified-candidate, validate-and-test]" in prepare
+
+
+def test_gpu_workflow_builds_candidate_only_on_hosted_job() -> None:
+    text = GPU_WORKFLOW.read_text(encoding="utf-8")
+    build = _job(text, "build-candidate", "qualify")
+    qualify = _job(text, "qualify", None)
+    assert "runs-on: ubuntu-latest" in build
+    assert "scripts/build_release_candidate.py" in build
+    assert "name: candidate-distributions" in build
+    assert "needs: build-candidate" in qualify
+    assert "actions/download-artifact@" in qualify
+    assert "python -m build" not in qualify
+    assert "--candidate-manifest candidate/candidate-manifest.json" in qualify
+    assert 'PYTHONPATH: ""' in qualify and 'PYTHONHOME: ""' in qualify
 
 
 def test_full_gpu_qualification_installs_only_the_exact_pinned_verl_source() -> None:

--- a/tests/unit/test_upstream_support_policy.py
+++ b/tests/unit/test_upstream_support_policy.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_support_matrix_matches_the_closed_profile_registry() -> None:
+    from miniverl.bridge.profiles import get_profile, list_profiles
+
+    matrix = json.loads(
+        Path("docs/generated/upstream-support-matrix.json").read_text(encoding="utf-8")
+    )
+    assert matrix["schema_version"] == 1
+    assert matrix["policy"] == "closed_immutable_profiles"
+    assert matrix["unprofiled_versions"] == "unsupported"
+    assert [row["name"] for row in matrix["profiles"]] == [
+        profile.name for profile in list_profiles()
+    ]
+    for row in matrix["profiles"]:
+        identity = get_profile(row["name"]).identity
+        assert row["status"] == "active"
+        assert row["upstream_tag"] == identity.upstream_tag
+        assert row["upstream_commit"] == identity.upstream_commit
+        assert row["distributed_execution_tested"] is False


### PR DESCRIPTION
## Summary

- build one strict hosted-runner wheel/sdist candidate, then install and qualify those exact bytes on the private RTX 4080 runner
- bind source SHA, workflow run and attempt, candidate manifest, wheel, environment, models and every declared evidence file into the qualification
- reject cross-origin credential forwarding, evidence size drift, cross-attempt pairs and GitHub workflow reruns
- require same-run `candidate-distributions` plus `gpu-full-qualification` for formal release; retain the complete full evidence set and checksums in workflow and GitHub Release assets
- make PyPI publication idempotent only when the already-public wheel and sdist set exactly matches the candidate; partial, extra or mismatched releases fail closed

## Root cause and contract

The prior path could forward API credentials across artifact redirects, validated artifact hashes without their declared byte counts, allowed rerun attempts to mix lifecycle boundaries, and accepted diagnostic smoke evidence for formal publication. The release chain is now:

`fresh dispatch attempt 1 → hosted candidate bytes → same-run RTX 4080 full qualification → dry-run consumes identical artifacts → tag release publishes identical bytes and full evidence`

No job rebuilds the accepted distributions. `gpu-release-smoke` remains useful diagnostics but cannot authorize publication.

## Validation

- exact PR head: `9809209479b44d4c413b71d4ad80fb192d86fa2e`
- focused release/security tests: 45 passed, including 301/302/303/307/308 header behavior and a two-origin local HTTP redirect
- full non-GPU/non-network suite: 2362 passed, 8 skipped, 22 deselected; 84% branch coverage
- extracted-sdist suite: 2359 passed, 11 skipped, 22 deselected
- local RTX 4080 GPU markers: 8 passed; network markers: 16 passed
- Ruff check/format, mypy, actionlint, strict MkDocs, Markdown links and `git diff --check` passed
- clean core wheel install kept Torch absent; clean `[train]` install completed the real demo
- development wheel SHA-256: `8e4b8d6eca11b04326e1d107ce4120a3049ea4c065aab77838c6efb55efa5201`
- development sdist SHA-256: `0e7dc2936b2677e5e4fd856c0682a11419b779cf553be581c585cfb5bcea855e`
- frozen calculator benchmark remains `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`; no frozen result JSON/JSONL changed

## External boundary

The remote exact-SHA full qualification is intentionally deferred until the final release commit: no self-hosted runner is currently registered. Release and dry-run workflows fail closed until a fresh ephemeral runner produces the required same-run full evidence. This is one measured RTX 4080 stack, not continuous GPU CI; other hardware and distributed verl execution remain unmeasured. No scientific result or capability claim changed, and this PR does not tag or publish a release.