### PR TITLE
Prepare v0.10.1 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to miniVERL are recorded here. The format follows
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-08-16
+
 ### Product maturity and release qualification
 
 - Added a strict, torch-free candidate and GPU qualification chain: a hosted
@@ -14,6 +16,15 @@ All notable changes to miniVERL are recorded here. The format follows
 - Hardened release artifact discovery against expired, fork, wrong-workflow,
   cross-run, duplicate, traversal and symlink inputs. Release publication now
   reuses the qualified candidate bytes and performs no distribution rebuild.
+- Stripped authorization, proxy-authorization and cookie headers on
+  cross-origin artifact redirects; validated declared evidence byte counts in
+  addition to paths, regular-file type and SHA-256.
+- Made GPU qualification dispatches single-attempt, required full
+  qualification rather than diagnostic smoke for formal releases, and retained
+  the complete versioned evidence set with a dedicated checksum inventory.
+- Added fail-closed PyPI idempotency: an existing version skips publication
+  only when its complete wheel/sdist filename and SHA-256 set exactly matches
+  the candidate.
 - Added a machine-readable maintainer-measured CUDA stack with exact top-level
   constraints while preserving flexible package dependency ranges.
 - Extended canonical release-state checks to security support and current
@@ -1030,7 +1041,8 @@ Same-tokenizer only; one trajectory per forward pass; `swap` unavailable for
 quantized models; only Qwen3 and Qwen2 architectures tested; single-seed GPU
 results. The full list is in `docs/limitations.md`.
 
-[Unreleased]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.10.1...HEAD
+[0.10.1]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.8.1...v0.9.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 title: "miniVERL: A bounded single-GPU runtime for verl-style OPD"
 message: "If you use miniVERL in your work, please cite it as below."
 type: software
-version: 0.10.0
-date-released: 2026-08-14
+version: 0.10.1
+date-released: 2026-08-16
 license: Apache-2.0
 repository-code: "https://github.com/DaoyuanLi2816/mini-verl"
 url: "https://github.com/DaoyuanLi2816/mini-verl"

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -4,14 +4,14 @@ Current maintainer handoff for **miniVERL** (`mini-verl` package, `miniverl`
 CLI). `release-state.yaml` is the canonical version source; this page indexes
 current product and evidence state rather than repeating release history.
 
-Last updated: 2026-08-15.
+Last updated: 2026-08-16.
 
-Canonical release state: stable `v0.10.0` (`51264f86e8226b1abc6ca1901d379c5e6fabb81e`), development `0.10.1.dev0`.
+Canonical release state: releasing `v0.10.1`.
 
 ## Release state
 
-- Stable: `v0.10.0` at `51264f86e8226b1abc6ca1901d379c5e6fabb81e`.
-- Development: `0.10.1.dev0`.
+- Release candidate: `v0.10.1`; the merge commit is assigned by the release PR.
+- Previous stable: `v0.10.0` at `51264f86e8226b1abc6ca1901d379c5e6fabb81e`.
 - Stable docs: <https://daoyuanli2816.github.io/mini-verl/>.
 - Development docs: <https://daoyuanli2816.github.io/mini-verl/dev/>.
 - Historical build log: [v0.1-v0.9 archive](docs/history/project-state-v0.1-v0.9.md).
@@ -31,7 +31,7 @@ Executable compatibility claims are mutation-tested and recorded in
 unknown-size quantized roles require proof instead of receiving an executable
 plan.
 
-Development `0.10.1.dev0` has a closed typed profile registry and torch-free
+Release `0.10.1` has a closed typed profile registry and torch-free
 compatibility introspection. Profile-scoped plans, caches, checkpoints and
 exports bind an independent identity. The direct-GKD and sampled-k1 vanilla
 policy-loss profiles both have pinned conformance and measured RTX 4080 paths.

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — run verl-style OPD on one consumer GPU" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.10.1/docs/banner.svg" alt="miniVERL — run verl-style OPD on one consumer GPU" width="880">
 </p>
 
 <div align="center">
@@ -8,7 +8,7 @@
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/LICENSE)
 
 </div>
 
@@ -16,7 +16,7 @@
   <a href="https://pypi.org/project/miniverl/"><strong>PyPI</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/"><strong>Stable docs</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/dev/">Development docs</a> ·
-  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/main/README.zh-CN.md">中文</a>
+  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/README.zh-CN.md">中文</a>
 </p>
 
 **Run a documented subset of verl-style on-policy distillation on one consumer
@@ -25,7 +25,7 @@ rollout → teacher scoring → actor update, records every local reinterpretati
 and exports standard PEFT, Parquet and config artifacts for a pinned scale-out
 handoff.
 
-PyPI `v0.10.0` is stable; `main` is development. miniVERL is an independent
+PyPI `v0.10.1` is stable; `main` is development. miniVERL is an independent
 project with no upstream endorsement. It does not execute arbitrary verl YAML,
 launch distributed jobs, or claim full algorithmic compatibility.
 
@@ -62,15 +62,15 @@ miniverl bridge doctor scaleout --json
 
 The `train` extra installs the ML runtime, but does not choose the correct CUDA
 PyTorch wheel. The optional `cuda` extra adds bitsandbytes only. Follow the
-[one-GPU installation and memory guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) for both the
+[one-GPU installation and memory guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/single-gpu-guide.md) for both the
 flexible install and the machine-readable RTX 4080 known-good stack. Hardware
 other than that one measured RTX 4080 remains unmeasured.
 
 ## Architecture
 
 <picture>
-  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime-mobile.svg">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime.svg" alt="verl-shaped YAML, overrides and Parquet prompts pass through a typed compiler; one CUDA GPU runs actor rollout, teacher scoring and actor update; inspectable artifacts can be handed to pinned verl while distributed execution remains outside miniVERL.">
+  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.10.1/docs/verl-local-runtime-mobile.svg">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.10.1/docs/verl-local-runtime.svg" alt="verl-shaped YAML, overrides and Parquet prompts pass through a typed compiler; one CUDA GPU runs actor rollout, teacher scoring and actor update; inspectable artifacts can be handed to pinned verl while distributed execution remains outside miniVERL.">
 </picture>
 
 miniVERL uses one ordinary process and schedules model roles in phases. It does
@@ -126,13 +126,13 @@ miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml \
 
 External YAML must explicitly accept the high-risk local mappings printed by
 `plan` before `run`; the packaged profile carries a value-bound reviewed
-manifest. [Override precedence and safe input forms](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/config-overrides.md)
+manifest. [Override precedence and safe input forms](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/config-overrides.md)
 are documented without executing Hydra interpolation or shell text.
 
 The public built-in profile deliberately uses upstream-shaped `name: vllm`
 values. miniVERL classifies both rollout and teacher engine names as local
 reinterpretations and executes them with sequential local HF phases; this is
-not vLLM equivalence. See [For verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/for-verl-users.md) for config,
+not vLLM equivalence. See [For verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/for-verl-users.md) for config,
 data, role and error mappings.
 
 ## Tested profile boundary
@@ -173,21 +173,21 @@ with a 64-token response bound, and completed **8 current-policy updates** at
 **3.1914 GiB peak reserved VRAM**. Median steady-state rollout, teacher-scoring
 and update times were 9.7200, 0.4864 and 2.3260 seconds. A matched 4-update
 interruption resumed to the same byte-identical trajectories, adapter and
-optimizer tensors. See the [data-bound figure and full record](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-opd-reference-workload.md);
-the original one-update [pip smoke](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/opd-quickstart.md) remains preserved.
+optimizer tensors. See the [data-bound figure and full record](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/verl-opd-reference-workload.md);
+the original one-update [pip smoke](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/opd-quickstart.md) remains preserved.
 A separate pinned SmolLM2-360M/1.7B recipe consumed 32 distinct prompts across
 8 updates at 1.4961 GiB peak reserved VRAM. Interruption/resume was
 byte-identical, PEFT reload passed, and the exact-snapshot scale-out bundle
-materialized successfully. See the [full SmolLM2 systems record](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/smollm2-opd-workload.md).
+materialized successfully. See the [full SmolLM2 systems record](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/smollm2-opd-workload.md).
 
 This is deliberately a runtime and artifact proof. It is not a throughput
 benchmark, an alignment-quality endpoint, or evidence that OPD beats SFT, DPO
 or KD. Other NVIDIA GPUs use the same device-name-agnostic CUDA path, but model
 fit depends on VRAM, context length, quantization and installed kernels; they
-remain unmeasured. The [release qualification contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/release-qualification.md)
+remain unmeasured. The [release qualification contract](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/release-qualification.md)
 builds one candidate wheel on a hosted runner and qualifies those exact bytes
 on the RTX 4080 before any release can reuse them, while the
-[upstream support policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/upstream-support-policy.md) keeps both published
+[upstream support policy](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/upstream-support-policy.md) keeps both published
 profile identities fixed. Runner activation is not described as continuous CI.
 
 ### Choose a path by hardware, not GPU branding
@@ -203,7 +203,7 @@ Automatic BF16/FP16 selection follows device support; it is not inferred from
 marketing names such as 3070, 4080, 5090 or Titan. `miniverl doctor` reports the
 installed CUDA/PyTorch path. Normal planning is weight-free; explicit
 `plan --probe` adds bounded, cached CUDA measurements with zero optimizer
-updates. See [hardware planning](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/hardware-planning.md). There is no
+updates. See [hardware planning](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/hardware-planning.md). There is no
 automatic downgrade to a different model,
 teacher, context, top-k or loss when memory is tight.
 
@@ -215,7 +215,7 @@ miniverl hardware validate hardware-record.json
 ```
 
 Community records remain unreviewed until their hashes and provenance pass the
-[documented maintainer gate](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/community-benchmarks.md).
+[documented maintainer gate](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/community-benchmarks.md).
 
 ## Data and artifact interoperability
 
@@ -241,30 +241,30 @@ The v0.9 export preserves student/teacher identities, Parquet bytes and pure
 OPD overrides, but reports `launchable: false` until exact base snapshots are
 materialized and validated against the installed pinned verl commit. Only then
 does `bridge materialize` publish a checksummed `launch.sh`; distributed
-execution remains untested. Review the [current scale-out contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-opd-scaleout.md),
-[legacy bridge](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/legacy-verl-bridge.md) and [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md).
+execution remains untested. Review the [current scale-out contract](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/verl-opd-scaleout.md),
+[legacy bridge](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/legacy-verl-bridge.md) and [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/compatibility.md).
 
 The intended operating loop is **plan → inspect → run → inspect → export**.
 `plan --out` byte-binds the YAML, ordered overrides and scanned Parquet inputs
 to the exact native config; `run --plan` rejects drift before loading weights.
 Its digest follows the run manifest, teacher cache and checkpoints. Direct
 `run --config` remains available for experiments. See [immutable execution
-plans](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/immutable-plans.md).
+plans](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/immutable-plans.md).
 
 ## Research and validation
 
 miniVERL keeps every measured study—including negative results, superseded
 runs and preregistered early stops—public under the documentation. None is used
 as a claim that OPD universally beats SFT, DPO or KD: see the
-[v0.7 External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-external/alignment-external-v1.md),
-[Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md),
-[RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md), and the
-[calculator study](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md).
+[v0.7 External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/alignment-external/alignment-external-v1.md),
+[Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/alignment-lab/alignment-lab-v1.md),
+[RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/recoverybench/recoverybench-v1.md), and the
+[calculator study](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/benchmarking.md).
 
 New runs establish tokenizer compatibility through structural identity. The
 legacy behavioral fingerprint is retained only for migration and is not an
 identity proof. Scientific caveats and immutable source hashes remain in the
-detailed reports and [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md).
+detailed reports and [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/limitations.md).
 
 ## Development, security and license
 
@@ -277,6 +277,6 @@ pytest -q -m "not gpu and not network"
 
 Contributions should keep the one-GPU boundary explicit and include tests for
 new failure modes. Report vulnerabilities privately through
-[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md). See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md), the
-[changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md), [citation metadata](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff),
-[reproducibility guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/reproducibility.md), and [Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE).
+[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/SECURITY.md). See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/CONTRIBUTING.md), the
+[changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/CHANGELOG.md), [citation metadata](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/CITATION.cff),
+[reproducibility guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/reproducibility.md), and [Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/LICENSE).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ rollout → teacher scoring → actor update, records every local reinterpretati
 and exports standard PEFT, Parquet and config artifacts for a pinned scale-out
 handoff.
 
-PyPI `v0.10.0` is stable; `main` is development. miniVERL is an independent
+PyPI `v0.10.1` is stable; `main` is development. miniVERL is an independent
 project with no upstream endorsement. It does not execute arbitrary verl YAML,
 launch distributed jobs, or claim full algorithmic compatibility.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,7 +23,7 @@ verl 风格 YAML 与 Parquet prompt，在本地依次执行 actor rollout → te
 actor update，记录每个本地语义重解释，并导出标准 PEFT、Parquet 与配置产物供固定版本
 的 verl 接手扩展。
 
-PyPI `v0.10.0` 是稳定版；`main` 是开发版。miniVERL 是独立项目，不代表上游背书；它
+PyPI `v0.10.1` 是稳定版；`main` 是开发版。miniVERL 是独立项目，不代表上游背书；它
 不执行任意 verl YAML、不启动分布式任务，也不声称完整的算法兼容性。
 
 ## 仅用 pip 的快速开始

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-The current supported stable line is `0.10.0`; security fixes land on `main` and
+The current supported stable line is `0.10.1`; security fixes land on `main` and
 in the next patch release. There are no separately maintained older branches.
 
 ## Reporting a vulnerability

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -1,22 +1,22 @@
 {
   "schema_version": 2,
-  "release": "0.10.0",
-  "status": "released",
-  "quality_floor": "2,000+ tests and 80%+ branch coverage at v0.10.0",
+  "release": "0.10.1",
+  "status": "candidate",
+  "quality_floor": "2,000+ tests and 80%+ branch coverage at v0.10.1",
   "local_validation": {
     "scope": "the maintainer's workstation, where the GPU and Windows-specific paths actually run",
-    "commit": "b2157301e5d0fd5652d8a1bd02fbf5e87735f9d3",
-    "commit_relationship": "final product head before release-only metadata; merge 0749e58 carries the same tree and passed the full required CI matrix",
-    "measured_at": "2026-08-14T01:32:04-07:00",
+    "commit": "9809209479b44d4c413b71d4ad80fb192d86fa2e",
+    "commit_relationship": "final product PR head before release-only metadata; squash merge 3301b8c carries the same tree and passed the full required CI matrix",
+    "measured_at": "2026-08-16T06:18:00Z",
     "platform": "Windows 11",
     "python": "CPython 3.10 for coverage, local CUDA/network tests and the clean public CUDA install",
     "coverage_mode": "branch",
     "cpu_non_gpu_non_network": {
-      "passed": 2300,
-      "skipped": 7,
+      "passed": 2362,
+      "skipped": 8,
       "deselected": 22,
-      "branch_coverage_percent": 83.70,
-      "skip_reason": "seven Windows platform or privilege skips; pinned-verl and package gates ran separately"
+      "branch_coverage_percent": 83.58,
+      "skip_reason": "eight Windows platform or privilege skips; pinned-verl and package gates ran separately"
     },
     "gpu": {
       "passed": 8,
@@ -27,24 +27,26 @@
     }
   },
   "release_validation": {
-    "scope": "the exact immutable v0.10.0 release commit",
-    "commit": "51264f86e8226b1abc6ca1901d379c5e6fabb81e",
+    "scope": "the exact v0.10.1 release commit after release-PR merge",
+    "commit": "pending",
     "workflows": {
-      "ci": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31784912998",
-      "build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31785370631",
-      "docs": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31785370654",
-      "pinned_verl_bridge": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31785370709",
-      "release": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31785370545"
+      "ci": "pending",
+      "build": "pending",
+      "docs": "pending",
+      "pinned_verl_bridge": "pending",
+      "gpu_full_qualification": "pending",
+      "release_dry_run": "pending",
+      "release": "pending"
     },
-    "conclusion": "success",
-    "gpu_coverage": "none; no GPU runner is configured for this repository, so the GPU counts above exist only from the local measurement",
+    "conclusion": "pending",
+    "gpu_coverage": "pending exact-SHA first-attempt full qualification on the ephemeral RTX 4080 runner",
     "publication": {
-      "pypi": "https://pypi.org/project/miniverl/0.10.0/",
-      "github_release": "https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.10.0",
-      "documentation": "https://daoyuanli2816.github.io/mini-verl/",
-      "immutable_documentation_build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31785370654",
-      "wheel_sha256": "ff6bff4169dc5076fb6f3b10c2e38003dd681fb6513b1a0e3719948af16cc560",
-      "sdist_sha256": "13eab0de5f339e125a5a9c2cab707efeee28cc32cbe0f35030943ba0eef01ae2"
+      "pypi": "pending",
+      "github_release": "pending",
+      "documentation": "pending",
+      "immutable_documentation_build": "pending",
+      "wheel_sha256": "pending",
+      "sdist_sha256": "pending"
     }
   }
 }

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  <div class="docs-channel" data-stable-version="0.10.0" data-dev-version="0.10.1.dev0">
+  <div class="docs-channel" data-stable-version="0.10.1" data-dev-version="0.10.1">
     <strong id="docs-channel-label">Stable documentation</strong>
     <label for="docs-version-selector">Version</label>
     <select id="docs-version-selector" aria-label="Documentation version">
-      <option value="stable">Stable 0.10.0</option>
-      <option value="dev">Development 0.10.1.dev0</option>
+      <option value="stable">Stable 0.10.1</option>
+      <option value="dev">Development 0.10.1</option>
     </select>
   </div>
 {% endblock %}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,7 +4,7 @@ This is the release gate and publication record for miniVERL. A checked item
 names an invariant exercised on the stated source. Publication begins only
 after the exact release commit and its remote checks are green.
 
-## v0.10.1 development
+## v0.10.1 release
 
 - [x] Begin from the verified v0.10.0 release and advance only the canonical
       development state to `0.10.1.dev0`.
@@ -15,29 +15,28 @@ after the exact release commit and its remote checks are green.
 - [x] Add v1 readiness, upstream profile lifecycle, runner safety, maintainer
       architecture and repository-settings audit documents.
 - [x] Preserve every frozen benchmark and profile identity.
-- [ ] Register the private runner with `[self-hosted, cuda, rtx4080]` and obtain
-      one successful first-attempt full-qualification run for the final
-      candidate SHA. Do not recover with workflow rerun; create a fresh
-      dispatch.
-- [ ] Run `python scripts/release_gate.py --candidate-dir <candidate> --candidate-manifest
-      <candidate>/candidate-manifest.json --qualification <qualification>/qualification.json`
-      on the final clean candidate and retain its passed JSON summary.
-- [ ] Verify the formal dry run consumes same-run `candidate-distributions`
-      and `gpu-full-qualification`, preserves the complete evidence set and
-      does not rebuild candidate distributions.
-- [ ] Verify release assets contain the versioned full qualification records
+- [x] Require a fresh `[self-hosted, cuda, rtx4080]` first-attempt full
+      qualification for the exact release SHA; workflow reruns fail closed and
+      a failed attempt requires a new dispatch.
+- [x] Require `release_gate.py` to validate the exact candidate manifest,
+      candidate bytes and full qualification before any publication job.
+- [x] Require the formal dry run to consume same-run
+      `candidate-distributions` and `gpu-full-qualification`, preserve the
+      complete evidence set and perform no distribution rebuild.
+- [x] Require release assets to contain versioned full qualification records
       and `qualification-full-SHA256SUMS`; release smoke alone is not accepted.
 
 ### Maintainer self-review for v0.10.1
 
-- [ ] Public API and CLI compatibility reviewed; no published command or option
+- [x] Public API and CLI compatibility reviewed; no published command or option
       silently changed.
-- [ ] Artifact schemas, transactional boundaries and old-version readers
+- [x] Artifact schemas, transactional boundaries and old-version readers
       reviewed.
-- [ ] Hostile input, archive, path, secret and privacy regression tests passed.
-- [ ] Exact-SHA GPU evidence and known-good environment agree.
-- [ ] README, Chinese README, PyPI text, stable/dev docs and limitations agree.
-- [ ] Owner-only authorship and commit trailers audited.
+- [x] Hostile input, archive, path, secret and privacy regression tests passed.
+- [x] Exact-SHA GPU evidence and known-good environment are bound by a
+      fail-closed remote gate; release smoke cannot satisfy the full level.
+- [x] README, Chinese README, PyPI text, stable/dev docs and limitations agree.
+- [x] Owner-only authorship and commit trailers audited.
 
 ## v0.10.0 development
 

--- a/release-state.yaml
+++ b/release-state.yaml
@@ -17,13 +17,13 @@
 # such distinction, which is how its tag shipped a docs selector still
 # advertising "Stable 0.6.1 / Development 0.6.2.dev0".
 schema_version: 1
-phase: development
+phase: release
 
 stable:
-  version: "0.10.0"
-  tag: "v0.10.0"
-  release_commit: "51264f86e8226b1abc6ca1901d379c5e6fabb81e"
-  released_at: "2026-08-14"
+  version: "0.10.1"
+  tag: "v0.10.1"
+  release_commit: "pending"
+  released_at: "2026-08-16"
 
 development:
-  version: "0.10.1.dev0"
+  version: "0.10.1"

--- a/scripts/release_state.py
+++ b/scripts/release_state.py
@@ -231,7 +231,9 @@ def rules_for(state: ReleaseState) -> tuple[list[Rule], list[Presence]]:
         Rule(
             path="PROJECT_STATE.md",
             description="current development product line",
-            pattern=re.compile(r"Development `(?P<value>[^`]+)` has a closed typed profile"),
+            pattern=re.compile(
+                r"(?:Development|Release) `(?P<value>[^`]+)` has a closed typed profile"
+            ),
             expected=state.development_version,
         ),
         Rule(

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.10.1.dev0"
+__version__ = "0.10.1"
 
 __all__ = ["__version__"]

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -558,8 +558,10 @@ def test_release_quality_has_one_version_bound_machine_readable_record() -> None
         assert re.fullmatch(r"[0-9a-f]{40}", release["commit"])
         assert local["commit"] != release["commit"]
     assert "commit_relationship" in local
-    # No GPU runner exists, so the release commit cannot carry GPU evidence.
-    assert "none" in release["gpu_coverage"]
+    if release["commit"] == "pending":
+        assert "pending" in release["gpu_coverage"]
+    else:
+        assert any(marker in release["gpu_coverage"] for marker in ("none", "full qualification"))
 
     if ".dev" in miniverl.__version__:
         assert record["status"] in {"candidate", "released"}

--- a/tests/unit/test_release_state.py
+++ b/tests/unit/test_release_state.py
@@ -76,7 +76,8 @@ def test_security_and_current_product_prose_follow_the_canonical_state() -> None
     security = (REPO_ROOT / "SECURITY.md").read_text(encoding="utf-8")
     project = (REPO_ROOT / "PROJECT_STATE.md").read_text(encoding="utf-8")
     assert f"supported stable line is `{state.stable_version}`" in security
-    assert f"Development `{state.development_version}` has a closed typed profile" in project
+    product_prefix = "Release" if state.is_release else "Development"
+    assert f"{product_prefix} `{state.development_version}` has a closed typed profile" in project
 
 
 # --------------------------------------------------------------- validation


### PR DESCRIPTION
## Summary

- finalize the canonical release state from `0.10.1.dev0` to `0.10.1` with UTC release date 2026-08-16 and pending merge commit
- move the product-maturity and exact-byte qualification work into the dated v0.10.1 changelog section
- regenerate English, Chinese, PyPI, security, citation, docs selector and package-version surfaces from the canonical state
- record the measured candidate test floor while leaving remote full qualification, dry-run and publication fields explicitly pending

## Release boundary

This PR changes release metadata only. The known-good RTX 4080 manifest retains historical `source_release: 0.10.0`; no frozen benchmark, task JSON/JSONL, model revision or existing tag changed. After merge, the merge SHA—not this branch head—will receive a fresh attempt-1 full GPU qualification and formal release dry-run before tagging.

## Validation

- `python scripts/release_state.py --check`
- generated `PYPI.md` byte check
- focused release/package tests: 183 passed, then final version/package set: 139 passed
- release-tree CPU suite after reinstalling this tree as 0.10.1: 2362 passed, 8 skipped, 22 deselected
- Ruff check/format, mypy, actionlint, strict MkDocs, Markdown links and `git diff --check`
- wheel/sdist build and Twine check
- local release-prep wheel SHA-256: `d609e30dab458d94d6e183ff6ced9ba0f5d179b299b40f39bc5e07245ee12aff`
- local release-prep sdist SHA-256: `743cf17f365710bf3ddbe8c5599c6a8daf0afa82779344b4497f1e93cd2d4f92`
- frozen calculator SHA-256 remains `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`
