### PR TITLE
chore: advance development after v0.10.1

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -6,12 +6,12 @@ current product and evidence state rather than repeating release history.
 
 Last updated: 2026-08-16.
 
-Canonical release state: releasing `v0.10.1`.
+Canonical release state: stable `v0.10.1` (`2364e9b8e8b550f44d1b66a77fc2d407b76b05b5`), development `0.10.2.dev0`.
 
 ## Release state
 
-- Release candidate: `v0.10.1`; the merge commit is assigned by the release PR.
-- Previous stable: `v0.10.0` at `51264f86e8226b1abc6ca1901d379c5e6fabb81e`.
+- Stable release: `v0.10.1` at `2364e9b8e8b550f44d1b66a77fc2d407b76b05b5`.
+- Development release: `0.10.2.dev0`.
 - Stable docs: <https://daoyuanli2816.github.io/mini-verl/>.
 - Development docs: <https://daoyuanli2816.github.io/mini-verl/dev/>.
 - Historical build log: [v0.1-v0.9 archive](docs/history/project-state-v0.1-v0.9.md).
@@ -31,7 +31,7 @@ Executable compatibility claims are mutation-tested and recorded in
 unknown-size quantized roles require proof instead of receiving an executable
 plan.
 
-Release `0.10.1` has a closed typed profile registry and torch-free
+Development `0.10.2.dev0` has a closed typed profile registry and torch-free
 compatibility introspection. Profile-scoped plans, caches, checkpoints and
 exports bind an independent identity. The direct-GKD and sampled-k1 vanilla
 policy-loss profiles both have pinned conformance and measured RTX 4080 paths.

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.10.1/docs/banner.svg" alt="miniVERL — run verl-style OPD on one consumer GPU" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — run verl-style OPD on one consumer GPU" width="880">
 </p>
 
 <div align="center">
@@ -8,7 +8,7 @@
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE)
 
 </div>
 
@@ -16,7 +16,7 @@
   <a href="https://pypi.org/project/miniverl/"><strong>PyPI</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/"><strong>Stable docs</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/dev/">Development docs</a> ·
-  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/README.zh-CN.md">中文</a>
+  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/main/README.zh-CN.md">中文</a>
 </p>
 
 **Run a documented subset of verl-style on-policy distillation on one consumer
@@ -62,15 +62,15 @@ miniverl bridge doctor scaleout --json
 
 The `train` extra installs the ML runtime, but does not choose the correct CUDA
 PyTorch wheel. The optional `cuda` extra adds bitsandbytes only. Follow the
-[one-GPU installation and memory guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/single-gpu-guide.md) for both the
+[one-GPU installation and memory guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) for both the
 flexible install and the machine-readable RTX 4080 known-good stack. Hardware
 other than that one measured RTX 4080 remains unmeasured.
 
 ## Architecture
 
 <picture>
-  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.10.1/docs/verl-local-runtime-mobile.svg">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.10.1/docs/verl-local-runtime.svg" alt="verl-shaped YAML, overrides and Parquet prompts pass through a typed compiler; one CUDA GPU runs actor rollout, teacher scoring and actor update; inspectable artifacts can be handed to pinned verl while distributed execution remains outside miniVERL.">
+  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime-mobile.svg">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime.svg" alt="verl-shaped YAML, overrides and Parquet prompts pass through a typed compiler; one CUDA GPU runs actor rollout, teacher scoring and actor update; inspectable artifacts can be handed to pinned verl while distributed execution remains outside miniVERL.">
 </picture>
 
 miniVERL uses one ordinary process and schedules model roles in phases. It does
@@ -126,13 +126,13 @@ miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml \
 
 External YAML must explicitly accept the high-risk local mappings printed by
 `plan` before `run`; the packaged profile carries a value-bound reviewed
-manifest. [Override precedence and safe input forms](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/config-overrides.md)
+manifest. [Override precedence and safe input forms](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/config-overrides.md)
 are documented without executing Hydra interpolation or shell text.
 
 The public built-in profile deliberately uses upstream-shaped `name: vllm`
 values. miniVERL classifies both rollout and teacher engine names as local
 reinterpretations and executes them with sequential local HF phases; this is
-not vLLM equivalence. See [For verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/for-verl-users.md) for config,
+not vLLM equivalence. See [For verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/for-verl-users.md) for config,
 data, role and error mappings.
 
 ## Tested profile boundary
@@ -173,21 +173,21 @@ with a 64-token response bound, and completed **8 current-policy updates** at
 **3.1914 GiB peak reserved VRAM**. Median steady-state rollout, teacher-scoring
 and update times were 9.7200, 0.4864 and 2.3260 seconds. A matched 4-update
 interruption resumed to the same byte-identical trajectories, adapter and
-optimizer tensors. See the [data-bound figure and full record](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/verl-opd-reference-workload.md);
-the original one-update [pip smoke](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/opd-quickstart.md) remains preserved.
+optimizer tensors. See the [data-bound figure and full record](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-opd-reference-workload.md);
+the original one-update [pip smoke](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/opd-quickstart.md) remains preserved.
 A separate pinned SmolLM2-360M/1.7B recipe consumed 32 distinct prompts across
 8 updates at 1.4961 GiB peak reserved VRAM. Interruption/resume was
 byte-identical, PEFT reload passed, and the exact-snapshot scale-out bundle
-materialized successfully. See the [full SmolLM2 systems record](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/smollm2-opd-workload.md).
+materialized successfully. See the [full SmolLM2 systems record](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/smollm2-opd-workload.md).
 
 This is deliberately a runtime and artifact proof. It is not a throughput
 benchmark, an alignment-quality endpoint, or evidence that OPD beats SFT, DPO
 or KD. Other NVIDIA GPUs use the same device-name-agnostic CUDA path, but model
 fit depends on VRAM, context length, quantization and installed kernels; they
-remain unmeasured. The [release qualification contract](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/release-qualification.md)
+remain unmeasured. The [release qualification contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/release-qualification.md)
 builds one candidate wheel on a hosted runner and qualifies those exact bytes
 on the RTX 4080 before any release can reuse them, while the
-[upstream support policy](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/upstream-support-policy.md) keeps both published
+[upstream support policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/upstream-support-policy.md) keeps both published
 profile identities fixed. Runner activation is not described as continuous CI.
 
 ### Choose a path by hardware, not GPU branding
@@ -203,7 +203,7 @@ Automatic BF16/FP16 selection follows device support; it is not inferred from
 marketing names such as 3070, 4080, 5090 or Titan. `miniverl doctor` reports the
 installed CUDA/PyTorch path. Normal planning is weight-free; explicit
 `plan --probe` adds bounded, cached CUDA measurements with zero optimizer
-updates. See [hardware planning](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/hardware-planning.md). There is no
+updates. See [hardware planning](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/hardware-planning.md). There is no
 automatic downgrade to a different model,
 teacher, context, top-k or loss when memory is tight.
 
@@ -215,7 +215,7 @@ miniverl hardware validate hardware-record.json
 ```
 
 Community records remain unreviewed until their hashes and provenance pass the
-[documented maintainer gate](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/community-benchmarks.md).
+[documented maintainer gate](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/community-benchmarks.md).
 
 ## Data and artifact interoperability
 
@@ -241,30 +241,30 @@ The v0.9 export preserves student/teacher identities, Parquet bytes and pure
 OPD overrides, but reports `launchable: false` until exact base snapshots are
 materialized and validated against the installed pinned verl commit. Only then
 does `bridge materialize` publish a checksummed `launch.sh`; distributed
-execution remains untested. Review the [current scale-out contract](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/verl-opd-scaleout.md),
-[legacy bridge](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/legacy-verl-bridge.md) and [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/compatibility.md).
+execution remains untested. Review the [current scale-out contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-opd-scaleout.md),
+[legacy bridge](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/legacy-verl-bridge.md) and [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md).
 
 The intended operating loop is **plan → inspect → run → inspect → export**.
 `plan --out` byte-binds the YAML, ordered overrides and scanned Parquet inputs
 to the exact native config; `run --plan` rejects drift before loading weights.
 Its digest follows the run manifest, teacher cache and checkpoints. Direct
 `run --config` remains available for experiments. See [immutable execution
-plans](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/immutable-plans.md).
+plans](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/immutable-plans.md).
 
 ## Research and validation
 
 miniVERL keeps every measured study—including negative results, superseded
 runs and preregistered early stops—public under the documentation. None is used
 as a claim that OPD universally beats SFT, DPO or KD: see the
-[v0.7 External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/alignment-external/alignment-external-v1.md),
-[Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/alignment-lab/alignment-lab-v1.md),
-[RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/recoverybench/recoverybench-v1.md), and the
-[calculator study](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/benchmarking.md).
+[v0.7 External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-external/alignment-external-v1.md),
+[Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md),
+[RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md), and the
+[calculator study](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md).
 
 New runs establish tokenizer compatibility through structural identity. The
 legacy behavioral fingerprint is retained only for migration and is not an
 identity proof. Scientific caveats and immutable source hashes remain in the
-detailed reports and [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/limitations.md).
+detailed reports and [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md).
 
 ## Development, security and license
 
@@ -277,6 +277,6 @@ pytest -q -m "not gpu and not network"
 
 Contributions should keep the one-GPU boundary explicit and include tests for
 new failure modes. Report vulnerabilities privately through
-[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/SECURITY.md). See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/CONTRIBUTING.md), the
-[changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/CHANGELOG.md), [citation metadata](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/CITATION.cff),
-[reproducibility guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/docs/reproducibility.md), and [Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.10.1/LICENSE).
+[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md). See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md), the
+[changelog](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md), [citation metadata](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff),
+[reproducibility guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/reproducibility.md), and [Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE).

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "release": "0.10.1",
-  "status": "candidate",
+  "status": "released",
   "quality_floor": "2,000+ tests and 80%+ branch coverage at v0.10.1",
   "local_validation": {
     "scope": "the maintainer's workstation, where the GPU and Windows-specific paths actually run",
@@ -27,26 +27,26 @@
     }
   },
   "release_validation": {
-    "scope": "the exact v0.10.1 release commit after release-PR merge",
-    "commit": "pending",
+    "scope": "the exact published v0.10.1 release commit",
+    "commit": "2364e9b8e8b550f44d1b66a77fc2d407b76b05b5",
     "workflows": {
-      "ci": "pending",
-      "build": "pending",
-      "docs": "pending",
-      "pinned_verl_bridge": "pending",
-      "gpu_full_qualification": "pending",
-      "release_dry_run": "pending",
-      "release": "pending"
+      "ci": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31931955082",
+      "build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31931955074",
+      "docs": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31934196386",
+      "pinned_verl_bridge": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31934196366",
+      "gpu_full_qualification": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31932226695",
+      "release_dry_run": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31933844796",
+      "release": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31934196365"
     },
-    "conclusion": "pending",
-    "gpu_coverage": "pending exact-SHA first-attempt full qualification on the ephemeral RTX 4080 runner",
+    "conclusion": "passed",
+    "gpu_coverage": "exact-SHA first-attempt full qualification passed on the ephemeral RTX 4080 runner; runtime correctness only",
     "publication": {
-      "pypi": "pending",
-      "github_release": "pending",
-      "documentation": "pending",
-      "immutable_documentation_build": "pending",
-      "wheel_sha256": "pending",
-      "sdist_sha256": "pending"
+      "pypi": "https://pypi.org/project/miniverl/0.10.1/",
+      "github_release": "https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.10.1",
+      "documentation": "https://daoyuanli2816.github.io/mini-verl/",
+      "immutable_documentation_build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31934196386",
+      "wheel_sha256": "fa5cdef1b6d0602ead7e90f6f51a024aa67c2f10d3f6c9d0507c3bbc3f1c82e8",
+      "sdist_sha256": "743cf17f365710bf3ddbe8c5599c6a8daf0afa82779344b449f7f1e93cd2d4f92"
     }
   }
 }

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  <div class="docs-channel" data-stable-version="0.10.1" data-dev-version="0.10.1">
+  <div class="docs-channel" data-stable-version="0.10.1" data-dev-version="0.10.2.dev0">
     <strong id="docs-channel-label">Stable documentation</strong>
     <label for="docs-version-selector">Version</label>
     <select id="docs-version-selector" aria-label="Documentation version">
       <option value="stable">Stable 0.10.1</option>
-      <option value="dev">Development 0.10.1</option>
+      <option value="dev">Development 0.10.2.dev0</option>
     </select>
   </div>
 {% endblock %}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,6 +4,11 @@ This is the release gate and publication record for miniVERL. A checked item
 names an invariant exercised on the stated source. Publication begins only
 after the exact release commit and its remote checks are green.
 
+## v0.10.2 development
+
+- [ ] Define and review the next focused release scope before changing product
+      behavior or scientific evidence.
+
 ## v0.10.1 release
 
 - [x] Begin from the verified v0.10.0 release and advance only the canonical
@@ -37,6 +42,21 @@ after the exact release commit and its remote checks are green.
       fail-closed remote gate; release smoke cannot satisfy the full level.
 - [x] README, Chinese README, PyPI text, stable/dev docs and limitations agree.
 - [x] Owner-only authorship and commit trailers audited.
+
+### After the v0.10.1 tag
+
+- [x] Exact-SHA full qualification run
+      [31932226695](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31932226695)
+      passed on attempt 1 on one RTX 4080.
+- [x] Non-publishing release dry-run
+      [31933844796](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31933844796)
+      reused the qualified candidate bytes without rebuilding.
+- [x] Tag release run
+      [31934196365](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31934196365)
+      passed OIDC publication, public hashes and attestations, clean install and
+      GitHub Release creation.
+- [x] Advance subsequent development to `0.10.2.dev0` while stable docs remain
+      bound to immutable `v0.10.1`.
 
 ## v0.10.0 development
 

--- a/release-state.yaml
+++ b/release-state.yaml
@@ -17,13 +17,13 @@
 # such distinction, which is how its tag shipped a docs selector still
 # advertising "Stable 0.6.1 / Development 0.6.2.dev0".
 schema_version: 1
-phase: release
+phase: development
 
 stable:
   version: "0.10.1"
   tag: "v0.10.1"
-  release_commit: "pending"
+  release_commit: "2364e9b8e8b550f44d1b66a77fc2d407b76b05b5"
   released_at: "2026-08-16"
 
 development:
-  version: "0.10.1"
+  version: "0.10.2.dev0"

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.10.1"
+__version__ = "0.10.2.dev0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Summary:
- records the completed v0.10.1 release commit, qualification, dry-run, publication, hashes, and public links
- advances main to 0.10.2.dev0 while keeping v0.10.1 as the stable docs and citation line
- regenerates the PyPI long description and documentation version selector

Validation:
- 192 targeted release/state/packaging tests passed; 1 Windows privilege skip
- 2362 non-GPU/non-network tests passed; 8 skipped, 22 deselected; 83.58% branch coverage
- Ruff, format, mypy, actionlint, release state, links, text integrity, known-good and schema checks passed
- MkDocs strict and 44 rendered SVG instances across four viewports passed
- package build and twine checks passed
- frozen calculator SHA-256 remains 53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc