### PR TITLE
Add transactional grouped rollout semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ All notable changes to miniVERL are recorded here. The format follows
 - Bound prompt-generation manifests and every v2 request to the live actor
   parameter version, base/tokenizer/adapter identity, backend and execution plan.
 
+### Transactional grouped rollouts
+
+- Added trajectory schema v3 with typed prompt-group, sample, seed, backend and
+  rollout-policy identity; v1 and v2 artifacts remain readable.
+- Added two conformance-only grouped profiles for Parquet prompt sources. They
+  train `n>1` current-policy samples independently through the existing direct
+  GKD or sampled-k1 objective, without a group baseline or GRPO semantics.
+- Made complete group publication journaled and replay-idempotent, and bound
+  prompt/group cursors, trajectory counts, backend synchronization, cache
+  identity and export provenance to exact interruption/resume state.
+
 ### Documentation narrative
 
 - Rebuilt the English, Chinese and PyPI landing narratives around the local

--- a/PYPI.md
+++ b/PYPI.md
@@ -132,7 +132,9 @@ profiles are available:
 
 Use `miniverl profiles show`, `compat explain` and `compat check` to inspect
 the complete mapping. [Compatibility profiles](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/profiles/index.md) explains
-how profile identity follows plans, caches, checkpoints and exports.
+how profile identity follows plans, caches, checkpoints and exports. Separate
+conformance-only grouped profiles add transactional Parquet `n>1` samples
+without changing either measured `n=1` profile or introducing GRPO semantics.
 
 ## Measured systems evidence
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ profiles are available:
 
 Use `miniverl profiles show`, `compat explain` and `compat check` to inspect
 the complete mapping. [Compatibility profiles](docs/profiles/index.md) explains
-how profile identity follows plans, caches, checkpoints and exports.
+how profile identity follows plans, caches, checkpoints and exports. Separate
+conformance-only grouped profiles add transactional Parquet `n>1` samples
+without changing either measured `n=1` profile or introducing GRPO semantics.
 
 ## Measured systems evidence
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -122,7 +122,8 @@ distillation:
 
 使用 `miniverl profiles show`、`compat explain` 与 `compat check` 查看完整映射。
 [兼容 profile](docs/profiles/index.md)说明 profile identity 如何跟随 plan、cache、checkpoint
-与 export。
+与 export。另有两个仅完成一致性验证的 grouped profile，为 Parquet prompt 提供事务化
+`n>1` 独立样本；它们不改变两个实测 `n=1` profile，也不引入 GRPO 语义。
 
 ## 实测系统证据
 

--- a/docs/for-verl-users.md
+++ b/docs/for-verl-users.md
@@ -19,8 +19,9 @@ by plans, caches, checkpoints and exports.
 
 - A resolved YAML using the `verl-opd-v0.8-single-gpu-v1` field subset.
 - Reward-free verl-style Parquet prompts with structured chat messages.
-- One actor, one teacher, `n=1`, token-mean aggregation, and either direct
-  forward-top-k GKD or the sampled-k1 vanilla policy-loss profile.
+- One actor, one teacher, token-mean aggregation, and either direct
+  forward-top-k GKD or sampled-k1 vanilla policy loss. The measured profiles
+  remain `n=1`; their grouped counterparts accept independent `n>1` samples.
 - Immutable Hugging Face revisions, PEFT adapters and tokenizer snapshots.
 - Familiar fields such as `actor_rollout_ref.model.path`,
   `distillation.teacher_models.teacher_model.model_path`, response bounds,
@@ -125,8 +126,9 @@ has progressed.
   documented profile; inspect-only compilation can still explain known
   unsupported values.
 - **Algorithm field rejected:** select the explicit PG-k1 profile for its
-  narrow sampled policy-loss path. Rewards, critics, external advantages, KL
-  penalties, `n>1`, multiple teachers and distributed counts remain unsupported.
+  narrow sampled policy-loss path, or a grouped profile for Parquet `n>1`.
+  Rewards, critics, external advantages, KL penalties, group-relative
+  baselines, multiple teachers and distributed counts remain unsupported.
 - **Interpolation rejected:** resolve Hydra/OmegaConf in your trusted verl
   environment first. miniVERL will not execute `${...}`.
 - **High-risk reinterpretation not accepted:** inspect `miniverl plan`, then

--- a/docs/generated/upstream-support-matrix.json
+++ b/docs/generated/upstream-support-matrix.json
@@ -18,6 +18,22 @@
       "upstream_commit": "7aed6b230776f963fa09509c10d9c3a767d1102c",
       "objective": "sampled_k1_vanilla_policy_loss",
       "distributed_execution_tested": false
+    },
+    {
+      "name": "verl-opd-v0.8-single-gpu-grouped-v1",
+      "status": "active",
+      "upstream_tag": "v0.8.0",
+      "upstream_commit": "7aed6b230776f963fa09509c10d9c3a767d1102c",
+      "objective": "forward_kl_topk_grouped_independent_samples",
+      "distributed_execution_tested": false
+    },
+    {
+      "name": "verl-opd-v0.8-single-gpu-pg-k1-grouped-v1",
+      "status": "active",
+      "upstream_tag": "v0.8.0",
+      "upstream_commit": "7aed6b230776f963fa09509c10d9c3a767d1102c",
+      "objective": "sampled_k1_grouped_independent_samples",
+      "distributed_execution_tested": false
     }
   ],
   "unprofiled_versions": "unsupported"

--- a/docs/generated/verl-opd-v0.8-compatibility.json
+++ b/docs/generated/verl-opd-v0.8-compatibility.json
@@ -5,7 +5,7 @@
     "locally_reinterpreted": 20,
     "semantically_conformant": 14
   },
-  "compiled_digest": "860b25e12c88bc772c9003008aafece2e4a71337a75373441f940ddde65bd008",
+  "compiled_digest": "0a42776d063064da484ddb47670baa03d11f51a9cf13b8b2e450e7455c66d5eb",
   "executable": true,
   "field_count": 77,
   "fields": [

--- a/docs/profiles/index.md
+++ b/docs/profiles/index.md
@@ -43,11 +43,15 @@ name.
 | --- | --- | --- | --- | --- |
 | `verl-opd-v0.8-single-gpu-v1` | direct GKD `forward_kl_topk` | top-k token IDs and log-probabilities | fuller distributional signal; larger target artifact | measured |
 | `verl-opd-v0.8-single-gpu-pg-k1-v1` | sampled `k1` + vanilla policy loss | sampled-token teacher log-probability | sampled-token signal; smaller target artifact | measured |
+| `verl-opd-v0.8-single-gpu-grouped-v1` | direct GKD over independent grouped samples | top-k token IDs and log-probabilities | configurable `n>1`; no group baseline | conformance only |
+| `verl-opd-v0.8-single-gpu-pg-k1-grouped-v1` | sampled `k1` over independent grouped samples | sampled-token teacher log-probability | configurable `n>1`; no GRPO estimator | conformance only |
 
-Both are reward-free, strict current-policy, one-actor/one-teacher profiles on
-one CUDA GPU. The PG profile uses a detached distillation-derived advantage
+All four are reward-free, strict current-policy, one-actor/one-teacher profiles
+on one CUDA GPU. The PG profiles use a detached distillation-derived advantage
 with the pinned vanilla policy-loss form. The measured records compare runtime
 and semantic conformance; task-quality questions belong to a declared benchmark.
+The two grouped profiles add transactional Parquet prompt groups while leaving
+the published `n=1` identities unchanged; each sample is optimized independently.
 See [For verl users](../for-verl-users.md), the
 [PG-k1 ADR](../adr/0010-verl-v0.8-pg-k1-contract.md), and the runtime evidence
 for the measured boundary.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -14,10 +14,10 @@ after the exact release commit and its remote checks are green.
       `0d6e0070ae73ef35f718aec3624ee5263ac96e3a` and candidate wheel
       `0256bd9e63ca6ed52999a5073a3577a008581a8d4418062314750d86f21cd5fe`
       before implementing `hf_cached`.
-- [ ] Add typed policy identity, lifecycle and strict synchronization contracts.
-- [ ] Qualify `hf_cached` at 64/256/512 response bounds and require at least 2x
+- [x] Add typed policy identity, lifecycle and strict synchronization contracts.
+- [x] Qualify `hf_cached` at 64/256/512 response bounds and require at least 2x
       speedup at 256 and 512 without exceeding 14.5 GiB peak reserved VRAM.
-- [ ] Add transactional `samples_per_prompt > 1` and exact no-skip/no-duplicate
+- [x] Add transactional `samples_per_prompt > 1` and exact no-skip/no-duplicate
       resume semantics without changing the published `n=1` profiles.
 - [ ] Add the new deterministic task-reward plus distillation-advantage profile;
       keep direct GKD and existing PG-k1 identities unchanged.

--- a/docs/rollout-runtime-v2.md
+++ b/docs/rollout-runtime-v2.md
@@ -35,6 +35,33 @@ profile identity and execution plan. A request for any other identity fails
 before model execution. Lifecycle transitions are explicit: `new` →
 `synchronized` → `quiesced` or `closed`.
 
+## Grouped prompt rollouts
+
+The grouped profiles accept `actor_rollout_ref.rollout.n > 1` for Parquet
+prompt sources. Each prompt receives a stable group identity and `n` independent
+current-policy trajectories. The direct-GKD and sampled-k1 objectives train
+those trajectories independently; there is no group baseline, GRPO estimator
+or reward normalization hidden behind `n`.
+
+Trajectory schema v3 binds the prompt digest, group and sample indices,
+generation seed, backend and policy identity into every record. A complete
+group is journaled and appended as one transaction. Checkpoints retain the
+prompt cursor, group cursor, trajectory count, policy version and backend sync
+identity, so an interrupted group is regenerated without skipping prompts;
+replaying an already committed identical group is a no-op rather than a
+duplicate append. Cache and export identities carry the same `n`, schema and
+seed-derivation versions.
+
+The runtime reports unique prompts, groups, trajectories, generated tokens,
+physical generation batches and per-group reward variance when rewards exist.
+Logical `n` stays separate from physical batch partitioning.
+
+Use `verl-opd-v0.8-single-gpu-grouped-v1` or
+`verl-opd-v0.8-single-gpu-pg-k1-grouped-v1`. The original measured profiles
+remain fixed at `n=1`; the grouped profiles are conformance-only until a later
+evidence stage measures them. Grouped rollouts currently require a Parquet
+prompt source. Environment-backed recipes remain `n=1`.
+
 The v0.11 baseline result remains the pre-change `hf_reference` measurement.
-It is not evidence for `hf_cached` performance. Grouped `n>1` publication and
-external-engine support are separate release-chain stages.
+It is not evidence for `hf_cached` or grouped-rollout performance. External
+engine support is a separate release-chain stage.

--- a/src/miniverl/alignment/workflow.py
+++ b/src/miniverl/alignment/workflow.py
@@ -201,7 +201,12 @@ def _sha256(path: Path) -> str:
 
 def _tagged(rows: list[Any], tag: str) -> list[Any]:
     marker = f":{tag}:v"
-    return [row for row in rows if marker in row.trajectory_id]
+    return [
+        row
+        for row in rows
+        if marker in row.trajectory_id
+        or marker in str(row.metadata.get("legacy_trajectory_id", ""))
+    ]
 
 
 def _decision_distribution(rows: list[Any]) -> dict[str, float]:

--- a/src/miniverl/bridge/export.py
+++ b/src/miniverl/bridge/export.py
@@ -27,6 +27,10 @@ from miniverl.bridge.contract import (
 )
 from miniverl.bridge.opd_pg_v08 import VERL_OPD_PG_K1_V08_PROFILE
 from miniverl.bridge.opd_v08 import VERL_OPD_V08_PROFILE
+from miniverl.bridge.profiles import (
+    VERL_OPD_GROUPED_V08_PROFILE,
+    VERL_OPD_PG_K1_GROUPED_V08_PROFILE,
+)
 from miniverl.errors import ConfigError
 from miniverl.utils.privacy import portable_payload
 from miniverl.utils.runs import read_json, write_json, write_text
@@ -428,7 +432,15 @@ def _write_hashes(root: Path) -> None:
     write_text(checksum, "\n".join(lines) + "\n")
 
 
-_OPD_PROFILES = frozenset({VERL_OPD_V08_PROFILE, VERL_OPD_PG_K1_V08_PROFILE})
+_PG_PROFILES = frozenset({VERL_OPD_PG_K1_V08_PROFILE, VERL_OPD_PG_K1_GROUPED_V08_PROFILE})
+_OPD_PROFILES = frozenset(
+    {
+        VERL_OPD_V08_PROFILE,
+        VERL_OPD_PG_K1_V08_PROFILE,
+        VERL_OPD_GROUPED_V08_PROFILE,
+        VERL_OPD_PG_K1_GROUPED_V08_PROFILE,
+    }
+)
 
 
 def _opd_run_contract(run: Path) -> tuple[dict[str, Any], dict[str, Any]] | None:
@@ -458,7 +470,7 @@ def _opd_run_contract(run: Path) -> tuple[dict[str, Any], dict[str, Any]] | None
             "distillation.distillation_loss.use_policy_gradient": True,
             "distillation.distillation_loss.policy_loss_mode": "vanilla",
         }
-        if profile == VERL_OPD_PG_K1_V08_PROFILE
+        if profile in _PG_PROFILES
         else {
             "distillation.distillation_loss.loss_mode": "forward_kl_topk",
             "distillation.distillation_loss.use_policy_gradient": False,
@@ -549,7 +561,7 @@ def _opd_overrides(
     # no such teacher inference key. It therefore belongs in provenance, not
     # in an override file that promises to parse upstream.
     teacher.get("inference", {}).pop("pipeline_model_parallel_size", None)
-    if profile == VERL_OPD_PG_K1_V08_PROFILE:
+    if profile in _PG_PROFILES:
         overrides["distillation"]["distillation_loss"].pop("topk", None)
     return overrides
 
@@ -581,7 +593,7 @@ exit 2
 def _opd_bundle_readme(profile: str) -> str:
     semantics = (
         "sampled k1 teacher log-probabilities and pinned vanilla policy-gradient loss"
-        if profile == VERL_OPD_PG_K1_V08_PROFILE
+        if profile in _PG_PROFILES
         else "pure GKD `forward_kl_topk` targets"
     )
     return f"""# miniVERL pure-OPD scale-out bundle
@@ -610,6 +622,9 @@ def _export_opd_bundle(
     destination: Path,
 ) -> dict[str, Any]:
     profile = str(compatibility["profile"])
+    samples_per_prompt = _get(source, "actor_rollout_ref.rollout.n")
+    if not isinstance(samples_per_prompt, int) or samples_per_prompt < 1:
+        raise ConfigError("compiled OPD source has no valid rollout.n identity")
     student_id = _get(source, "actor_rollout_ref.model.path")
     student_revision = _get(source, "miniverl.student_revision")
     if student_id != adapter["base_model"] or student_revision != adapter["revision"]:
@@ -697,14 +712,19 @@ def _export_opd_bundle(
             "miniverl_version": __version__,
             "target_semantics": (
                 "pure OPD sampled k1 policy gradient"
-                if profile == VERL_OPD_PG_K1_V08_PROFILE
+                if profile in _PG_PROFILES
                 else "pure GKD forward_kl_topk OPD"
             ),
             "target_representation": (
-                "sampled_token_log_probability"
-                if profile == VERL_OPD_PG_K1_V08_PROFILE
-                else "topk_distribution"
+                "sampled_token_log_probability" if profile in _PG_PROFILES else "topk_distribution"
             ),
+            "grouped_rollout_semantics": {
+                "samples_per_prompt": samples_per_prompt,
+                "trajectory_schema_version": 3,
+                "sample_semantics": "independent_current_policy_trajectory",
+                "group_baseline": False,
+                "grpo": False,
+            },
             "artifact_complete": False,
             "artifact_bundle_complete": True,
             "config_semantics_supported": True,
@@ -724,10 +744,7 @@ def _export_opd_bundle(
             "unsupported_semantics": [
                 item
                 for item in _UNSUPPORTED
-                if not (
-                    profile == VERL_OPD_PG_K1_V08_PROFILE
-                    and item == "PPO advantage or clipping semantics"
-                )
+                if not (profile in _PG_PROFILES and item == "PPO advantage or clipping semantics")
             ],
             "distributed_execution_status": "not tested",
         }

--- a/src/miniverl/bridge/opd_pg_v08.py
+++ b/src/miniverl/bridge/opd_pg_v08.py
@@ -127,7 +127,9 @@ def pg_field_rules_digest() -> str:
     return _canonical_digest([pg_compatibility_rule(field) for field in sorted(_PG_FIELD_RULES)])
 
 
-def _pg_semantic_blocker(path: str, value: Any) -> str | None:
+def _pg_semantic_blocker(
+    path: str, value: Any, *, allow_grouped_samples: bool = False
+) -> str | None:
     required = {
         "distillation.enabled": (True, "distillation must be enabled"),
         "distillation.distillation_loss.loss_mode": (
@@ -175,7 +177,6 @@ def _pg_semantic_blocker(path: str, value: Any) -> str | None:
             "token-mean",
             "only token-mean aggregation is supported",
         ),
-        "actor_rollout_ref.rollout.n": (1, "one generation per prompt is required"),
         "actor_rollout_ref.rollout.tensor_model_parallel_size": (
             1,
             "tensor parallelism greater than one is unsupported",
@@ -194,6 +195,11 @@ def _pg_semantic_blocker(path: str, value: Any) -> str | None:
         ),
         "trainer.nnodes": (1, "multi-node execution is unsupported"),
     }
+    if path == "actor_rollout_ref.rollout.n":
+        if allow_grouped_samples and isinstance(value, int) and value >= 1:
+            return None
+        if value != 1:
+            return "one generation per prompt is required by this legacy profile"
     expected = required.get(path)
     if expected is not None and value != expected[0]:
         return expected[1]
@@ -226,6 +232,8 @@ def compile_verl_pg_k1_v08(
     reinterpretations_accepted: bool = True,
     acceptance_source: str = "library_call",
     require_executable: bool = True,
+    allow_grouped_samples: bool = False,
+    profile_name: str = VERL_OPD_PG_K1_V08_PROFILE,
 ) -> CompiledLocalExecutionPlan:
     """Compile the closed sampled-k1 profile into a deterministic local plan."""
     merged = copy.deepcopy(dict(payload))
@@ -268,7 +276,11 @@ def compile_verl_pg_k1_v08(
     blockers: list[str] = []
     for path, value in sorted(flat.items()):
         rule = _PG_FIELD_RULES[path]
-        blocker = _pg_semantic_blocker(path, value)
+        blocker = _pg_semantic_blocker(
+            path,
+            value,
+            allow_grouped_samples=allow_grouped_samples,
+        )
         if blocker:
             blockers.append(path)
             classification: FieldClassification = "unsupported"
@@ -326,10 +338,13 @@ def compile_verl_pg_k1_v08(
         "policy_gradient": True,
         "policy_loss_mode": "vanilla",
         "teacher_target": "sampled_token_log_probability",
+        "samples_per_prompt": source.actor_rollout_ref.rollout.n,
+        "group_semantics": "independent_current_policy_trajectories",
+        "trajectory_schema_version": 3 if allow_grouped_samples else 2,
     }
     high_risk = [item.upstream_field for item in compatibility if item.user_confirmation_required]
     common = {
-        "profile": VERL_OPD_PG_K1_V08_PROFILE,
+        "profile": profile_name,
         "upstream": {"repository": VERL_REPOSITORY, "tag": VERL_TAG, "commit": VERL_COMMIT},
         "source_digest": _canonical_digest(merged),
         "source_leaf_fields": sorted(flat),
@@ -370,6 +385,8 @@ def load_verl_pg_k1_v08(
     trailing_overrides: Sequence[str] = (),
     accept_local_reinterpretations: bool = False,
     require_executable: bool = True,
+    allow_grouped_samples: bool = False,
+    profile_name: str = VERL_OPD_PG_K1_V08_PROFILE,
 ) -> CompiledLocalExecutionPlan:
     """Load one resolved YAML document without executing interpolation."""
     if path.suffix.lower() in {".sh", ".bash", ".ps1", ".cmd", ".bat"}:
@@ -388,6 +405,8 @@ def load_verl_pg_k1_v08(
         reinterpretations_accepted=accept_local_reinterpretations,
         acceptance_source="cli_flag" if accept_local_reinterpretations else "not_accepted",
         require_executable=require_executable,
+        allow_grouped_samples=allow_grouped_samples,
+        profile_name=profile_name,
     )
 
 
@@ -399,6 +418,8 @@ def load_verl_pg_k1_v08_source(
     trailing_overrides: Sequence[str] = (),
     accept_local_reinterpretations: bool = False,
     require_executable: bool = True,
+    allow_grouped_samples: bool = False,
+    profile_name: str = VERL_OPD_PG_K1_V08_PROFILE,
 ) -> CompiledLocalExecutionPlan:
     """Load the PG profile from an explicit resolved YAML path."""
     return load_verl_pg_k1_v08(
@@ -408,4 +429,6 @@ def load_verl_pg_k1_v08_source(
         trailing_overrides=trailing_overrides,
         accept_local_reinterpretations=accept_local_reinterpretations,
         require_executable=require_executable,
+        allow_grouped_samples=allow_grouped_samples,
+        profile_name=profile_name,
     )

--- a/src/miniverl/bridge/opd_runtime.py
+++ b/src/miniverl/bridge/opd_runtime.py
@@ -11,6 +11,10 @@ from pydantic import BaseModel, ConfigDict
 from miniverl.bridge.opd_capabilities import decide_placement
 from miniverl.bridge.opd_pg_v08 import VERL_OPD_PG_K1_V08_PROFILE
 from miniverl.bridge.opd_v08 import CompiledLocalExecutionPlan
+from miniverl.bridge.profiles import (
+    VERL_OPD_GROUPED_V08_PROFILE,
+    VERL_OPD_PG_K1_GROUPED_V08_PROFILE,
+)
 from miniverl.config.models import RunConfig
 from miniverl.errors import ConfigError
 
@@ -97,16 +101,28 @@ def build_system_plan(compiled: CompiledLocalExecutionPlan) -> OPDSystemPlan:
     )
     max_tokens = source.data.max_prompt_length + source.data.max_response_length
     rollout_batch = source.miniverl.batching.rollout_batch_size
-    token_buffers = max_tokens * rollout_batch * 64 * 1024
-    pg_k1 = compiled.profile == VERL_OPD_PG_K1_V08_PROFILE
+    samples_per_prompt = source.actor_rollout_ref.rollout.n
+    token_buffers = max_tokens * rollout_batch * samples_per_prompt * 64 * 1024
+    pg_k1 = compiled.profile in {
+        VERL_OPD_PG_K1_V08_PROFILE,
+        VERL_OPD_PG_K1_GROUPED_V08_PROFILE,
+    }
     if pg_k1:
         # token id + position + actor/teacher log-probs + response-mask weight
-        target_bytes = source.data.train_batch_size * source.data.max_response_length * 28
+        target_bytes = (
+            source.data.train_batch_size * samples_per_prompt * source.data.max_response_length * 28
+        )
     else:
         top_k = source.distillation.distillation_loss.topk
         if top_k is None:
             raise ConfigError("direct forward_kl_topk profile requires a positive topk")
-        target_bytes = source.data.train_batch_size * source.data.max_response_length * top_k * 12
+        target_bytes = (
+            source.data.train_batch_size
+            * samples_per_prompt
+            * source.data.max_response_length
+            * top_k
+            * 12
+        )
     known_static = sum(
         value
         for value in (student_static, teacher_static, trainable_optimizer)
@@ -255,6 +271,8 @@ def build_system_plan(compiled: CompiledLocalExecutionPlan) -> OPDSystemPlan:
         },
         batching={
             "rollout": source.miniverl.batching.rollout_batch_size,
+            "samples_per_prompt": samples_per_prompt,
+            "group_semantics": "independent_current_policy_trajectories",
             "declared_rollout_sequence_cap": source.actor_rollout_ref.rollout.max_num_seqs,
             "declared_rollout_token_cap": (source.actor_rollout_ref.rollout.max_num_batched_tokens),
             "teacher_score": source.miniverl.batching.teacher_score_batch_size,
@@ -310,7 +328,10 @@ def compile_native_run_config(
     from miniverl.bridge.profiles import get_profile
 
     profile_identity = get_profile(compiled.profile).identity.model_dump(mode="json")
-    pg_k1 = compiled.profile == VERL_OPD_PG_K1_V08_PROFILE
+    pg_k1 = compiled.profile in {
+        VERL_OPD_PG_K1_V08_PROFILE,
+        VERL_OPD_PG_K1_GROUPED_V08_PROFILE,
+    }
     loss_payload = (
         {
             "mode": "verl_pg_k1",
@@ -405,6 +426,13 @@ def compile_native_run_config(
             "seed": source.data.seed or 0,
         },
         "rollout": {
+            "backend": (
+                "hf_cached"
+                if compiled.profile
+                in {VERL_OPD_GROUPED_V08_PROFILE, VERL_OPD_PG_K1_GROUPED_V08_PROFILE}
+                else "hf_reference"
+            ),
+            "samples_per_prompt": source.actor_rollout_ref.rollout.n,
             "max_turns": 1,
             "max_total_tokens": source.data.max_prompt_length + source.data.max_response_length,
             "temperature": source.actor_rollout_ref.rollout.temperature,
@@ -424,7 +452,7 @@ def compile_native_run_config(
         "train": {
             "cycles": total_steps,
             "rollouts_per_cycle": logical_batch,
-            "gradient_accumulation_steps": logical_batch,
+            "gradient_accumulation_steps": logical_batch * source.actor_rollout_ref.rollout.n,
             "trajectory_batch_size": source.miniverl.batching.update_trajectory_batch_size,
             "length_bucketing": source.actor_rollout_ref.actor.use_dynamic_bsz,
             "max_update_padded_tokens": (source.actor_rollout_ref.actor.ppo_max_token_len_per_gpu),

--- a/src/miniverl/bridge/opd_v08.py
+++ b/src/miniverl/bridge/opd_v08.py
@@ -994,7 +994,7 @@ def _resolve_overrides(
     return records
 
 
-def _semantic_blocker(path: str, value: Any) -> str | None:
+def _semantic_blocker(path: str, value: Any, *, allow_grouped_samples: bool = False) -> str | None:
     required = {
         "distillation.enabled": (True, "distillation must be enabled"),
         "distillation.distillation_loss.loss_mode": (
@@ -1018,7 +1018,6 @@ def _semantic_blocker(path: str, value: Any) -> str | None:
             "token-mean",
             "only token-mean aggregation is supported",
         ),
-        "actor_rollout_ref.rollout.n": (1, "one generation per prompt is required"),
         "actor_rollout_ref.rollout.tensor_model_parallel_size": (
             1,
             "tensor parallelism greater than one is unsupported",
@@ -1037,6 +1036,11 @@ def _semantic_blocker(path: str, value: Any) -> str | None:
         ),
         "trainer.nnodes": (1, "multi-node execution is unsupported"),
     }
+    if path == "actor_rollout_ref.rollout.n":
+        if allow_grouped_samples and isinstance(value, int) and value >= 1:
+            return None
+        if value != 1:
+            return "one generation per prompt is required by this legacy profile"
     expected = required.get(path)
     if expected is not None and value != expected[0]:
         return expected[1]
@@ -1072,6 +1076,8 @@ def compile_verl_opd_v08(
     reinterpretations_accepted: bool = True,
     acceptance_source: str = "library_call",
     require_executable: bool = True,
+    allow_grouped_samples: bool = False,
+    profile_name: str = VERL_OPD_V08_PROFILE,
 ) -> CompiledLocalExecutionPlan:
     """Compile one resolved documented profile into a deterministic local plan."""
     merged = copy.deepcopy(dict(payload))
@@ -1114,7 +1120,11 @@ def compile_verl_opd_v08(
     blockers: list[str] = []
     for path, value in sorted(flat.items()):
         rule = _FIELD_RULES[path]
-        blocker = _semantic_blocker(path, value)
+        blocker = _semantic_blocker(
+            path,
+            value,
+            allow_grouped_samples=allow_grouped_samples,
+        )
         if blocker:
             blockers.append(path)
             classification: FieldClassification = "unsupported"
@@ -1170,9 +1180,13 @@ def compile_verl_opd_v08(
         "loss_reduction": source.actor_rollout_ref.actor.loss_agg_mode,
         "task_rewards": False,
         "policy_gradient": False,
+        "samples_per_prompt": source.actor_rollout_ref.rollout.n,
+        "group_semantics": "independent_current_policy_trajectories",
+        "trajectory_schema_version": 3 if allow_grouped_samples else 2,
     }
     high_risk = [item.upstream_field for item in compatibility if item.user_confirmation_required]
     common = {
+        "profile": profile_name,
         "upstream": {"repository": VERL_REPOSITORY, "tag": VERL_TAG, "commit": VERL_COMMIT},
         "source_digest": _canonical_digest(merged),
         "source_leaf_fields": sorted(flat),
@@ -1212,6 +1226,8 @@ def load_verl_opd_v08(
     trailing_overrides: Sequence[str] = (),
     accept_local_reinterpretations: bool = False,
     require_executable: bool = True,
+    allow_grouped_samples: bool = False,
+    profile_name: str = VERL_OPD_V08_PROFILE,
 ) -> CompiledLocalExecutionPlan:
     """Load a resolved YAML mapping; scripts and interpolations are never evaluated."""
     if path.suffix.lower() in {".sh", ".bash", ".ps1", ".cmd", ".bat"}:
@@ -1230,6 +1246,8 @@ def load_verl_opd_v08(
         reinterpretations_accepted=accept_local_reinterpretations,
         acceptance_source="cli_flag" if accept_local_reinterpretations else "not_accepted",
         require_executable=require_executable,
+        allow_grouped_samples=allow_grouped_samples,
+        profile_name=profile_name,
     )
 
 
@@ -1241,6 +1259,8 @@ def load_verl_opd_v08_source(
     trailing_overrides: Sequence[str] = (),
     accept_local_reinterpretations: bool = False,
     require_executable: bool = True,
+    allow_grouped_samples: bool = False,
+    profile_name: str = VERL_OPD_V08_PROFILE,
 ) -> CompiledLocalExecutionPlan:
     """Load a path or the packaged Qwen3 quickstart profile."""
     source_text = str(source)
@@ -1252,6 +1272,8 @@ def load_verl_opd_v08_source(
             trailing_overrides=trailing_overrides,
             accept_local_reinterpretations=accept_local_reinterpretations,
             require_executable=require_executable,
+            allow_grouped_samples=allow_grouped_samples,
+            profile_name=profile_name,
         )
     from importlib.resources import files
 
@@ -1271,6 +1293,8 @@ def load_verl_opd_v08_source(
         reinterpretations_accepted=False,
         acceptance_source="packaged_approval_mismatch",
         require_executable=require_executable,
+        allow_grouped_samples=allow_grouped_samples,
+        profile_name=profile_name,
     )
     try:
         approval = json.loads(approval_resource.read_text(encoding="utf-8"))
@@ -1299,6 +1323,8 @@ def load_verl_opd_v08_source(
             "cli_flag" if accept_local_reinterpretations else "packaged_approval_manifest"
         ),
         require_executable=require_executable,
+        allow_grouped_samples=allow_grouped_samples,
+        profile_name=profile_name,
     )
 
 

--- a/src/miniverl/bridge/profiles.py
+++ b/src/miniverl/bridge/profiles.py
@@ -43,7 +43,12 @@ __all__ = [
     "get_profile",
     "list_profiles",
     "load_profile_source",
+    "VERL_OPD_GROUPED_V08_PROFILE",
+    "VERL_OPD_PG_K1_GROUPED_V08_PROFILE",
 ]
+
+VERL_OPD_GROUPED_V08_PROFILE = "verl-opd-v0.8-single-gpu-grouped-v1"
+VERL_OPD_PG_K1_GROUPED_V08_PROFILE = "verl-opd-v0.8-single-gpu-pg-k1-grouped-v1"
 
 
 class _FrozenModel(BaseModel):
@@ -135,16 +140,21 @@ class CompatibilityProfile(ABC):
 
 @dataclass(frozen=True)
 class _DirectGKDProfile(CompatibilityProfile):
+    name: str = VERL_OPD_V08_PROFILE
+    grouped: bool = False
+
     @property
     def identity(self) -> ProfileIdentity:
         return ProfileIdentity.create(
-            profile_name=VERL_OPD_V08_PROFILE,
+            profile_name=self.name,
             profile_schema_version=1,
             upstream_repository=VERL_REPOSITORY,
             upstream_tag=VERL_TAG,
             upstream_commit=VERL_COMMIT,
             field_rule_digest=field_rules_digest(),
-            native_compiler_version="direct-gkd-native-v1",
+            native_compiler_version=(
+                "direct-gkd-native-grouped-v1" if self.grouped else "direct-gkd-native-v1"
+            ),
             loss_conformance_version="forward-kl-topk-verl-v0.8-v1",
             export_version="verl-opd-export-v1",
         )
@@ -152,10 +162,10 @@ class _DirectGKDProfile(CompatibilityProfile):
     @property
     def summary(self) -> ProfileSummary:
         return ProfileSummary(
-            name=VERL_OPD_V08_PROFILE,
+            name=self.name,
             objective="direct GKD forward_kl_topk",
             teacher_target="top-k token IDs and log-probabilities",
-            status="measured",
+            status="conformance_only" if self.grouped else "measured",
             identity=self.identity,
         )
 
@@ -168,7 +178,7 @@ class _DirectGKDProfile(CompatibilityProfile):
         unsupported = classification == "unsupported"
         informational = classification == "informational_only"
         return CompatibilityExplanation(
-            profile=VERL_OPD_V08_PROFILE,
+            profile=self.name,
             upstream_field=field,
             classification=classification,
             local_target=rule["local_target"],
@@ -193,6 +203,8 @@ class _DirectGKDProfile(CompatibilityProfile):
             source,
             accept_local_reinterpretations=accept_local_reinterpretations,
             require_executable=False,
+            allow_grouped_samples=self.grouped,
+            profile_name=self.name,
         )
         fields = [item.model_dump(mode="json") for item in compiled.compatibility]
         unsupported = sum(not item.executable for item in compiled.compatibility)
@@ -236,18 +248,24 @@ class _DirectGKDProfile(CompatibilityProfile):
     def show(self) -> dict[str, Any]:
         from importlib.resources import files
 
+        import yaml
+
         minimal_yaml = (
             files("miniverl")
             .joinpath("resources/qwen3_0_6b_1_7b_opd.yaml")
             .read_text(encoding="utf-8")
         )
+        if self.grouped:
+            payload = yaml.safe_load(minimal_yaml)
+            payload["actor_rollout_ref"]["rollout"]["n"] = 4
+            minimal_yaml = yaml.safe_dump(payload, sort_keys=False, allow_unicode=True)
         return {
             **self.summary.model_dump(mode="json"),
             "identity": self.identity.model_dump(mode="json"),
             "algorithm_contract": {
                 "actor_count": 1,
                 "teacher_count": 1,
-                "generations_per_prompt": 1,
+                "generations_per_prompt": 4 if self.grouped else 1,
                 "objective": "forward_kl_topk",
                 "task_rewards": False,
                 "distributed_execution": False,
@@ -255,7 +273,7 @@ class _DirectGKDProfile(CompatibilityProfile):
             },
             "minimal_yaml": minimal_yaml,
             "override_invocation": (
-                "miniverl plan --profile verl-opd-v0.8-single-gpu-v1 "
+                f"miniverl plan --profile {self.name} "
                 "--config builtin:qwen3-0.6b-1.7b-opd "
                 "--set data.train_batch_size=4 --json"
             ),
@@ -264,16 +282,21 @@ class _DirectGKDProfile(CompatibilityProfile):
 
 @dataclass(frozen=True)
 class _PGK1Profile(CompatibilityProfile):
+    name: str = VERL_OPD_PG_K1_V08_PROFILE
+    grouped: bool = False
+
     @property
     def identity(self) -> ProfileIdentity:
         return ProfileIdentity.create(
-            profile_name=VERL_OPD_PG_K1_V08_PROFILE,
+            profile_name=self.name,
             profile_schema_version=1,
             upstream_repository=VERL_REPOSITORY,
             upstream_tag=VERL_TAG,
             upstream_commit=VERL_COMMIT,
             field_rule_digest=pg_field_rules_digest(),
-            native_compiler_version="pg-k1-native-v1",
+            native_compiler_version=(
+                "pg-k1-native-grouped-v1" if self.grouped else "pg-k1-native-v1"
+            ),
             loss_conformance_version="pg-k1-verl-v0.8-v1",
             export_version="verl-opd-pg-k1-export-v1",
         )
@@ -281,10 +304,10 @@ class _PGK1Profile(CompatibilityProfile):
     @property
     def summary(self) -> ProfileSummary:
         return ProfileSummary(
-            name=VERL_OPD_PG_K1_V08_PROFILE,
+            name=self.name,
             objective="k1 + vanilla policy loss",
             teacher_target="sampled-token teacher log-probability",
-            status="measured",
+            status="conformance_only" if self.grouped else "measured",
             identity=self.identity,
         )
 
@@ -297,7 +320,7 @@ class _PGK1Profile(CompatibilityProfile):
         unsupported = classification == "unsupported"
         informational = classification == "informational_only"
         return CompatibilityExplanation(
-            profile=VERL_OPD_PG_K1_V08_PROFILE,
+            profile=self.name,
             upstream_field=field,
             classification=classification,
             local_target=rule["local_target"],
@@ -322,6 +345,8 @@ class _PGK1Profile(CompatibilityProfile):
             source,
             accept_local_reinterpretations=accept_local_reinterpretations,
             require_executable=False,
+            allow_grouped_samples=self.grouped,
+            profile_name=self.name,
         )
         fields = [item.model_dump(mode="json") for item in compiled.compatibility]
         unsupported = sum(not item.executable for item in compiled.compatibility)
@@ -387,13 +412,15 @@ class _PGK1Profile(CompatibilityProfile):
             }
         )
         payload["algorithm"]["adv_estimator"] = None
+        if self.grouped:
+            payload["actor_rollout_ref"]["rollout"]["n"] = 4
         return {
             **self.summary.model_dump(mode="json"),
             "identity": self.identity.model_dump(mode="json"),
             "algorithm_contract": {
                 "actor_count": 1,
                 "teacher_count": 1,
-                "generations_per_prompt": 1,
+                "generations_per_prompt": 4 if self.grouped else 1,
                 "objective": "sampled k1 through vanilla policy loss",
                 "task_rewards": False,
                 "distributed_execution": False,
@@ -401,7 +428,7 @@ class _PGK1Profile(CompatibilityProfile):
             },
             "minimal_yaml": yaml.safe_dump(payload, sort_keys=False, allow_unicode=True),
             "override_invocation": (
-                "miniverl plan --profile verl-opd-v0.8-single-gpu-pg-k1-v1 "
+                f"miniverl plan --profile {self.name} "
                 "--config pg-k1.yaml --set data.train_batch_size=4 --json"
             ),
         }
@@ -410,6 +437,14 @@ class _PGK1Profile(CompatibilityProfile):
 _REGISTRY: dict[str, CompatibilityProfile] = {
     VERL_OPD_V08_PROFILE: _DirectGKDProfile(),
     VERL_OPD_PG_K1_V08_PROFILE: _PGK1Profile(),
+    VERL_OPD_GROUPED_V08_PROFILE: _DirectGKDProfile(
+        name=VERL_OPD_GROUPED_V08_PROFILE,
+        grouped=True,
+    ),
+    VERL_OPD_PG_K1_GROUPED_V08_PROFILE: _PGK1Profile(
+        name=VERL_OPD_PG_K1_GROUPED_V08_PROFILE,
+        grouped=True,
+    ),
 }
 
 
@@ -451,7 +486,7 @@ def load_profile_source(
 ) -> Any:
     """Compile one source through the selected closed built-in profile."""
     get_profile(name)  # fail closed before dispatch; never load third-party code
-    if name == VERL_OPD_V08_PROFILE:
+    if name in {VERL_OPD_V08_PROFILE, VERL_OPD_GROUPED_V08_PROFILE}:
         return load_verl_opd_v08_source(
             source,
             override_files=override_files,
@@ -459,8 +494,13 @@ def load_profile_source(
             trailing_overrides=trailing_overrides,
             accept_local_reinterpretations=accept_local_reinterpretations,
             require_executable=require_executable,
+            allow_grouped_samples=name == VERL_OPD_GROUPED_V08_PROFILE,
+            profile_name=name,
         )
-    if name == VERL_OPD_PG_K1_V08_PROFILE:
+    if name in {
+        VERL_OPD_PG_K1_V08_PROFILE,
+        VERL_OPD_PG_K1_GROUPED_V08_PROFILE,
+    }:
         return load_verl_pg_k1_v08_source(
             source,
             override_files=override_files,
@@ -468,5 +508,7 @@ def load_profile_source(
             trailing_overrides=trailing_overrides,
             accept_local_reinterpretations=accept_local_reinterpretations,
             require_executable=require_executable,
+            allow_grouped_samples=name == VERL_OPD_PG_K1_GROUPED_V08_PROFILE,
+            profile_name=name,
         )
     raise AssertionError(f"registered profile {name!r} has no compiler dispatch")

--- a/src/miniverl/cache/store.py
+++ b/src/miniverl/cache/store.py
@@ -190,6 +190,9 @@ class TeacherCache:
         estimator_implementation_version: str | None = None,
         execution_plan_digest: str | None = None,
         profile_identity: dict[str, Any] | None = None,
+        samples_per_prompt: int = 1,
+        trajectory_schema_version: int = 2,
+        group_generation_seed_version: str = "miniverl-rollout-seed-v1",
         dtype: str = "float32",
         entries_per_shard: int = 32,
         overwrite: bool = False,
@@ -234,6 +237,9 @@ class TeacherCache:
             estimator_implementation_version=estimator_implementation_version,
             execution_plan_digest=execution_plan_digest,
             profile_identity=dict(profile_identity or {}),
+            samples_per_prompt=samples_per_prompt,
+            trajectory_schema_version=trajectory_schema_version,
+            group_generation_seed_version=group_generation_seed_version,
             dtype=dtype,
             entries_per_shard=entries_per_shard,
         )
@@ -290,6 +296,9 @@ class TeacherCache:
         estimator_implementation_version: str | None = None,
         execution_plan_digest: str | None = None,
         profile_identity: dict[str, Any] | None = None,
+        samples_per_prompt: int = 1,
+        trajectory_schema_version: int = 2,
+        group_generation_seed_version: str = "miniverl-rollout-seed-v1",
         dtype: str,
     ) -> None:
         """Reject reuse when any objective or teacher identity component changed."""
@@ -309,6 +318,13 @@ class TeacherCache:
                     hint="re-score the legacy cache so its index records the current "
                     "tokenizer and adapter provenance",
                 )
+        if self.index.schema_version < 4 and (
+            samples_per_prompt != 1 or trajectory_schema_version > 2
+        ):
+            raise StaleCacheError(
+                "legacy teacher cache cannot verify grouped rollout identity",
+                hint="re-score the cache with trajectory schema v3 and grouped provenance",
+            )
         expected: dict[str, Any] = {
             "teacher_model_id": teacher_model_id,
             "teacher_model_revision": teacher_model_revision,
@@ -331,6 +347,10 @@ class TeacherCache:
             )
             expected["execution_plan_digest"] = execution_plan_digest
             expected["profile_identity"] = dict(profile_identity or {})
+        if self.index.schema_version >= 4:
+            expected["samples_per_prompt"] = samples_per_prompt
+            expected["trajectory_schema_version"] = trajectory_schema_version
+            expected["group_generation_seed_version"] = group_generation_seed_version
         mismatches = {
             key: (getattr(self.index, key), value)
             for key, value in expected.items()

--- a/src/miniverl/config/models.py
+++ b/src/miniverl/config/models.py
@@ -855,10 +855,10 @@ class RunConfig(_Base):
             )
         if self.source.kind is SourceKind.VERL_PARQUET and self.environment is not None:
             raise ValueError("source.kind=verl_parquet must not define environment")
-        if self.rollout.samples_per_prompt != 1:
+        if self.source.kind is SourceKind.ENVIRONMENT and self.rollout.samples_per_prompt != 1:
             raise ValueError(
-                "rollout.samples_per_prompt > 1 requires the transactional grouped-rollout "
-                "runtime, which is not enabled in this build"
+                "rollout.samples_per_prompt > 1 currently requires source.kind=verl_parquet; "
+                "multi-turn tool episodes retain one trajectory per task"
             )
         if self.source.kind is SourceKind.VERL_PARQUET:
             if mode is not TrainingMode.OPD:

--- a/src/miniverl/runtime/rollout.py
+++ b/src/miniverl/runtime/rollout.py
@@ -14,6 +14,7 @@ from miniverl.models.base import GenerationOutput
 from miniverl.runtime.backends import HFCachedGenerationBackend, HFReferenceGenerationBackend
 from miniverl.runtime.generation import (
     GenerationRequest,
+    GenerationResult,
     PolicySnapshot,
     RolloutBackendKind,
     RolloutGroupIdentity,
@@ -21,7 +22,15 @@ from miniverl.runtime.generation import (
     derive_sample_seed,
 )
 from miniverl.runtime.policy_sync import build_rollout_policy_identity
-from miniverl.schemas.trajectory import Span, SpanType, TerminationReason, Trajectory
+from miniverl.schemas.trajectory import (
+    TRAJECTORY_SCHEMA_VERSION,
+    Span,
+    SpanType,
+    TerminationReason,
+    Trajectory,
+    derive_grouped_trajectory_id,
+    validate_trajectory_groups,
+)
 
 __all__ = [
     "GeneratedPromptBatch",
@@ -60,7 +69,9 @@ class PreparedPromptBatch:
     """One logical prompt batch and its deterministic physical partition."""
 
     prompts: tuple[RenderedPrompt, ...]
+    groups: tuple[RolloutGroupIdentity, ...]
     physical_batches: tuple[tuple[int, ...], ...]
+    group_cursor: int
 
 
 @dataclass(frozen=True)
@@ -68,6 +79,9 @@ class GeneratedPromptBatch:
     """Outputs restored to logical order plus the actual physical batch sizes."""
 
     outputs: tuple[GenerationOutput, ...]
+    groups: tuple[RolloutGroupIdentity, ...]
+    generation_seeds: tuple[int, ...]
+    rollout_policy_identity_digest: str
     policy_version: int
     physical_batch_sizes: tuple[int, ...]
     oom_downshifts: int = 0
@@ -102,16 +116,15 @@ class PromptDatasetRolloutRuntime:
         """Independent response bound for the verl Parquet profile."""
         return min(self.config.max_new_tokens_per_turn, self.source_config.max_response_length)
 
-    def prepare_batch(self, inputs: list[RenderedPrompt]) -> PreparedPromptBatch:
+    def prepare_batch(
+        self, inputs: list[RenderedPrompt], *, group_cursor: int = 0
+    ) -> PreparedPromptBatch:
         if self._closed:
             raise RuntimeError("prompt rollout runtime is closed")
         if not inputs:
             raise ValueError("prompt rollout batch cannot be empty")
-        if self.config.samples_per_prompt != 1:
-            raise ValueError(
-                "samples_per_prompt > 1 is reserved by the v2 contract but requires the "
-                "transactional grouped-rollout runtime"
-            )
+        if group_cursor < 0:
+            raise ValueError("group_cursor must be non-negative")
         max_new = self.max_new_tokens
         for prompt in inputs:
             if len(prompt.token_ids) + max_new > self.config.max_total_tokens:
@@ -122,7 +135,20 @@ class PromptDatasetRolloutRuntime:
         groups: list[tuple[int, ...]] = []
         current: list[int] = []
         current_width = 0
-        for index, prompt in enumerate(inputs):
+        logical_groups: list[RolloutGroupIdentity] = []
+        for prompt_index, prompt in enumerate(inputs):
+            prompt_group_id = f"g{group_cursor + prompt_index:012d}-{prompt.record.row_digest[:12]}"
+            logical_groups.extend(
+                RolloutGroupIdentity(
+                    prompt_group_id=prompt_group_id,
+                    prompt_digest=prompt.rendered_prompt_digest,
+                    sample_index=sample_index,
+                    samples_per_prompt=self.config.samples_per_prompt,
+                )
+                for sample_index in range(self.config.samples_per_prompt)
+            )
+        for index, _logical_group in enumerate(logical_groups):
+            prompt = inputs[index // self.config.samples_per_prompt]
             candidate_width = max(current_width, len(prompt.token_ids))
             candidate_size = len(current) + 1
             padded_tokens = candidate_size * (candidate_width + max_new)
@@ -142,7 +168,12 @@ class PromptDatasetRolloutRuntime:
                 )
         if current:
             groups.append(tuple(current))
-        return PreparedPromptBatch(prompts=tuple(inputs), physical_batches=tuple(groups))
+        return PreparedPromptBatch(
+            prompts=tuple(inputs),
+            groups=tuple(logical_groups),
+            physical_batches=tuple(groups),
+            group_cursor=group_cursor,
+        )
 
     def _generate_group(
         self,
@@ -152,32 +183,33 @@ class PromptDatasetRolloutRuntime:
         base_seed: int,
         policy_version: int,
         policy_identity: Any,
-    ) -> tuple[list[tuple[int, GenerationOutput]], list[int], int]:
+    ) -> tuple[list[tuple[int, GenerationResult]], list[int], int]:
         try:
             requests = []
             for index in indices:
-                prompt = batch.prompts[index]
+                logical_group = batch.groups[index]
+                prompt_index = index // self.config.samples_per_prompt
+                prompt = batch.prompts[prompt_index]
                 sample_seed = (
-                    base_seed * 1_000_003 + index
+                    base_seed * 1_000_003 + prompt_index
                     if self.config.backend is RolloutBackendKind.HF_REFERENCE
+                    and self.config.samples_per_prompt == 1
                     else derive_sample_seed(
                         run_seed=base_seed,
                         prompt_digest=prompt.rendered_prompt_digest,
                         policy_version=policy_version,
-                        sample_index=0,
+                        sample_index=logical_group.sample_index,
                     )
                 )
                 requests.append(
                     GenerationRequest(
                         request_id=hashlib.sha256(
-                            f"{prompt.rendered_prompt_digest}:{policy_version}:0".encode("ascii")
+                            (
+                                f"{logical_group.prompt_group_id}:{policy_version}:"
+                                f"{logical_group.sample_index}"
+                            ).encode("ascii")
                         ).hexdigest(),
-                        group=RolloutGroupIdentity(
-                            prompt_group_id=prompt.record.row_digest,
-                            prompt_digest=prompt.rendered_prompt_digest,
-                            sample_index=0,
-                            samples_per_prompt=1,
-                        ),
+                        group=logical_group,
                         deterministic_sample_seed=sample_seed,
                         prompt_token_ids=tuple(prompt.token_ids),
                         max_new_tokens=self.max_new_tokens,
@@ -191,16 +223,7 @@ class PromptDatasetRolloutRuntime:
                     )
                 )
             generated = self.generation_backend.generate(requests)
-            output = [
-                GenerationOutput(
-                    token_ids=list(result.output_token_ids),
-                    text=result.decoded_text,
-                    stop_reason=result.stop_reason,
-                    matched_stop=result.matched_stop,
-                    logprobs=list(result.sampled_token_logprobs),
-                )
-                for result in generated.results
-            ]
+            output = list(generated.results)
         except BaseException as exc:
             message = str(exc).lower()
             is_oom = type(exc).__name__ in {"OutOfMemoryError", "CudaOutOfMemoryError"} or (
@@ -254,7 +277,7 @@ class PromptDatasetRolloutRuntime:
             execution_plan_digest=self.execution_plan_digest,
         )
         self.generation_backend.synchronize(PolicySnapshot(policy_identity))
-        indexed: list[tuple[int, GenerationOutput]] = []
+        indexed: list[tuple[int, GenerationResult]] = []
         physical_sizes: list[int] = []
         downshifts = 0
         for group in batch.physical_batches:
@@ -269,8 +292,34 @@ class PromptDatasetRolloutRuntime:
             physical_sizes.extend(sizes)
             downshifts += count
         indexed.sort(key=lambda item: item[0])
+        results = tuple(result for _, result in indexed)
         return GeneratedPromptBatch(
-            outputs=tuple(output for _, output in indexed),
+            outputs=tuple(
+                GenerationOutput(
+                    token_ids=list(result.output_token_ids),
+                    text=result.decoded_text,
+                    stop_reason=result.stop_reason,
+                    matched_stop=result.matched_stop,
+                    logprobs=list(result.sampled_token_logprobs),
+                )
+                for result in results
+            ),
+            groups=tuple(result.group for result in results),
+            generation_seeds=tuple(
+                (
+                    seed * 1_000_003 + index
+                    if self.config.backend is RolloutBackendKind.HF_REFERENCE
+                    and self.config.samples_per_prompt == 1
+                    else derive_sample_seed(
+                        run_seed=seed,
+                        prompt_digest=result.group.prompt_digest,
+                        policy_version=policy_version,
+                        sample_index=result.group.sample_index,
+                    )
+                )
+                for index, result in enumerate(results)
+            ),
+            rollout_policy_identity_digest=policy_identity.digest,
             policy_version=policy_version,
             physical_batch_sizes=tuple(physical_sizes),
             oom_downshifts=downshifts,
@@ -287,12 +336,21 @@ class PromptDatasetRolloutRuntime:
             raise ValueError(
                 f"generated policy version {generated.policy_version} does not match {policy_version}"
             )
-        if len(generated.outputs) != len(batch.prompts):
-            raise ValueError("generated prompt count does not match the prepared batch")
+        if len(generated.outputs) != len(batch.groups):
+            raise ValueError("generated sample count does not match the prepared batch")
         trajectories: list[Trajectory] = []
         model_id = str(getattr(self.backend, "model_id", self.backend.capabilities.name))
         revision = getattr(self.backend, "model_revision", None)
-        for prompt, output in zip(batch.prompts, generated.outputs, strict=True):
+        for logical_index, (output, group, generation_seed) in enumerate(
+            zip(
+                generated.outputs,
+                generated.groups,
+                generated.generation_seeds,
+                strict=True,
+            )
+        ):
+            prompt_index = logical_index // self.config.samples_per_prompt
+            prompt = batch.prompts[prompt_index]
             prompt_ids = list(prompt.token_ids)
             response_ids = list(output.token_ids)
             if not response_ids:
@@ -301,9 +359,12 @@ class PromptDatasetRolloutRuntime:
                 )
             boundary = len(prompt_ids)
             token_ids = [*prompt_ids, *response_ids]
-            trajectory_id = hashlib.sha256(
-                f"{prompt.record.row_digest}:{policy_version}".encode("ascii")
-            ).hexdigest()
+            trajectory_id = derive_grouped_trajectory_id(
+                prompt_group_id=group.prompt_group_id,
+                sample_index=group.sample_index,
+                rollout_policy_identity_digest=generated.rollout_policy_identity_digest,
+                generation_seed=generation_seed,
+            )
             metadata = {
                 "source_kind": "verl_parquet",
                 "data_source": prompt.record.data_source,
@@ -333,6 +394,7 @@ class PromptDatasetRolloutRuntime:
                 metadata["actor_rollout_policy_version"] = policy_version
             trajectories.append(
                 Trajectory(
+                    schema_version=TRAJECTORY_SCHEMA_VERSION,
                     trajectory_id=trajectory_id,
                     task_id=prompt.record.row_digest,
                     environment="verl_parquet",
@@ -361,6 +423,13 @@ class PromptDatasetRolloutRuntime:
                     tokenizer_fingerprint=str(self.backend.tokenizer.fingerprint),
                     model_id=model_id,
                     model_revision=revision,
+                    prompt_group_id=group.prompt_group_id,
+                    prompt_digest=group.prompt_digest,
+                    sample_index=group.sample_index,
+                    samples_per_prompt=group.samples_per_prompt,
+                    generation_seed=generation_seed,
+                    rollout_backend=self.config.backend.value,
+                    rollout_policy_identity_digest=(generated.rollout_policy_identity_digest),
                     termination_reason=(
                         TerminationReason.EOS_WITHOUT_FINAL
                         if output.stop_reason == "eos"
@@ -371,6 +440,7 @@ class PromptDatasetRolloutRuntime:
                     metadata=metadata,
                 )
             )
+        validate_trajectory_groups(trajectories)
         return trajectories
 
     def close(self) -> None:

--- a/src/miniverl/schemas/cache.py
+++ b/src/miniverl/schemas/cache.py
@@ -22,8 +22,8 @@ __all__ = [
     "CacheCompressionStats",
 ]
 
-CACHE_SCHEMA_VERSION = 3
-READABLE_CACHE_SCHEMA_VERSIONS = frozenset({1, 2, CACHE_SCHEMA_VERSION})
+CACHE_SCHEMA_VERSION = 4
+READABLE_CACHE_SCHEMA_VERSIONS = frozenset({1, 2, 3, CACHE_SCHEMA_VERSION})
 
 
 class CacheEntryMeta(BaseModel):
@@ -84,6 +84,9 @@ class CacheIndex(BaseModel):
     estimator_implementation_version: str | None = None
     execution_plan_digest: str | None = None
     profile_identity: dict[str, Any] = Field(default_factory=dict)
+    samples_per_prompt: int = Field(default=1, ge=1)
+    trajectory_schema_version: int = Field(default=2, ge=1)
+    group_generation_seed_version: str = "miniverl-rollout-seed-v1"
     dtype: str = "float32"
     entries_per_shard: int = Field(default=32, ge=1, le=4096)
     entries: dict[str, CacheEntryMeta] = Field(default_factory=dict)

--- a/src/miniverl/schemas/trajectory.py
+++ b/src/miniverl/schemas/trajectory.py
@@ -22,6 +22,7 @@ output.
 
 from __future__ import annotations
 
+import hashlib
 from enum import Enum
 from typing import Any
 
@@ -39,13 +40,42 @@ __all__ = [
     "MODEL_GENERATED_SPAN_TYPES",
     "CRITICAL_SPAN_TYPES",
     "TRAJECTORY_SCHEMA_VERSION",
+    "derive_grouped_trajectory_id",
+    "validate_trajectory_groups",
 ]
 
 LEGACY_TRAJECTORY_SCHEMA_VERSION = 1
-TRAJECTORY_SCHEMA_VERSION = 2
+PRE_GROUP_TRAJECTORY_SCHEMA_VERSION = 2
+TRAJECTORY_SCHEMA_VERSION = 3
 READABLE_TRAJECTORY_SCHEMA_VERSIONS = frozenset(
-    {LEGACY_TRAJECTORY_SCHEMA_VERSION, TRAJECTORY_SCHEMA_VERSION}
+    {
+        LEGACY_TRAJECTORY_SCHEMA_VERSION,
+        PRE_GROUP_TRAJECTORY_SCHEMA_VERSION,
+        TRAJECTORY_SCHEMA_VERSION,
+    }
 )
+
+
+def derive_grouped_trajectory_id(
+    *,
+    prompt_group_id: str,
+    sample_index: int,
+    rollout_policy_identity_digest: str,
+    generation_seed: int,
+) -> str:
+    """Bind one trajectory ID to its logical group, sample, policy and seed."""
+
+    payload = (
+        f"miniverl-trajectory-v3\0{prompt_group_id}\0{sample_index}\0"
+        f"{rollout_policy_identity_digest}\0{generation_seed}"
+    ).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _is_sha256(value: str | None) -> bool:
+    return bool(
+        value and len(value) == 64 and all(character in "0123456789abcdef" for character in value)
+    )
 
 
 class SpanType(str, Enum):
@@ -187,7 +217,9 @@ class Trajectory(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: int = TRAJECTORY_SCHEMA_VERSION
+    # Keep direct construction backward compatible for downstream callers.
+    # Runtime writers explicitly upgrade new artifacts to the current schema.
+    schema_version: int = PRE_GROUP_TRAJECTORY_SCHEMA_VERSION
     trajectory_id: str
     task_id: str
     environment: str
@@ -203,6 +235,16 @@ class Trajectory(BaseModel):
     tokenizer_fingerprint: str
     model_id: str
     model_revision: str | None = None
+
+    # Schema-v3 rollout identity. Versions 1 and 2 remain readable with these
+    # fields absent; every new grouped-rollout writer emits version 3.
+    prompt_group_id: str | None = None
+    prompt_digest: str | None = None
+    sample_index: int | None = Field(default=None, ge=0)
+    samples_per_prompt: int | None = Field(default=None, ge=1)
+    generation_seed: int | None = Field(default=None, ge=0)
+    rollout_backend: str | None = None
+    rollout_policy_identity_digest: str | None = None
 
     verification: VerificationRecord | None = None
     termination_reason: TerminationReason
@@ -225,6 +267,46 @@ class Trajectory(BaseModel):
 
     @model_validator(mode="after")
     def _validate_structure(self) -> Trajectory:
+        if self.schema_version not in READABLE_TRAJECTORY_SCHEMA_VERSIONS:
+            raise ValueError(f"trajectory schema_version {self.schema_version!r} is not readable")
+        grouped = (
+            self.prompt_group_id,
+            self.prompt_digest,
+            self.sample_index,
+            self.samples_per_prompt,
+            self.generation_seed,
+            self.rollout_backend,
+            self.rollout_policy_identity_digest,
+        )
+        if self.schema_version >= TRAJECTORY_SCHEMA_VERSION:
+            if any(value is None or value == "" for value in grouped):
+                raise ValueError("trajectory schema v3 requires complete grouped rollout identity")
+            assert self.sample_index is not None
+            assert self.samples_per_prompt is not None
+            if self.sample_index >= self.samples_per_prompt:
+                raise ValueError("sample_index must be smaller than samples_per_prompt")
+            if not _is_sha256(self.prompt_digest):
+                raise ValueError("prompt_digest must be a lowercase SHA-256 digest")
+            if not _is_sha256(self.rollout_policy_identity_digest):
+                raise ValueError(
+                    "rollout_policy_identity_digest must be a lowercase SHA-256 digest"
+                )
+            assert self.prompt_group_id is not None
+            assert self.generation_seed is not None
+            assert self.rollout_policy_identity_digest is not None
+            expected_id = derive_grouped_trajectory_id(
+                prompt_group_id=self.prompt_group_id,
+                sample_index=self.sample_index,
+                rollout_policy_identity_digest=self.rollout_policy_identity_digest,
+                generation_seed=self.generation_seed,
+            )
+            if self.trajectory_id != expected_id:
+                raise ValueError(
+                    "trajectory_id must bind prompt group, sample, policy identity and seed"
+                )
+        elif any(value is not None for value in grouped):
+            raise ValueError("legacy trajectory schemas cannot contain schema-v3 grouped fields")
+
         n = len(self.token_ids)
         if n == 0:
             raise ValueError("trajectory has no tokens")
@@ -314,3 +396,41 @@ class Trajectory(BaseModel):
         for span in self.spans:
             counts[span.span_type.value] = counts.get(span.span_type.value, 0) + span.length
         return counts
+
+
+def validate_trajectory_groups(trajectories: list[Trajectory]) -> None:
+    """Reject incomplete, duplicated or internally inconsistent schema-v3 groups."""
+
+    if not trajectories:
+        raise ValueError("trajectory group collection cannot be empty")
+    groups: dict[str, list[Trajectory]] = {}
+    identities: set[tuple[str, int]] = set()
+    for trajectory in trajectories:
+        if trajectory.schema_version != TRAJECTORY_SCHEMA_VERSION:
+            raise ValueError("grouped rollout publication requires trajectory schema v3")
+        assert trajectory.prompt_group_id is not None
+        assert trajectory.sample_index is not None
+        identity = (trajectory.prompt_group_id, trajectory.sample_index)
+        if identity in identities:
+            raise ValueError("duplicate (prompt_group_id, sample_index) trajectory")
+        identities.add(identity)
+        groups.setdefault(trajectory.prompt_group_id, []).append(trajectory)
+
+    for group_id, members in groups.items():
+        expected_size = members[0].samples_per_prompt
+        prompt_digest = members[0].prompt_digest
+        policy_digest = members[0].rollout_policy_identity_digest
+        if expected_size is None:
+            raise ValueError(f"group {group_id!r} has no samples_per_prompt")
+        if len(members) != expected_size:
+            raise ValueError(
+                f"group {group_id!r} is incomplete: {len(members)} of {expected_size} samples"
+            )
+        if {member.samples_per_prompt for member in members} != {expected_size}:
+            raise ValueError(f"group {group_id!r} mixes samples_per_prompt values")
+        if {member.prompt_digest for member in members} != {prompt_digest}:
+            raise ValueError(f"group {group_id!r} mixes prompt digests")
+        if {member.rollout_policy_identity_digest for member in members} != {policy_digest}:
+            raise ValueError(f"group {group_id!r} mixes rollout policy identities")
+        if {member.sample_index for member in members} != set(range(expected_size)):
+            raise ValueError(f"group {group_id!r} does not contain sample indices 0..n-1")

--- a/src/miniverl/training/checkpoint.py
+++ b/src/miniverl/training/checkpoint.py
@@ -55,6 +55,14 @@ class CheckpointState:
     rollout_iteration: int | None = None
     rollout_policy_version: int | None = None
     task_cursor: int = 0
+    prompt_cursor: int | None = None
+    rollout_group_cursor: int = 0
+    trajectory_count: int = 0
+    samples_per_prompt: int = 1
+    group_generation_seed_version: str = "miniverl-rollout-seed-v1"
+    pending_group_identity: list[str] = field(default_factory=list)
+    committed_group_identity: list[str] = field(default_factory=list)
+    backend_sync_identity: str = ""
     scheduler: dict[str, Any] = field(default_factory=dict)
     scaler: dict[str, Any] | None = None
     optimizer_param_groups: list[dict[str, Any]] = field(default_factory=list)
@@ -88,6 +96,16 @@ class CheckpointState:
                 else self.rollout_policy_version
             ),
             "task_cursor": self.task_cursor,
+            "prompt_cursor": (
+                self.task_cursor if self.prompt_cursor is None else self.prompt_cursor
+            ),
+            "rollout_group_cursor": self.rollout_group_cursor,
+            "trajectory_count": self.trajectory_count,
+            "samples_per_prompt": self.samples_per_prompt,
+            "group_generation_seed_version": self.group_generation_seed_version,
+            "pending_group_identity": self.pending_group_identity,
+            "committed_group_identity": self.committed_group_identity,
+            "backend_sync_identity": self.backend_sync_identity,
             "scheduler": self.scheduler,
             "scaler": self.scaler,
             "optimizer_param_groups": self.optimizer_param_groups,
@@ -312,6 +330,16 @@ def save_checkpoint(
                 if state.rollout_policy_version is None
                 else state.rollout_policy_version
             ),
+            "prompt_cursor": (
+                state.task_cursor if state.prompt_cursor is None else state.prompt_cursor
+            ),
+            "rollout_group_cursor": state.rollout_group_cursor,
+            "trajectory_count": state.trajectory_count,
+            "samples_per_prompt": state.samples_per_prompt,
+            "group_generation_seed_version": state.group_generation_seed_version,
+            "pending_group_identity": state.pending_group_identity,
+            "committed_group_identity": state.committed_group_identity,
+            "backend_sync_identity": state.backend_sync_identity,
             "config_digest": state.config_digest,
             "resolved_config_digest": state.resolved_config_digest,
             "offline_dataset_digest": state.offline_dataset_digest,
@@ -416,6 +444,19 @@ def validate_checkpoint(directory: str | Path) -> ValidatedCheckpoint:
         raise CheckpointError("checkpoint manifest and state disagree on global_step")
     if manifest.get("policy_version") != state.policy_version:
         raise CheckpointError("checkpoint manifest and state disagree on policy_version")
+    for field_name in (
+        "prompt_cursor",
+        "rollout_group_cursor",
+        "trajectory_count",
+        "samples_per_prompt",
+        "group_generation_seed_version",
+        "pending_group_identity",
+        "committed_group_identity",
+        "backend_sync_identity",
+    ):
+        expected = state.to_dict()[field_name]
+        if manifest.get(field_name, expected) != expected:
+            raise CheckpointError(f"checkpoint manifest and state disagree on {field_name}")
     parameter_version = (
         state.policy_version if state.parameter_version is None else state.parameter_version
     )

--- a/src/miniverl/training/trainer.py
+++ b/src/miniverl/training/trainer.py
@@ -69,7 +69,7 @@ from miniverl.models.factory import (
     resolve_device,
 )
 from miniverl.schemas.alignment import AlignmentMap
-from miniverl.schemas.trajectory import Trajectory
+from miniverl.schemas.trajectory import TRAJECTORY_SCHEMA_VERSION, Trajectory
 from miniverl.selection.selectors import (
     SelectionResult,
     SelectionStats,
@@ -86,7 +86,7 @@ from miniverl.training.memory import (
 )
 from miniverl.training.optim import LearningRateSchedule, build_optimizer
 from miniverl.trajectory.alignment import build_alignment_map
-from miniverl.trajectory.io import append_trajectories
+from miniverl.trajectory.io import append_trajectories, append_trajectory_groups
 from miniverl.utils import gpu
 from miniverl.utils.env import collect_environment
 from miniverl.utils.locking import RunLock
@@ -301,6 +301,12 @@ class OPDTrainer:
         self._last_cycle_metrics: dict[str, Any] = {}
         self._last_selection_stats: list[SelectionStats] = []
         self._last_rollout_execution: dict[str, Any] | None = None
+        self._rollout_group_cursor = 0
+        self._trajectory_count = 0
+        self._committed_task_cursor = 0
+        self._pending_group_identity: list[str] = []
+        self._committed_group_identity: list[str] = []
+        self._backend_sync_identity = ""
 
     # -- construction --------------------------------------------------------
 
@@ -309,7 +315,12 @@ class OPDTrainer:
         """Optimizer steps performed per training cycle."""
         accum = self.config.train.gradient_accumulation_steps
         rollouts = self.config.train.rollouts_per_cycle
-        return max(1, (rollouts + accum - 1) // accum)
+        trajectories = (
+            rollouts * self.config.rollout.samples_per_prompt
+            if self.config.source.kind is SourceKind.VERL_PARQUET
+            else rollouts
+        )
+        return max(1, (trajectories + accum - 1) // accum)
 
     @property
     def state(self) -> TrainerState:
@@ -351,6 +362,14 @@ class OPDTrainer:
             else state.rollout_policy_version
         )
         self.task_cursor = state.task_cursor
+        self._committed_task_cursor = (
+            state.task_cursor if state.prompt_cursor is None else state.prompt_cursor
+        )
+        self._rollout_group_cursor = state.rollout_group_cursor
+        self._trajectory_count = state.trajectory_count
+        self._pending_group_identity = list(state.pending_group_identity)
+        self._committed_group_identity = list(state.committed_group_identity)
+        self._backend_sync_identity = state.backend_sync_identity
         self._cycles_completed = (
             max(state.cycle + 1, 0) if state.rollout_iteration is None else state.rollout_iteration
         )
@@ -1171,30 +1190,68 @@ class OPDTrainer:
         if self.prompt_dataset is not None:
             if oracle:
                 raise ConfigError("Parquet prompt rollouts have no oracle trajectory source")
+            prompt_cursor_before = self.task_cursor - len(tasks)
+            group_cursor_before = self._rollout_group_cursor
             seed = (
                 rollout_seed_base
                 if rollout_seed_base is not None
                 else self.config.run.seed + self.global_step * 1013
             )
-            prepared = self.rollout_runtime.prepare_batch(tasks)
-            generated = self.rollout_runtime.generate(
-                prepared,
-                policy_version=self.policy_version,
-                seed=seed,
-            )
-            self._last_rollout_execution = {
-                "physical_batch_sizes": list(generated.physical_batch_sizes),
-                "oom_downshifts": generated.oom_downshifts,
-            }
-            trajectories = self.rollout_runtime.to_trajectories(
-                prepared,
-                generated,
-                policy_version=self.policy_version,
-            )
-            for offset, trajectory in enumerate(trajectories):
-                trajectory.metadata["generation_seed"] = seed * 1_000_003 + offset
+            try:
+                prepared = self.rollout_runtime.prepare_batch(
+                    tasks,
+                    group_cursor=group_cursor_before,
+                )
+                self._pending_group_identity = sorted(
+                    {group.prompt_group_id for group in prepared.groups}
+                )
+                generated = self.rollout_runtime.generate(
+                    prepared,
+                    policy_version=self.policy_version,
+                    seed=seed,
+                )
+                self._backend_sync_identity = generated.rollout_policy_identity_digest
+                self._last_rollout_execution = {
+                    "physical_batch_sizes": list(generated.physical_batch_sizes),
+                    "physical_generation_batches": len(generated.physical_batch_sizes),
+                    "oom_downshifts": generated.oom_downshifts,
+                }
+                trajectories = self.rollout_runtime.to_trajectories(
+                    prepared,
+                    generated,
+                    policy_version=self.policy_version,
+                )
+                transaction_id = hashlib.sha256(
+                    (
+                        f"{self.run_id}:{self.cycle}:{group_cursor_before}:"
+                        f"{generated.rollout_policy_identity_digest}"
+                    ).encode()
+                ).hexdigest()
+                append_trajectory_groups(
+                    self.paths.trajectories,
+                    trajectories,
+                    transaction_id=transaction_id,
+                )
+            except BaseException as exc:
+                self.task_cursor = prompt_cursor_before
+                self._prompt_train_iterator = None
+                self._pending_group_identity = []
+                if isinstance(exc, KeyboardInterrupt):
+                    try:
+                        self._save_checkpoint_impl(name="interrupted-group")
+                    except BaseException as checkpoint_error:
+                        logger.warning(
+                            "could not save the rolled-back interruption checkpoint: %s",
+                            checkpoint_error,
+                        )
+                raise
+            self._committed_group_identity = list(self._pending_group_identity)
+            self._pending_group_identity = []
+            self._rollout_group_cursor += len(tasks)
+            self._trajectory_count += len(trajectories)
+            self._committed_task_cursor = self.task_cursor
+            for trajectory in trajectories:
                 stats.observe(trajectory)
-            append_trajectories(self.paths.trajectories, trajectories)
             return trajectories, stats
         assert self.runner is not None
         for offset, task in enumerate(tasks):
@@ -1219,6 +1276,8 @@ class OPDTrainer:
             trajectories.append(traj)
             stats.observe(traj)
         append_trajectories(self.paths.trajectories, trajectories)
+        self._trajectory_count += len(trajectories)
+        self._committed_task_cursor = self.task_cursor
         return trajectories, stats
 
     def _open_cache(self) -> TeacherCache:
@@ -1265,6 +1324,11 @@ class OPDTrainer:
                 ),
                 "execution_plan_digest": self.config.run.execution_plan_digest,
                 "profile_identity": self.config.run.profile_identity,
+                "samples_per_prompt": self.config.rollout.samples_per_prompt,
+                "trajectory_schema_version": (
+                    TRAJECTORY_SCHEMA_VERSION if self.prompt_dataset is not None else 2
+                ),
+                "group_generation_seed_version": "miniverl-rollout-seed-v1",
                 "dtype": self.config.cache.dtype,
             }
             if (path / "index.json").is_file():
@@ -2329,6 +2393,7 @@ class OPDTrainer:
         self._last_rollout_execution = None
         rollout_seconds = 0.0
         teacher_scoring_seconds = 0.0
+        trajectories: list[Trajectory] = []
 
         if mode is TrainingMode.OFFLINE_KD and self._offline_samples is not None:
             samples = self._offline_batch_for_cycle()
@@ -2407,6 +2472,7 @@ class OPDTrainer:
                 rollout_tokens_per_second=round(stats.generated_tokens / rollout_seconds, 2),
                 rollout_seconds=round(rollout_seconds, 4),
                 teacher_scoring_seconds=round(teacher_scoring_seconds, 4),
+                grouped_rollouts=self._group_rollout_metrics(trajectories),
             )
             if mode is TrainingMode.OFFLINE_KD:
                 self._offline_samples = samples
@@ -2481,6 +2547,7 @@ class OPDTrainer:
                         else None
                     ),
                     "rollout_execution": self._last_rollout_execution,
+                    "grouped_rollouts": self._group_rollout_metrics(trajectories),
                 }
             )
         if self._cache is not None:
@@ -2501,6 +2568,39 @@ class OPDTrainer:
         # train() calls resume at the next iteration.
         self._cycles_completed = max(self._cycles_completed, self.cycle + 1)
         return records
+
+    def _group_rollout_metrics(self, trajectories: list[Trajectory]) -> dict[str, Any]:
+        """Describe logical prompt groups separately from physical batches."""
+
+        grouped: dict[str, list[Trajectory]] = {}
+        for trajectory in trajectories:
+            group_id = trajectory.prompt_group_id or trajectory.task_id
+            grouped.setdefault(group_id, []).append(trajectory)
+        reward_variances: dict[str, float] = {}
+        for group_id, members in grouped.items():
+            rewards = [
+                float(member.verification.reward)
+                for member in members
+                if member.verification is not None
+            ]
+            if len(rewards) == len(members) and rewards:
+                mean = sum(rewards) / len(rewards)
+                reward_variances[group_id] = sum((value - mean) ** 2 for value in rewards) / len(
+                    rewards
+                )
+        execution = self._last_rollout_execution or {}
+        return {
+            "unique_prompts": len(grouped),
+            "groups": len(grouped),
+            "samples_per_prompt": self.config.rollout.samples_per_prompt,
+            "trajectories": len(trajectories),
+            "generated_tokens": sum(item.generated_token_count for item in trajectories),
+            "per_group_reward_variance": {
+                "status": "measured" if reward_variances else "not_applicable",
+                "values": reward_variances,
+            },
+            "physical_generation_batches": int(execution.get("physical_generation_batches", 0)),
+        }
 
     def _write_token_analysis(self, samples: list[TrainSample]) -> int:
         """Persist per-token divergence data for the report's token view.
@@ -2871,7 +2971,7 @@ class OPDTrainer:
             backend=self.student,
             source_config=config.source,
             rollout_config=config.rollout.model_copy(
-                update={"temperature": config.eval.temperature}
+                update={"temperature": config.eval.temperature, "samples_per_prompt": 1}
             ),
             profile_identity=config.run.profile_identity,
             execution_plan_digest=config.run.execution_plan_digest,
@@ -2992,7 +3092,19 @@ class OPDTrainer:
             cycle=self.cycle,
             rollout_iteration=self._cycles_completed,
             rollout_policy_version=self._last_rollout_policy_version,
-            task_cursor=self.task_cursor,
+            task_cursor=(
+                self._committed_task_cursor if self.prompt_dataset is not None else self.task_cursor
+            ),
+            prompt_cursor=(
+                self._committed_task_cursor if self.prompt_dataset is not None else self.task_cursor
+            ),
+            rollout_group_cursor=self._rollout_group_cursor,
+            trajectory_count=self._trajectory_count,
+            samples_per_prompt=self.config.rollout.samples_per_prompt,
+            group_generation_seed_version="miniverl-rollout-seed-v1",
+            pending_group_identity=list(self._pending_group_identity),
+            committed_group_identity=list(self._committed_group_identity),
+            backend_sync_identity=self._backend_sync_identity,
             scheduler=self.schedule.state_dict(),
             config_digest=self._config_digest(),
             resolved_config_digest=self._resolved_config_digest(),
@@ -3044,6 +3156,17 @@ class OPDTrainer:
                 "the checkpoint was written by a different configuration",
                 hint="resume with the run's config.original.yaml compatibility layer, "
                 "not config.resolved.yaml or a modified recipe",
+            )
+        if validated.state.samples_per_prompt != self.config.rollout.samples_per_prompt:
+            raise ConfigError(
+                "checkpoint samples_per_prompt does not match the current rollout plan"
+            )
+        if validated.state.group_generation_seed_version != "miniverl-rollout-seed-v1":
+            raise ConfigError("checkpoint uses an unsupported group generation seed version")
+        if validated.state.pending_group_identity:
+            raise ConfigError(
+                "checkpoint contains a pending partial rollout group",
+                hint="recover the trajectory transaction before resuming training",
             )
         identity = self._checkpoint_identity()
         if validated.identity:

--- a/src/miniverl/trajectory/io.py
+++ b/src/miniverl/trajectory/io.py
@@ -7,7 +7,9 @@ it must never execute anything.
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 from collections.abc import Iterable, Iterator
 from pathlib import Path
 
@@ -16,10 +18,102 @@ from pydantic import ValidationError
 from miniverl.errors import SchemaValidationError
 from miniverl.schemas.trajectory import (
     READABLE_TRAJECTORY_SCHEMA_VERSIONS,
+    TRAJECTORY_SCHEMA_VERSION,
     Trajectory,
+    derive_grouped_trajectory_id,
+    validate_trajectory_groups,
 )
+from miniverl.utils.runs import write_json_atomic
 
-__all__ = ["write_trajectories", "read_trajectories", "iter_trajectories", "count_trajectories"]
+__all__ = [
+    "append_trajectory_groups",
+    "append_trajectories",
+    "count_trajectories",
+    "iter_trajectories",
+    "read_trajectories",
+    "write_trajectories",
+]
+
+
+def _serialize_trajectory(traj: Trajectory) -> str:
+    try:
+        return json.dumps(
+            traj.model_dump(mode="json"),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+    except (OverflowError, RecursionError, TypeError, ValueError) as exc:
+        raise SchemaValidationError(
+            f"trajectory {traj.trajectory_id!r} is not finite JSON: {exc}"
+        ) from exc
+
+
+def _upgrade_for_write(traj: Trajectory) -> Trajectory:
+    """Upgrade an in-memory v1/v2 trajectory to the canonical n=1 v3 form."""
+
+    if traj.schema_version == TRAJECTORY_SCHEMA_VERSION:
+        return traj
+    legacy_id = traj.trajectory_id
+    prompt_payload = {
+        "task_id": traj.task_id,
+        "environment": traj.environment,
+        "prompt_token_ids": [
+            token_id
+            for token_id, generated in zip(
+                traj.token_ids,
+                traj.model_generated_mask,
+                strict=True,
+            )
+            if not generated
+        ],
+    }
+    prompt_digest = hashlib.sha256(
+        json.dumps(prompt_payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    policy_payload = {
+        "model_id": traj.model_id,
+        "model_revision": traj.model_revision,
+        "policy_version": traj.policy_version,
+        "tokenizer_fingerprint": traj.tokenizer_fingerprint,
+    }
+    policy_digest = hashlib.sha256(
+        json.dumps(policy_payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    raw_seed = traj.metadata.get("generation_seed", traj.metadata.get("seed", 0))
+    generation_seed = raw_seed if isinstance(raw_seed, int) and raw_seed >= 0 else 0
+    group_digest = hashlib.sha256(
+        f"{traj.environment}\0{traj.task_id}\0{legacy_id}\0{prompt_digest}".encode()
+    ).hexdigest()
+    prompt_group_id = f"n1-{group_digest[:24]}"
+    rollout_backend = traj.metadata.get("rollout_backend", "environment_direct")
+    if not isinstance(rollout_backend, str) or not rollout_backend:
+        rollout_backend = "environment_direct"
+    metadata = dict(traj.metadata)
+    metadata.setdefault("legacy_trajectory_id", legacy_id)
+    payload = traj.model_dump(mode="json")
+    payload.update(
+        {
+            "schema_version": TRAJECTORY_SCHEMA_VERSION,
+            "trajectory_id": derive_grouped_trajectory_id(
+                prompt_group_id=prompt_group_id,
+                sample_index=0,
+                rollout_policy_identity_digest=policy_digest,
+                generation_seed=generation_seed,
+            ),
+            "prompt_group_id": prompt_group_id,
+            "prompt_digest": prompt_digest,
+            "sample_index": 0,
+            "samples_per_prompt": 1,
+            "generation_seed": generation_seed,
+            "rollout_backend": rollout_backend,
+            "rollout_policy_identity_digest": policy_digest,
+            "metadata": metadata,
+        }
+    )
+    upgraded = Trajectory.model_validate(payload)
+    for field_name in Trajectory.model_fields:
+        setattr(traj, field_name, getattr(upgraded, field_name))
+    return traj
 
 
 def write_trajectories(path: str | Path, trajectories: Iterable[Trajectory]) -> int:
@@ -29,16 +123,8 @@ def write_trajectories(path: str | Path, trajectories: Iterable[Trajectory]) -> 
     written = 0
     with p.open("w", encoding="utf-8", newline="\n") as fh:
         for traj in trajectories:
-            try:
-                serialized = json.dumps(
-                    traj.model_dump(mode="json"),
-                    ensure_ascii=False,
-                    allow_nan=False,
-                )
-            except (OverflowError, RecursionError, TypeError, ValueError) as exc:
-                raise SchemaValidationError(
-                    f"trajectory {traj.trajectory_id!r} is not finite JSON: {exc}"
-                ) from exc
+            traj = _upgrade_for_write(traj)
+            serialized = _serialize_trajectory(traj)
             fh.write(serialized)
             fh.write("\n")
             written += 1
@@ -52,20 +138,138 @@ def append_trajectories(path: str | Path, trajectories: Iterable[Trajectory]) ->
     written = 0
     with p.open("a", encoding="utf-8", newline="\n") as fh:
         for traj in trajectories:
-            try:
-                serialized = json.dumps(
-                    traj.model_dump(mode="json"),
-                    ensure_ascii=False,
-                    allow_nan=False,
-                )
-            except (OverflowError, RecursionError, TypeError, ValueError) as exc:
-                raise SchemaValidationError(
-                    f"trajectory {traj.trajectory_id!r} is not finite JSON: {exc}"
-                ) from exc
+            traj = _upgrade_for_write(traj)
+            serialized = _serialize_trajectory(traj)
             fh.write(serialized)
             fh.write("\n")
             written += 1
     return written
+
+
+def _group_journal(path: Path) -> Path:
+    return path.with_name(f".{path.name}.group-transaction.json")
+
+
+def _recover_group_append(path: Path) -> None:
+    journal = _group_journal(path)
+    if not journal.is_file():
+        return
+    try:
+        payload = json.loads(journal.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError, TypeError) as exc:
+        raise SchemaValidationError(f"cannot recover trajectory group journal: {exc}") from exc
+    status = payload.get("status")
+    if status == "pending":
+        start_offset = payload.get("start_offset")
+        if not isinstance(start_offset, int) or start_offset < 0:
+            raise SchemaValidationError("trajectory group journal has an invalid start_offset")
+        if path.exists():
+            with path.open("r+b") as handle:
+                if handle.seek(0, os.SEEK_END) < start_offset:
+                    raise SchemaValidationError(
+                        "trajectory file is shorter than its pending group transaction"
+                    )
+                handle.truncate(start_offset)
+                handle.flush()
+                os.fsync(handle.fileno())
+    elif status != "committed":
+        raise SchemaValidationError("trajectory group journal has an unknown status")
+    journal.unlink()
+
+
+def append_trajectory_groups(
+    path: str | Path,
+    trajectories: Iterable[Trajectory],
+    *,
+    transaction_id: str,
+) -> int:
+    """Atomically append one or more complete schema-v3 prompt groups.
+
+    The sibling journal is published before data bytes. A process crash before
+    the committed journal is published is repaired by truncating back to the
+    recorded byte offset on the next call. All logical groups supplied here
+    therefore become visible together or not at all.
+    """
+
+    if not transaction_id:
+        raise ValueError("transaction_id cannot be empty")
+    rows = list(trajectories)
+    validate_trajectory_groups(rows)
+    if any(row.schema_version != TRAJECTORY_SCHEMA_VERSION for row in rows):
+        raise ValueError("transactional group writer only publishes the current schema")
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    _recover_group_append(p)
+    requested = {row.trajectory_id: row for row in rows}
+    existing: dict[str, Trajectory] = {}
+    if p.is_file():
+        for row in iter_trajectories(p):
+            if row.trajectory_id not in requested:
+                continue
+            if row.trajectory_id in existing:
+                raise SchemaValidationError(
+                    f"trajectory file already contains duplicate id {row.trajectory_id!r}"
+                )
+            existing[row.trajectory_id] = row
+    if existing:
+        if set(existing) != set(requested):
+            raise ValueError(
+                "transactional trajectory group is partially present; refusing to append "
+                "a mixed committed/uncommitted replay"
+            )
+        mismatched = [
+            trajectory_id
+            for trajectory_id, row in requested.items()
+            if existing[trajectory_id].model_dump(mode="json") != row.model_dump(mode="json")
+        ]
+        if mismatched:
+            raise SchemaValidationError(
+                "committed trajectory replay changed payload for " + ", ".join(sorted(mismatched))
+            )
+        return 0
+    encoded = "".join(f"{_serialize_trajectory(row)}\n" for row in rows).encode("utf-8")
+    start_offset = p.stat().st_size if p.exists() else 0
+    journal = _group_journal(p)
+    groups = sorted({str(row.prompt_group_id) for row in rows})
+    write_json_atomic(
+        journal,
+        {
+            "schema_version": 1,
+            "status": "pending",
+            "transaction_id": transaction_id,
+            "start_offset": start_offset,
+            "groups": groups,
+            "trajectories": len(rows),
+        },
+    )
+    try:
+        with p.open("ab") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        end_offset = start_offset + len(encoded)
+        write_json_atomic(
+            journal,
+            {
+                "schema_version": 1,
+                "status": "committed",
+                "transaction_id": transaction_id,
+                "start_offset": start_offset,
+                "end_offset": end_offset,
+                "groups": groups,
+                "trajectories": len(rows),
+            },
+        )
+    except BaseException:
+        if p.exists():
+            with p.open("r+b") as handle:
+                handle.truncate(start_offset)
+                handle.flush()
+                os.fsync(handle.fileno())
+        journal.unlink(missing_ok=True)
+        raise
+    journal.unlink()
+    return len(rows)
 
 
 def iter_trajectories(path: str | Path) -> Iterator[Trajectory]:

--- a/tests/integration/test_grouped_rollout_resume.py
+++ b/tests/integration/test_grouped_rollout_resume.py
@@ -1,0 +1,190 @@
+"""Matched interruption/resume for transactional n>1 prompt groups."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from tests.conftest import requires_torch
+
+pytestmark = [requires_torch, pytest.mark.torch]
+
+
+def _config(tmp_path: Path, train: Path):  # type: ignore[no-untyped-def]
+    from miniverl.config import RunConfig
+
+    return RunConfig.model_validate(
+        {
+            "run": {
+                "name": "grouped-resume",
+                "mode": "opd",
+                "seed": 117,
+                "output_dir": str(tmp_path / "runs"),
+                "execution_plan_digest": "d" * 64,
+            },
+            "models": {
+                "backend": "toy",
+                "device": "cpu",
+                "student": {
+                    "model_id": "toy-student",
+                    "lora": {"enabled": False},
+                    "toy": {
+                        "hidden_size": 16,
+                        "num_layers": 1,
+                        "num_heads": 2,
+                        "intermediate_size": 32,
+                        "max_position_embeddings": 128,
+                    },
+                },
+                "teacher": {
+                    "model_id": "toy-teacher",
+                    "toy_pretrain_steps": 0,
+                    "toy": {
+                        "hidden_size": 16,
+                        "num_layers": 1,
+                        "num_heads": 2,
+                        "intermediate_size": 32,
+                        "max_position_embeddings": 128,
+                    },
+                },
+            },
+            "source": {
+                "kind": "verl_parquet",
+                "train_files": [str(train)],
+                "allow_plain_string_prompts": True,
+                "max_prompt_length": 32,
+                "shuffle": False,
+            },
+            "rollout": {
+                "backend": "hf_cached",
+                "samples_per_prompt": 4,
+                "max_turns": 1,
+                "max_new_tokens_per_turn": 3,
+                "max_total_tokens": 64,
+                "temperature": 0.8,
+                "prompt_batch_size": 2,
+                "max_padded_tokens": 128,
+                "record_logprobs": True,
+            },
+            "selection": {"selector": "all_model_tokens"},
+            "loss": {
+                "mode": "forward_kl_topk",
+                "divergence": "forward_kl",
+                "aggregation": "token-mean",
+                "temperature": 1.0,
+                "scale_by_temperature_squared": False,
+                "top_k": 4,
+                "log_prob_min_clamp": -10.0,
+                "chunk_size": 16,
+            },
+            "train": {
+                "cycles": 2,
+                "rollouts_per_cycle": 2,
+                "gradient_accumulation_steps": 2,
+                "learning_rate": 0.001,
+            },
+            "memory": {"strategy": "resident"},
+            "cache": {"entries_per_shard": 4, "dtype": "float32", "keep_cycles": 2},
+            "eval": {"enabled": False},
+            "report": {"enabled": False},
+        }
+    )
+
+
+def _trajectory_payloads(run_dir: Path) -> list[dict]:
+    return [
+        json.loads(line)
+        for line in (run_dir / "trajectories.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+
+
+def _cache_tensors(run_dir: Path):  # type: ignore[no-untyped-def]
+    from safetensors.torch import load_file
+
+    cache = run_dir / "teacher-cache"
+    return {
+        shard.name: load_file(str(shard)) for shard in sorted(cache.glob("shard-*.safetensors"))
+    }
+
+
+def test_interrupted_group_resume_matches_uninterrupted_run_exactly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from miniverl.trainer import OPDTrainer
+
+    train = tmp_path / "train.parquet"
+    pq.write_table(
+        pa.Table.from_pylist(
+            [
+                {"prompt": "alpha", "data_source": "unit"},
+                {"prompt": "beta", "data_source": "unit"},
+            ]
+        ),
+        train,
+        row_group_size=1,
+    )
+    config = _config(tmp_path, train)
+
+    reference = OPDTrainer.from_config(config, run_id="group-reference")
+    try:
+        reference_result = reference.train()
+    finally:
+        reference.close()
+
+    interrupted = OPDTrainer.from_config(config, run_id="group-interrupted")
+    original_generate = interrupted.student.generate_batch_cached
+    calls = 0
+
+    def interrupt_second_batch(prefixes, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise KeyboardInterrupt
+        return original_generate(prefixes, **kwargs)
+
+    monkeypatch.setattr(interrupted.student, "generate_batch_cached", interrupt_second_batch)
+    interrupted_root = interrupted.paths.root
+    with pytest.raises(KeyboardInterrupt):
+        interrupted.train()
+    interruption_state = json.loads(
+        (interrupted_root / "checkpoints" / "interrupted-group" / "state.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert interruption_state["prompt_cursor"] == 0
+    assert interruption_state["rollout_group_cursor"] == 0
+    assert interruption_state["trajectory_count"] == 0
+    assert interruption_state["pending_group_identity"] == []
+    interrupted.close()
+
+    resumed = OPDTrainer.from_config(config, resume=interrupted_root)
+    try:
+        resumed_result = resumed.train()
+    finally:
+        resumed.close()
+
+    reference_rows = _trajectory_payloads(reference_result.run_dir)
+    resumed_rows = _trajectory_payloads(resumed_result.run_dir)
+    assert resumed_rows == reference_rows
+    identities = [(row["prompt_group_id"], row["sample_index"]) for row in resumed_rows]
+    assert len(identities) == len(set(identities)) == 16
+    assert resumed_result.global_step == reference_result.global_step == 8
+    assert resumed_result.policy_version == reference_result.policy_version == 8
+
+    reference_cache = _cache_tensors(reference_result.run_dir)
+    resumed_cache = _cache_tensors(resumed_result.run_dir)
+    assert reference_cache.keys() == resumed_cache.keys()
+    for shard_name, reference_tensors in reference_cache.items():
+        assert reference_tensors.keys() == resumed_cache[shard_name].keys()
+        for tensor_name, reference_tensor in reference_tensors.items():
+            assert reference_tensor.equal(resumed_cache[shard_name][tensor_name])
+
+    for filename in ("adapter.safetensors", "optimizer.safetensors"):
+        assert (reference_result.run_dir / "checkpoints" / "final" / filename).read_bytes() == (
+            resumed_result.run_dir / "checkpoints" / "final" / filename
+        ).read_bytes()

--- a/tests/integration/test_prompt_opd_pipeline.py
+++ b/tests/integration/test_prompt_opd_pipeline.py
@@ -41,7 +41,7 @@ def test_prompt_resume_reconstructs_the_dataset_cursor(monkeypatch) -> None:
     assert trainer.task_cursor == 10
 
 
-def test_prompt_opd_trains_without_an_environment_or_reward(tmp_path) -> None:
+def test_prompt_opd_trains_n4_as_independent_trajectories(tmp_path) -> None:
     from miniverl.config import RunConfig
     from miniverl.trainer import OPDTrainer
 
@@ -115,6 +115,7 @@ def test_prompt_opd_trains_without_an_environment_or_reward(tmp_path) -> None:
                 "temperature": 0.0,
                 "prompt_batch_size": 2,
                 "max_padded_tokens": 128,
+                "samples_per_prompt": 4,
             },
             "selection": {"selector": "all_model_tokens"},
             "loss": {
@@ -146,8 +147,8 @@ def test_prompt_opd_trains_without_an_environment_or_reward(tmp_path) -> None:
     finally:
         trainer.close()
 
-    assert result.global_step == 1
-    assert result.policy_version == 1
+    assert result.global_step == 4
+    assert result.policy_version == 4
     manifest = json.loads((result.run_dir / "manifest.json").read_text(encoding="utf-8"))
     assert manifest["source"]["kind"] == "verl_parquet"
     assert manifest["execution_plan_digest"] == "a" * 64
@@ -166,7 +167,11 @@ def test_prompt_opd_trains_without_an_environment_or_reward(tmp_path) -> None:
         json.loads(line)
         for line in (result.run_dir / "trajectories.jsonl").read_text(encoding="utf-8").splitlines()
     ]
-    assert len(rows) == 2
+    assert len(rows) == 8
+    assert {(row["prompt_group_id"], row["sample_index"]) for row in rows} == {
+        (group, sample) for group in {row["prompt_group_id"] for row in rows} for sample in range(4)
+    }
+    assert {row["samples_per_prompt"] for row in rows} == {4}
     assert all(
         not any(row["model_generated_mask"][: row["metadata"]["prompt_token_count"]])
         for row in rows
@@ -179,8 +184,18 @@ def test_prompt_opd_trains_without_an_environment_or_reward(tmp_path) -> None:
     update = next(row for row in metrics if row.get("phase") == "opd")
     cycle = next(row for row in metrics if row.get("phase") == "opd_cycle")
     assert cycle["rollout_execution"] == {
-        "physical_batch_sizes": [2],
+        "physical_batch_sizes": [2, 2, 2, 2],
+        "physical_generation_batches": 4,
         "oom_downshifts": 0,
+    }
+    assert cycle["grouped_rollouts"] == {
+        "unique_prompts": 2,
+        "groups": 2,
+        "samples_per_prompt": 4,
+        "trajectories": 8,
+        "generated_tokens": sum(row["generated_token_count"] for row in rows),
+        "per_group_reward_variance": {"status": "not_applicable", "values": {}},
+        "physical_generation_batches": 4,
     }
     assert update["loss_aggregation"] == "token-mean"
     assert set(update["verl_forward_kl_topk"]) == {

--- a/tests/unit/test_inspection_reporting.py
+++ b/tests/unit/test_inspection_reporting.py
@@ -45,7 +45,7 @@ from miniverl.schemas.trajectory import (
     Turn,
     VerificationRecord,
 )
-from miniverl.trajectory.io import write_trajectories
+from miniverl.trajectory.io import read_trajectories, write_trajectories
 from miniverl.trajectory.masks import build_masks
 from miniverl.utils.runs import RunPaths, write_json
 
@@ -422,15 +422,30 @@ def synthetic_run(tmp_path: Path) -> Path:
     )
     _write_jsonl(root / "metrics.jsonl", _metrics())
     _write_jsonl(root / "events.jsonl", _events())
-    _write_jsonl(root / "token_analysis.jsonl", _token_analysis())
-    written = write_trajectories(root / "trajectories.jsonl", _trajectories())
+    trajectories = _trajectories()
+    written = write_trajectories(root / "trajectories.jsonl", trajectories)
     assert written == 3
+    ids = {
+        str(trajectory.metadata["legacy_trajectory_id"]): trajectory.trajectory_id
+        for trajectory in trajectories
+    }
+    token_analysis = _token_analysis()
+    for record in token_analysis:
+        record["trajectory_id"] = ids[str(record["trajectory_id"])]
+    _write_jsonl(root / "token_analysis.jsonl", token_analysis)
     return root
 
 
 @pytest.fixture
 def trajectory_file(synthetic_run: Path) -> Path:
     return synthetic_run / "trajectories.jsonl"
+
+
+def _stored_ids(path: Path) -> dict[str, str]:
+    return {
+        str(trajectory.metadata["legacy_trajectory_id"]): trajectory.trajectory_id
+        for trajectory in read_trajectories(path)
+    }
 
 
 @pytest.fixture
@@ -496,9 +511,11 @@ def test_summarize_file_tools_used_excludes_invalid_calls(trajectory_file: Path)
     # traj-1's only call is a parse failure, so "search" was never really used.
     assert summary.tools_used == {"calculator": 2}
     invalid = [s for s in summary.samples if s.invalid_tool_calls]
-    assert [s.trajectory_id for s in invalid] == ["traj-1"]
+    ids = _stored_ids(trajectory_file)
+    assert [s.trajectory_id for s in invalid] == [ids["traj-1"]]
     assert all(
-        s.valid_tool_calls == (0 if s.trajectory_id == "traj-1" else 1) for s in summary.samples
+        s.valid_tool_calls == (0 if s.trajectory_id == ids["traj-1"] else 1)
+        for s in summary.samples
     )
 
 
@@ -519,10 +536,11 @@ def test_provenance_check_never_calls_context_spans_trainable(trajectory_file: P
 
 
 def test_summarize_file_filters_by_trajectory_id(trajectory_file: Path) -> None:
-    summary = summarize_file(trajectory_file, trajectory_id="traj-1")
+    trajectory_id = _stored_ids(trajectory_file)["traj-1"]
+    summary = summarize_file(trajectory_file, trajectory_id=trajectory_id)
 
     assert summary.trajectories == 1
-    assert [s.trajectory_id for s in summary.samples] == ["traj-1"]
+    assert [s.trajectory_id for s in summary.samples] == [trajectory_id]
     assert summary.tokens == SEQ_LEN
     assert summary.termination_reasons == {"max_turns": 1}
     assert summary.tools_used == {}
@@ -607,7 +625,7 @@ def test_missing_trajectory_file_is_reported_as_schema_error(tmp_path: Path) -> 
 def test_iter_spans_for_display_marks_only_assistant_spans_in_loss(
     trajectory_file: Path,
 ) -> None:
-    rows = list(iter_spans_for_display(trajectory_file, "traj-0"))
+    rows = list(iter_spans_for_display(trajectory_file, _stored_ids(trajectory_file)["traj-0"]))
 
     assert [row["span_type"] for row in rows] == [t.value for t, _, _, _ in SPAN_LAYOUT]
     assert [row["in_loss"] for row in rows] == [False, False, True, False, True]
@@ -725,13 +743,14 @@ def test_report_data_prefers_trajectories_with_token_analysis(
     report_data: ReportData,
 ) -> None:
     ids = [view.trajectory_id for view in report_data.trajectories]
+    stored = _stored_ids(report_data.run_dir / "trajectories.jsonl")
 
     # The two trajectories with token analysis come first; the remaining display
     # budget is then filled rather than wasted.
-    assert ids[:2] == ["traj-0", "traj-1"]
-    assert set(ids) == {"traj-0", "traj-1", "traj-2"}
-    assert set(report_data.token_analysis) == {"traj-0", "traj-1"}
-    assert len(report_data.token_analysis["traj-0"]) == 3
+    assert ids[:2] == [stored["traj-0"], stored["traj-1"]]
+    assert set(ids) == set(stored.values())
+    assert set(report_data.token_analysis) == {stored["traj-0"], stored["traj-1"]}
+    assert len(report_data.token_analysis[stored["traj-0"]]) == 3
 
     first = report_data.trajectories[0]
     assert first.tokens == SEQ_LEN
@@ -767,7 +786,12 @@ def test_stored_rollouts_are_displayed_without_token_analysis(synthetic_run: Pat
     assert not (synthetic_run / "eval_trajectories.jsonl").exists()
 
     data = ReportData.from_run(synthetic_run, max_trajectories=5)
-    assert [view.trajectory_id for view in data.trajectories] == ["traj-0", "traj-1", "traj-2"]
+    stored = _stored_ids(synthetic_run / "trajectories.jsonl")
+    assert [view.trajectory_id for view in data.trajectories] == [
+        stored["traj-0"],
+        stored["traj-1"],
+        stored["traj-2"],
+    ]
 
 
 def test_view_of_annotations_resolve() -> None:
@@ -876,7 +900,7 @@ def test_render_html_shows_context_spans_as_not_in_loss(report_data: ReportData)
 
     assert "no (context)" in html
     assert "tool_result" in html
-    assert "traj-0" in html
+    assert report_data.trajectories[0].trajectory_id in html
 
 
 def test_render_html_rejects_an_empty_manifest(synthetic_run: Path) -> None:

--- a/tests/unit/test_profile_registry.py
+++ b/tests/unit/test_profile_registry.py
@@ -8,13 +8,20 @@ from miniverl.errors import ConfigError
 
 DIRECT_PROFILE = "verl-opd-v0.8-single-gpu-v1"
 PG_PROFILE = "verl-opd-v0.8-single-gpu-pg-k1-v1"
+GROUPED_PROFILE = "verl-opd-v0.8-single-gpu-grouped-v1"
+GROUPED_PG_PROFILE = "verl-opd-v0.8-single-gpu-pg-k1-grouped-v1"
 
 
 def test_registry_exposes_immutable_direct_gkd_identity() -> None:
     from miniverl.bridge.profiles import get_profile, list_profiles
 
     profiles = list_profiles()
-    assert [item.name for item in profiles] == [DIRECT_PROFILE, PG_PROFILE]
+    assert [item.name for item in profiles] == [
+        DIRECT_PROFILE,
+        PG_PROFILE,
+        GROUPED_PROFILE,
+        GROUPED_PG_PROFILE,
+    ]
 
     profile = get_profile(DIRECT_PROFILE)
     identity = profile.identity
@@ -90,3 +97,38 @@ def test_unknown_profile_fails_closed_without_plugin_loading() -> None:
 
     with pytest.raises(ConfigError, match="unknown compatibility profile"):
         get_profile("third-party:anything")
+
+
+def test_grouped_profile_makes_rollout_n_effective_without_changing_legacy_profile() -> None:
+    from miniverl.bridge.opd_runtime import build_system_plan, compile_native_run_config
+    from miniverl.bridge.profiles import load_profile_source
+
+    config = Path(__file__).resolve().parents[2] / "examples/verl-opd-v0.8-single-gpu.yaml"
+    grouped = load_profile_source(
+        GROUPED_PROFILE,
+        config,
+        overrides=["actor_rollout_ref.rollout.n=4"],
+        accept_local_reinterpretations=True,
+    )
+    mapping = next(
+        item
+        for item in grouped.compatibility
+        if item.upstream_field == "actor_rollout_ref.rollout.n"
+    )
+    native = compile_native_run_config(grouped, system_plan=build_system_plan(grouped))
+
+    assert grouped.profile == GROUPED_PROFILE
+    assert mapping.classification == "exact"
+    assert mapping.local_target == "rollout.n"
+    assert mapping.executable is True
+    assert native.rollout.samples_per_prompt == 4
+    assert native.rollout.backend.value == "hf_cached"
+    assert native.train.gradient_accumulation_steps == native.train.rollouts_per_cycle * 4
+
+    with pytest.raises(ConfigError, match="not executable"):
+        load_profile_source(
+            DIRECT_PROFILE,
+            config,
+            overrides=["actor_rollout_ref.rollout.n=4"],
+            accept_local_reinterpretations=True,
+        )

--- a/tests/unit/test_prompt_rollout_runtime.py
+++ b/tests/unit/test_prompt_rollout_runtime.py
@@ -12,6 +12,7 @@ from miniverl.data.verl_parquet import PromptRecord, RenderedPrompt
 from miniverl.models.tokenizers import ToyTokenizer
 from miniverl.models.toy import ToyBackend
 from miniverl.runtime.rollout import PromptDatasetRolloutRuntime
+from miniverl.schemas.trajectory import TRAJECTORY_SCHEMA_VERSION, validate_trajectory_groups
 
 
 def _record(index: int) -> PromptRecord:
@@ -262,3 +263,63 @@ def test_oom_downshift_changes_only_physical_batching(monkeypatch) -> None:
     assert generated.oom_downshifts == 1
     assert rollout_config.prompt_batch_size == 2
     assert generated.policy_version == 3
+
+
+def test_n4_group_identity_and_outputs_are_partition_invariant() -> None:
+    tokenizer = ToyTokenizer()
+    rendered = [
+        RenderedPrompt(
+            record=_record(index),
+            text=f"prompt {index}",
+            token_ids=tuple(tokenizer.encode(f"prompt {index}")),
+            tokenizer_identity=tokenizer.identity,
+            rendered_prompt_digest=f"{index + 50:064x}",
+            prompt_token_count=len(tokenizer.encode(f"prompt {index}")),
+            truncation_decision="not_needed",
+            original_prompt_token_count=len(tokenizer.encode(f"prompt {index}")),
+        )
+        for index in range(2)
+    ]
+
+    def run(batch_size: int):  # type: ignore[no-untyped-def]
+        backend = ToyBackend(tokenizer=tokenizer, model_id="toy", seed=31, trainable=False)
+        runtime = PromptDatasetRolloutRuntime(
+            backend=backend,
+            source_config=VerlParquetSourceConfig(
+                train_files=["unused.parquet"], allow_plain_string_prompts=True
+            ),
+            rollout_config=RolloutConfig(
+                backend="hf_cached",
+                samples_per_prompt=4,
+                max_new_tokens_per_turn=4,
+                max_total_tokens=32,
+                temperature=0.8,
+                prompt_batch_size=batch_size,
+                max_padded_tokens=256,
+                record_logprobs=True,
+            ),
+        )
+        batch = runtime.prepare_batch(rendered, group_cursor=9)
+        generated = runtime.generate(batch, policy_version=2, seed=123)
+        return generated, runtime.to_trajectories(batch, generated, policy_version=2)
+
+    whole, trajectories = run(8)
+    partitioned, partitioned_trajectories = run(2)
+
+    assert len(trajectories) == 8
+    assert [row.token_ids for row in whole.outputs] == [
+        row.token_ids for row in partitioned.outputs
+    ]
+    assert [row.logprobs for row in whole.outputs] == [row.logprobs for row in partitioned.outputs]
+    assert [row.trajectory_id for row in trajectories] == [
+        row.trajectory_id for row in partitioned_trajectories
+    ]
+    assert {row.schema_version for row in trajectories} == {TRAJECTORY_SCHEMA_VERSION}
+    assert {row.prompt_group_id for row in trajectories} == {
+        f"g{index:012d}-{rendered[index - 9].record.row_digest[:12]}" for index in (9, 10)
+    }
+    assert [row.sample_index for row in trajectories] == [0, 1, 2, 3, 0, 1, 2, 3]
+    assert {row.samples_per_prompt for row in trajectories} == {4}
+    assert len({row.generation_seed for row in trajectories}) == 8
+    assert len({row.trajectory_id for row in trajectories}) == 8
+    validate_trajectory_groups(trajectories)

--- a/tests/unit/test_recoverybench.py
+++ b/tests/unit/test_recoverybench.py
@@ -292,6 +292,16 @@ def test_structured_recovery_provenance_round_trips_and_reads_v1(tmp_path: Path)
 
     payload = trajectory.model_dump(mode="json")
     payload["schema_version"] = 1
+    for key in (
+        "prompt_group_id",
+        "prompt_digest",
+        "sample_index",
+        "samples_per_prompt",
+        "generation_seed",
+        "rollout_backend",
+        "rollout_policy_identity_digest",
+    ):
+        payload.pop(key)
     for turn in payload["turns"]:
         if turn["tool_result"] is not None:
             for key in ("error_code", "retryable", "intervention", "tool_result_metadata"):

--- a/tests/unit/test_trajectory_group_transactions.py
+++ b/tests/unit/test_trajectory_group_transactions.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from miniverl.schemas.trajectory import (
+    TRAJECTORY_SCHEMA_VERSION,
+    Span,
+    SpanType,
+    TerminationReason,
+    Trajectory,
+    derive_grouped_trajectory_id,
+    validate_trajectory_groups,
+)
+from miniverl.training.checkpoint import CheckpointState
+from miniverl.trajectory.io import (
+    append_trajectory_groups,
+    read_trajectories,
+    write_trajectories,
+)
+from miniverl.utils.runs import write_json_atomic
+
+
+def _group(group_index: int, *, n: int = 2) -> list[Trajectory]:
+    group_id = f"group-{group_index}"
+    prompt_digest = f"{group_index + 1:064x}"
+    policy_digest = "a" * 64
+    rows = []
+    for sample_index in range(n):
+        seed = 1000 + group_index * 10 + sample_index
+        rows.append(
+            Trajectory(
+                schema_version=TRAJECTORY_SCHEMA_VERSION,
+                trajectory_id=derive_grouped_trajectory_id(
+                    prompt_group_id=group_id,
+                    sample_index=sample_index,
+                    rollout_policy_identity_digest=policy_digest,
+                    generation_seed=seed,
+                ),
+                task_id=f"task-{group_index}",
+                environment="verl_parquet",
+                token_ids=[1],
+                attention_mask=[1],
+                model_generated_mask=[False],
+                critical_mask=[False],
+                spans=[Span(span_type=SpanType.USER, start=0, end=1, turn_id=0)],
+                tokenizer_fingerprint="tokenizer",
+                model_id="model",
+                termination_reason=TerminationReason.MAX_TOKENS,
+                prompt_group_id=group_id,
+                prompt_digest=prompt_digest,
+                sample_index=sample_index,
+                samples_per_prompt=n,
+                generation_seed=seed,
+                rollout_backend="hf_cached",
+                rollout_policy_identity_digest=policy_digest,
+            )
+        )
+    return rows
+
+
+def test_group_validator_rejects_a_partial_group() -> None:
+    with pytest.raises(ValueError, match="incomplete"):
+        validate_trajectory_groups(_group(0)[:1])
+
+
+def test_checkpoint_round_trips_group_and_prompt_cursors() -> None:
+    state = CheckpointState(
+        task_cursor=12,
+        prompt_cursor=12,
+        rollout_group_cursor=6,
+        trajectory_count=24,
+        samples_per_prompt=4,
+        pending_group_identity=[],
+        committed_group_identity=["group-5"],
+        backend_sync_identity="b" * 64,
+    )
+
+    restored = CheckpointState.from_dict(state.to_dict())
+
+    assert restored.prompt_cursor == 12
+    assert restored.rollout_group_cursor == 6
+    assert restored.trajectory_count == 24
+    assert restored.samples_per_prompt == 4
+    assert restored.committed_group_identity == ["group-5"]
+    assert restored.backend_sync_identity == "b" * 64
+
+
+def test_transactional_group_append_never_publishes_half_a_group(tmp_path: Path) -> None:
+    target = tmp_path / "trajectories.jsonl"
+    append_trajectory_groups(target, _group(0), transaction_id="first")
+
+    rows = read_trajectories(target)
+    assert len(rows) == 2
+    assert {row.sample_index for row in rows} == {0, 1}
+    assert not (tmp_path / ".trajectories.jsonl.group-transaction.json").exists()
+
+
+def test_exact_committed_group_replay_is_idempotent(tmp_path: Path) -> None:
+    target = tmp_path / "trajectories.jsonl"
+    group = _group(0)
+    append_trajectory_groups(target, group, transaction_id="first")
+    before = target.read_bytes()
+
+    written = append_trajectory_groups(target, group, transaction_id="replayed")
+
+    assert written == 0
+    assert target.read_bytes() == before
+    assert len(read_trajectories(target)) == 2
+
+
+def test_partial_committed_group_replay_fails_closed(tmp_path: Path) -> None:
+    target = tmp_path / "trajectories.jsonl"
+    target.write_text(
+        json.dumps(_group(0)[0].model_dump(mode="json")) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="partially present"):
+        append_trajectory_groups(target, _group(0), transaction_id="partial-replay")
+
+
+def test_generic_writer_upgrades_n1_legacy_object_to_current_schema(tmp_path: Path) -> None:
+    target = tmp_path / "trajectories.jsonl"
+    legacy = _group(0, n=1)[0].model_copy(
+        update={
+            "schema_version": 2,
+            "trajectory_id": "legacy-id",
+            "prompt_group_id": None,
+            "prompt_digest": None,
+            "sample_index": None,
+            "samples_per_prompt": None,
+            "generation_seed": None,
+            "rollout_backend": None,
+            "rollout_policy_identity_digest": None,
+        }
+    )
+
+    write_trajectories(target, [legacy])
+    loaded = read_trajectories(target)[0]
+
+    assert loaded.schema_version == TRAJECTORY_SCHEMA_VERSION
+    assert loaded.samples_per_prompt == 1
+    assert loaded.sample_index == 0
+    assert loaded.metadata["legacy_trajectory_id"] == "legacy-id"
+    assert loaded.trajectory_id == derive_grouped_trajectory_id(
+        prompt_group_id=str(loaded.prompt_group_id),
+        sample_index=0,
+        rollout_policy_identity_digest=str(loaded.rollout_policy_identity_digest),
+        generation_seed=int(loaded.generation_seed or 0),
+    )
+    assert legacy.trajectory_id == loaded.trajectory_id
+
+
+def test_failed_commit_publication_restores_old_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import miniverl.trajectory.io as trajectory_io
+
+    target = tmp_path / "trajectories.jsonl"
+    append_trajectory_groups(target, _group(0), transaction_id="first")
+    before = target.read_bytes()
+    calls = 0
+    original = trajectory_io.write_json_atomic
+
+    def fail_commit(path, payload):  # type: ignore[no-untyped-def]
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("injected committed-journal failure")
+        return original(path, payload)
+
+    monkeypatch.setattr(trajectory_io, "write_json_atomic", fail_commit)
+    with pytest.raises(OSError, match="committed-journal"):
+        append_trajectory_groups(target, _group(1), transaction_id="second")
+
+    assert target.read_bytes() == before
+    assert [row.prompt_group_id for row in read_trajectories(target)] == ["group-0"] * 2
+    assert not (tmp_path / ".trajectories.jsonl.group-transaction.json").exists()
+
+
+def test_pending_crash_journal_is_rolled_back_before_the_next_group(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "trajectories.jsonl"
+    append_trajectory_groups(target, _group(0), transaction_id="first")
+    committed = target.read_bytes()
+    with target.open("ab") as handle:
+        handle.write(b'{"partial":')
+    journal = tmp_path / ".trajectories.jsonl.group-transaction.json"
+    write_json_atomic(
+        journal,
+        {
+            "schema_version": 1,
+            "status": "pending",
+            "transaction_id": "crashed",
+            "start_offset": len(committed),
+            "groups": ["group-1"],
+            "trajectories": 2,
+        },
+    )
+
+    append_trajectory_groups(target, _group(2), transaction_id="after-recovery")
+
+    rows = read_trajectories(target)
+    assert [row.prompt_group_id for row in rows] == ["group-0"] * 2 + ["group-2"] * 2
+    assert json.loads(target.read_text(encoding="utf-8").splitlines()[-1])["schema_version"] == 3
+    assert not journal.exists()

--- a/tests/unit/test_verl_opd_export.py
+++ b/tests/unit/test_verl_opd_export.py
@@ -166,7 +166,7 @@ def _opd_run(
             },
         },
     }
-    if profile == "verl-opd-v0.8-single-gpu-pg-k1-v1":
+    if "pg-k1" in profile:
         source["distillation"]["distillation_loss"] = {
             "loss_mode": "k1",
             "topk": None,
@@ -179,6 +179,8 @@ def _opd_run(
             "clip_ratio_low": 0.2,
             "clip_ratio_high": 0.2,
         }
+    if "grouped" in profile:
+        source["actor_rollout_ref"]["rollout"]["n"] = 4
     (run / "verl-source-config.json").write_text(json.dumps(source), encoding="utf-8")
     (run / "verl-compatibility-report.json").write_text(
         json.dumps(
@@ -226,6 +228,32 @@ def test_pg_k1_export_preserves_sampled_logprob_semantics_without_topk(tmp_path:
     assert diagnosis["verdict"] == "ok"
     assert diagnosis["config_profile"]["profile"] == profile
     assert diagnosis["config_profile"]["target_representation"] == ("sampled_token_log_probability")
+
+
+@pytest.mark.parametrize(
+    "profile",
+    [
+        "verl-opd-v0.8-single-gpu-grouped-v1",
+        "verl-opd-v0.8-single-gpu-pg-k1-grouped-v1",
+    ],
+)
+def test_grouped_export_binds_independent_sample_semantics(
+    tmp_path: Path,
+    profile: str,
+) -> None:
+    from miniverl.bridge.contract import VERL_TAG
+    from miniverl.bridge.export import export_verl_bundle
+
+    run, _, _ = _opd_run(tmp_path, profile=profile)
+    report = export_verl_bundle(run, target_verl=VERL_TAG, out=tmp_path / "grouped-bundle")
+
+    assert report["grouped_rollout_semantics"] == {
+        "samples_per_prompt": 4,
+        "trajectory_schema_version": 3,
+        "sample_semantics": "independent_current_policy_trajectory",
+        "group_baseline": False,
+        "grpo": False,
+    }
 
 
 def test_pure_opd_export_is_reward_free_and_preserves_data_bytes(tmp_path: Path) -> None:

--- a/tests/unit/test_verl_pg_profile.py
+++ b/tests/unit/test_verl_pg_profile.py
@@ -90,7 +90,12 @@ def test_registry_lists_pg_profile_with_independent_identity() -> None:
     from miniverl.bridge.profiles import get_profile, list_profiles
 
     names = [profile.name for profile in list_profiles()]
-    assert names == ["verl-opd-v0.8-single-gpu-v1", PG_PROFILE]
+    assert names == [
+        "verl-opd-v0.8-single-gpu-v1",
+        PG_PROFILE,
+        "verl-opd-v0.8-single-gpu-grouped-v1",
+        "verl-opd-v0.8-single-gpu-pg-k1-grouped-v1",
+    ]
     direct = get_profile(names[0])
     pg = get_profile(PG_PROFILE)
     assert pg.identity.digest != direct.identity.digest


### PR DESCRIPTION
## Summary

- add trajectory schema v3 with typed group, sample, seed, backend, and rollout-policy identity while retaining v1/v2 readers
- make complete prompt-group publication journaled, crash-recoverable, and replay-idempotent
- support independent `n > 1` Parquet prompt samples through new direct-GKD and sampled-k1 grouped profiles without changing the measured `n = 1` profiles
- bind prompt/group cursors, trajectory count, backend synchronization, cache identity, checkpoint state, metrics, and export provenance to grouped semantics
- upgrade all newly written trajectories to schema v3, preserving prior logical IDs as legacy provenance

The grouped samples are independent current-policy trajectories. This does not add a group baseline, GRPO, a new reward, or a new benchmark. The two grouped profiles are conformance-only.

## Validation

- `git diff --check`
- `ruff check .`
- `ruff format --check .`
- `mypy src/miniverl`
- actionlint 1.7.12
- `pytest -q -m "not gpu and not network" --cov=miniverl`: 2423 passed, 9 platform skips, 83% coverage
- `pytest -q -m gpu`: 10 passed
- `pytest -q -m network`: 16 passed
- exact grouped interruption/resume: prompt order, group/sample IDs, output tokens, sampled log-probabilities, teacher-cache tensors, optimizer tensors, and final adapter match
- generated documentation checks, Markdown/link and text-integrity checks
- `mkdocs build --strict`
- browser visual gate: 44 SVG instances across 1440, 1024, 820, and 390 px viewports
- package build and `twine check`
- clean core wheel install with torch absent

Local development build hashes:

- wheel: `c32542c884a9f582b26e0229c62b5da3a72867148311799b29cfc61a00c2b2f9`
- sdist: `a3bf8b3625c868f4d0ff44ec61768e76816741ac204def3ce3db54a8fd28f4fd`

Frozen evidence remains byte-identical:

- calculator: `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`
- rollout baseline: `b25daee7ee726b7a7be18d7dbe26590fb61325bf212cfd9e7110b69f5fa8889c`
