### PR TITLE
Add the measured single-GPU vLLM rollout backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,19 @@ All notable changes to miniVERL are recorded here. The format follows
   normalization, arbitrary reward code, GRPO claim or distributed execution
   claim. No task-quality benchmark was run for this profile.
 
+### Managed vLLM rollout
+
+- Added an optional, miniVERL-managed vLLM 0.28 backend for direct GKD on the
+  qualified Linux/WSL2 CUDA path. It owns localhost startup, unique
+  content-bound LoRA identities, raw output IDs, bounded requests and complete
+  process-group teardown between rollout and training phases.
+- Disabled persistent prefix caching and made every failed adapter refresh
+  quiesce and close the server, so a stale policy cannot serve after a failed
+  synchronization.
+- Kept PG-k1 on `hf_cached`: the BF16 external engine and NF4 actor agreed on
+  greedy tokens in the qualification probe, but their sampled-token
+  log-probabilities did not satisfy the preregistered numerical threshold.
+
 ### Documentation narrative
 
 - Rebuilt the English, Chinese and PyPI landing narratives around the local

--- a/docs/rollout-runtime-v2.md
+++ b/docs/rollout-runtime-v2.md
@@ -62,6 +62,35 @@ remain fixed at `n=1`; the grouped profiles are conformance-only until a later
 evidence stage measures them. Grouped rollouts currently require a Parquet
 prompt source. Environment-backed recipes remain `n=1`.
 
-The v0.11 baseline result remains the pre-change `hf_reference` measurement.
-It is not evidence for `hf_cached` or grouped-rollout performance. External
-engine support is a separate release-chain stage.
+## Managed vLLM for direct GKD
+
+Install the optional engine in the same Linux or WSL2 environment as the
+training stack:
+
+```bash
+pip install "miniverl[train,rollout-vllm]"
+```
+
+Bind it into the immutable execution plan for the grouped direct-GKD profile:
+
+```bash
+miniverl plan \
+  --profile verl-opd-v0.8-single-gpu-grouped-v1 \
+  --config verl-opd.yaml \
+  --accept-local-reinterpretations \
+  --rollout-backend vllm \
+  --out plan.json
+miniverl run --plan plan.json
+```
+
+miniVERL starts the pinned vLLM server on an ephemeral localhost port, exports
+the live PEFT adapter under a policy-version-and-digest name, generates raw
+token IDs, and terminates the complete process group before teacher scoring or
+the actor update. Prefix caching is disabled, and a failed policy refresh
+closes the server before another request can run.
+
+This backend is qualified for direct GKD. Use `hf_cached` for PG-k1: vLLM's
+BF16 rollout and the NF4 training actor are a recorded numerical-equivalence
+class, not sampled-logprob identity. The release-chain qualification measured
+throughput separately from the conformance probes; the frozen pre-change
+`hf_reference` result remains the compatibility baseline.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ dpo = [
 # `bridge doctor --require-adapter-payload` can never be satisfied, so the extra
 # that exists for bridge work has to carry it.
 bridge = ["pyarrow>=15", "numpy>=1.24"]
+rollout-vllm = [
+  "vllm==0.28.0; platform_system == 'Linux'",
+]
 # External alignment benchmarks. Deliberately separate from the core and from
 # [train]: a plain `pip install miniverl` must not pull in dataset tooling,
 # judge models or a network client. The judge models themselves are ordinary

--- a/src/miniverl/bridge/opd_plan.py
+++ b/src/miniverl/bridge/opd_plan.py
@@ -158,6 +158,7 @@ def build_immutable_opd_plan(
     *,
     source: str | Path,
     system_plan: OPDSystemPlan | None = None,
+    rollout_backend: str | None = None,
 ) -> ImmutableOPDPlan:
     """Scan local inputs and build a deterministic, weight-free execution artifact."""
     acceptance = compiled.reinterpretation_acceptance
@@ -168,7 +169,11 @@ def build_immutable_opd_plan(
         )
     source_identity, base = _source_identity(source)
     system = system_plan or build_system_plan(compiled)
-    native = compile_native_run_config(compiled, system_plan=system)
+    native = compile_native_run_config(
+        compiled,
+        system_plan=system,
+        rollout_backend=rollout_backend,
+    )
     _resolve_data_paths(native, base)
     student = _revision(
         native.models.student.model_id,

--- a/src/miniverl/bridge/opd_runtime.py
+++ b/src/miniverl/bridge/opd_runtime.py
@@ -297,6 +297,7 @@ def compile_native_run_config(
     compiled: CompiledLocalExecutionPlan,
     *,
     system_plan: OPDSystemPlan | None = None,
+    rollout_backend: str | None = None,
 ) -> RunConfig:
     """Translate the supported profile into an executable, validated RunConfig."""
     source = compiled.source
@@ -339,6 +340,16 @@ def compile_native_run_config(
         VERL_OPD_PG_K1_REWARDED_V08_PROFILE,
     }
     rewarded = compiled.profile == VERL_OPD_PG_K1_REWARDED_V08_PROFILE
+    if rollout_backend not in {None, "hf_reference", "hf_cached", "vllm"}:
+        raise ConfigError(
+            f"unsupported local rollout backend {rollout_backend!r}",
+            hint="choose hf_reference, hf_cached, or vllm",
+        )
+    if rollout_backend == "vllm" and pg_k1:
+        raise ConfigError(
+            "the measured vLLM backend is qualified for direct GKD only",
+            hint="use hf_cached for PG-k1 sampled-token log-probabilities",
+        )
     rewarded_loss = cast(VerlRewardedPGK1LossConfig, source.distillation.distillation_loss)
     loss_payload = (
         {
@@ -447,11 +458,14 @@ def compile_native_run_config(
         },
         "rollout": {
             "backend": (
-                "hf_cached"
-                if compiled.profile
-                in {VERL_OPD_GROUPED_V08_PROFILE, VERL_OPD_PG_K1_GROUPED_V08_PROFILE}
-                or rewarded
-                else "hf_reference"
+                rollout_backend
+                or (
+                    "hf_cached"
+                    if compiled.profile
+                    in {VERL_OPD_GROUPED_V08_PROFILE, VERL_OPD_PG_K1_GROUPED_V08_PROFILE}
+                    or rewarded
+                    else "hf_reference"
+                )
             ),
             "samples_per_prompt": source.actor_rollout_ref.rollout.n,
             "max_turns": 1,
@@ -467,6 +481,19 @@ def compile_native_run_config(
             "max_padded_tokens": source.actor_rollout_ref.rollout.max_num_batched_tokens
             or (source.data.max_prompt_length + source.data.max_response_length)
             * source.miniverl.batching.rollout_batch_size,
+            **(
+                {
+                    "engine": {
+                        "managed": True,
+                        "host": "127.0.0.1",
+                        "memory_fraction": (
+                            source.actor_rollout_ref.rollout.gpu_memory_utilization
+                        ),
+                    }
+                }
+                if rollout_backend == "vllm"
+                else {}
+            ),
         },
         "selection": {"selector": "all_model_tokens"},
         "loss": loss_payload,

--- a/src/miniverl/cli.py
+++ b/src/miniverl/cli.py
@@ -928,6 +928,11 @@ def plan_command(
     profile: str = typer.Option(
         "verl-opd-v0.8-single-gpu-v1", "--profile", help="Pinned compatibility profile."
     ),
+    rollout_backend: Optional[str] = typer.Option(
+        None,
+        "--rollout-backend",
+        help="Local execution backend: hf_reference, hf_cached, or vllm.",
+    ),
     overrides: list[str] = typer.Option([], "--set", help="Repeatable dotted key=value override."),
     override_files: list[Path] = typer.Option(
         [],
@@ -971,6 +976,14 @@ def plan_command(
         )
         plan = build_system_plan(compiled)
         payload = plan.model_dump(mode="json")
+        if rollout_backend is not None:
+            from miniverl.bridge.opd_runtime import compile_native_run_config
+
+            payload["resolved_native_config"] = compile_native_run_config(
+                compiled,
+                system_plan=plan,
+                rollout_backend=rollout_backend,
+            ).model_dump(mode="json")
         artifact = None
         if out is not None or probe:
             from miniverl.bridge.opd_plan import (
@@ -979,7 +992,12 @@ def plan_command(
                 write_immutable_opd_plan,
             )
 
-            artifact = build_immutable_opd_plan(compiled, source=config, system_plan=plan)
+            artifact = build_immutable_opd_plan(
+                compiled,
+                source=config,
+                system_plan=plan,
+                rollout_backend=rollout_backend,
+            )
             if probe:
                 _require_training_stack("miniverl plan --probe")
                 from miniverl.bridge.opd_probe import run_hardware_probe
@@ -1051,6 +1069,11 @@ def verl_run_command(
     profile: str = typer.Option(
         "verl-opd-v0.8-single-gpu-v1", "--profile", help="Pinned compatibility profile."
     ),
+    rollout_backend: Optional[str] = typer.Option(
+        None,
+        "--rollout-backend",
+        help="Local execution backend: hf_reference, hf_cached, or vllm.",
+    ),
     overrides: list[str] = typer.Option([], "--set", help="Repeatable dotted key=value override."),
     override_files: list[Path] = typer.Option(
         [],
@@ -1077,7 +1100,11 @@ def verl_run_command(
         if plan_path is not None and config is not None:
             raise ConfigError("--plan and --config are mutually exclusive")
         if plan_path is not None and (
-            overrides or override_files or ctx.args or accept_local_reinterpretations
+            overrides
+            or override_files
+            or ctx.args
+            or accept_local_reinterpretations
+            or rollout_backend is not None
         ):
             raise ConfigError(
                 "--plan cannot be combined with config overrides or reinterpretation flags",
@@ -1116,7 +1143,11 @@ def verl_run_command(
                     ),
                 )
             system_plan = build_system_plan(compiled)
-            native = compile_native_run_config(compiled, system_plan=system_plan)
+            native = compile_native_run_config(
+                compiled,
+                system_plan=system_plan,
+                rollout_backend=rollout_backend,
+            )
         from miniverl.config.models import VerlParquetSourceConfig
 
         if not isinstance(native.source, VerlParquetSourceConfig):  # pragma: no cover
@@ -1145,7 +1176,8 @@ def verl_run_command(
             console.print(f"  data       {_esc(', '.join(native.source.train_files))}")
             console.print(f"  actor      {_esc(native.models.student.model_id)}")
             console.print(
-                f"  rollout    local HF, n=1, max response "
+                f"  rollout    {_esc(native.rollout.backend.value)}, "
+                f"n={native.rollout.samples_per_prompt}, max response "
                 f"{_esc(native.source.max_response_length)}"
             )
             console.print(f"  teacher    {_esc(native.models.teacher.model_id)}")

--- a/src/miniverl/config/models.py
+++ b/src/miniverl/config/models.py
@@ -570,6 +570,21 @@ class RolloutConfig(_Base):
     compile_backend: bool = False
     engine: RolloutEngineConfig = Field(default_factory=RolloutEngineConfig)
 
+    @model_validator(mode="after")
+    def _external_engine_is_fail_closed(self) -> RolloutConfig:
+        if self.backend is not RolloutBackendKind.VLLM:
+            return self
+        if not self.engine.managed or self.engine.host != "127.0.0.1":
+            raise ValueError("rollout.backend=vllm requires a managed localhost engine")
+        if self.record_logprobs:
+            raise ValueError(
+                "rollout.backend=vllm is qualified for direct GKD only; its sampled-token "
+                "log-probabilities did not pass the PG numerical-conformance gate"
+            )
+        if self.compile_backend:
+            raise ValueError("rollout.compile_backend applies only to hf_cached")
+        return self
+
 
 class SourceKind(str, Enum):
     """Where rollout inputs originate."""
@@ -875,7 +890,7 @@ class RunConfig(_Base):
             and self.rollout.backend is not RolloutBackendKind.HF_REFERENCE
         ):
             raise ValueError(
-                "rollout.backend=hf_cached currently requires source.kind=verl_parquet; "
+                "non-reference rollout backends currently require source.kind=verl_parquet; "
                 "tool-environment episodes retain the hf_reference path"
             )
         if self.source.kind is SourceKind.VERL_PARQUET and self.environment is not None:

--- a/src/miniverl/runtime/backends/__init__.py
+++ b/src/miniverl/runtime/backends/__init__.py
@@ -2,5 +2,6 @@
 
 from miniverl.runtime.backends.hf_cached import HFCachedGenerationBackend
 from miniverl.runtime.backends.hf_reference import HFReferenceGenerationBackend
+from miniverl.runtime.backends.vllm import VLLMGenerationBackend
 
-__all__ = ["HFCachedGenerationBackend", "HFReferenceGenerationBackend"]
+__all__ = ["HFCachedGenerationBackend", "HFReferenceGenerationBackend", "VLLMGenerationBackend"]

--- a/src/miniverl/runtime/backends/vllm.py
+++ b/src/miniverl/runtime/backends/vllm.py
@@ -1,0 +1,633 @@
+"""Managed localhost vLLM rollout backend for the measured direct-GKD path."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import platform
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import suppress
+from dataclasses import dataclass
+from importlib import metadata
+from pathlib import Path
+from typing import Any, Protocol
+
+from miniverl.config.models import RolloutEngineConfig
+from miniverl.models.base import GenerationOutput
+from miniverl.runtime.generation import (
+    BackendCapabilities,
+    BackendLifecycleState,
+    BackendMetrics,
+    GenerationBatch,
+    GenerationRequest,
+    GenerationResult,
+    PolicySnapshot,
+    PolicySyncResult,
+    ReproducibilityClass,
+    RolloutBackendKind,
+    RolloutPolicyIdentity,
+)
+
+__all__ = [
+    "VLLMGenerationBackend",
+    "build_vllm_server_command",
+    "parse_vllm_completion",
+]
+
+_QUALIFIED_VLLM_VERSION = "0.28.0"
+_BACKEND_VERSION = f"vllm-{_QUALIFIED_VLLM_VERSION}-direct-gkd-v1"
+
+
+def build_vllm_server_command(
+    *,
+    python_executable: str,
+    model_path: str,
+    host: str,
+    port: int,
+    memory_fraction: float,
+    max_model_len: int,
+    wsl_compatibility: bool,
+) -> tuple[list[str], dict[str, str]]:
+    """Build the pinned, localhost-only command without importing vLLM."""
+
+    if host != "127.0.0.1":
+        raise ValueError("the managed vLLM server may bind only to localhost")
+    command = [
+        python_executable,
+        "-m",
+        "vllm.entrypoints.openai.api_server",
+        model_path,
+        "--host",
+        host,
+        "--port",
+        str(port),
+        "--dtype",
+        "bfloat16",
+        "--max-model-len",
+        str(max_model_len),
+        "--gpu-memory-utilization",
+        str(memory_fraction),
+        "--enforce-eager",
+        "--no-enable-prefix-caching",
+        "--return-tokens-as-token-ids",
+        "--generation-config",
+        "vllm",
+        "--logprobs-mode",
+        "raw_logprobs",
+        "--enable-lora",
+        "--max-lora-rank",
+        "64",
+        "--max-loras",
+        "1",
+        "--max-cpu-loras",
+        "2",
+    ]
+    environment = {
+        "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "True",
+        "TRANSFORMERS_OFFLINE": "1",
+        "HF_HUB_OFFLINE": "1",
+    }
+    if wsl_compatibility:
+        # vLLM 0.28's V2 runner requires UVA, which WSL2 does not expose, and
+        # the FlashInfer sampler JIT requires a system nvcc installation.
+        environment["VLLM_USE_V2_MODEL_RUNNER"] = "0"
+        environment["VLLM_USE_FLASHINFER_SAMPLER"] = "0"
+    return command, environment
+
+
+def _only_choice(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or len(choices) != 1 or not isinstance(choices[0], dict):
+        raise RuntimeError("vLLM returned an invalid completion choice")
+    return choices[0]
+
+
+def parse_vllm_completion(payload: Mapping[str, Any], *, need_logprobs: bool) -> GenerationOutput:
+    """Parse the raw-ID encoding used by vLLM's OpenAI completion endpoint."""
+
+    choice = _only_choice(payload)
+    logprob_payload = choice.get("logprobs")
+    if not isinstance(logprob_payload, dict):
+        raise RuntimeError("vLLM did not return the logprobs envelope needed for raw token ids")
+    raw_tokens = logprob_payload.get("tokens")
+    raw_logprobs = logprob_payload.get("token_logprobs")
+    if not isinstance(raw_tokens, list) or not raw_tokens:
+        raise RuntimeError("vLLM returned no raw token ids")
+    token_ids: list[int] = []
+    for token in raw_tokens:
+        if not isinstance(token, str) or not token.startswith("token_id:"):
+            raise RuntimeError("vLLM response contained a token without a raw token id")
+        try:
+            token_id = int(token.removeprefix("token_id:"))
+        except ValueError as exc:
+            raise RuntimeError("vLLM response contained an invalid raw token id") from exc
+        if token_id < 0:
+            raise RuntimeError("vLLM response contained a negative raw token id")
+        token_ids.append(token_id)
+    if not isinstance(raw_logprobs, list) or len(raw_logprobs) != len(token_ids):
+        raise RuntimeError("vLLM sampled-token logprobs do not align with raw token ids")
+    try:
+        parsed_logprobs = [float(value) for value in raw_logprobs]
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("vLLM returned a non-numeric sampled-token logprob") from exc
+    if not all(math.isfinite(value) for value in parsed_logprobs):
+        raise RuntimeError("vLLM returned a non-finite sampled-token logprob")
+
+    finish_reason = choice.get("finish_reason")
+    raw_stop = choice.get("stop_reason")
+    matched_stop: str | None = None
+    if finish_reason == "length":
+        stop_reason = "max_new_tokens"
+    elif isinstance(raw_stop, str):
+        stop_reason = "stop_sequence"
+        matched_stop = raw_stop
+    else:
+        stop_reason = "eos"
+    return GenerationOutput(
+        token_ids=token_ids,
+        text=str(choice.get("text", "")),
+        stop_reason=stop_reason,
+        matched_stop=matched_stop,
+        logprobs=parsed_logprobs if need_logprobs else [],
+    )
+
+
+def _json_request(
+    base_url: str,
+    path: str,
+    *,
+    payload: Mapping[str, Any] | None,
+    timeout: float,
+) -> Any:
+    data = None if payload is None else json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    request = urllib.request.Request(
+        f"{base_url}{path}",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="GET" if payload is None else "POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise RuntimeError(f"managed vLLM request {path} failed: {exc}") from exc
+    content_type = response.headers.get("Content-Type", "")
+    if "json" not in content_type:
+        return body
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"managed vLLM request {path} returned invalid JSON") from exc
+
+
+def _free_local_port(host: str) -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind((host, 0))
+        return int(listener.getsockname()[1])
+
+
+def _is_wsl() -> bool:
+    return platform.system() == "Linux" and "microsoft" in platform.release().lower()
+
+
+def _resolve_model_snapshot(model_id: str, revision: str | None) -> Path:
+    direct = Path(model_id)
+    if direct.is_dir():
+        return direct.resolve()
+    try:
+        from huggingface_hub import try_to_load_from_cache
+
+        cached = try_to_load_from_cache(model_id, "config.json", revision=revision)
+    except (OSError, ValueError) as exc:
+        raise RuntimeError(f"could not resolve cached base snapshot {model_id!r}: {exc}") from exc
+    if not isinstance(cached, str):
+        revision_hint = f" --revision {revision}" if revision else ""
+        raise RuntimeError(
+            f"base snapshot {model_id!r} is not cached; run `hf download {model_id}"
+            f"{revision_hint}` before using rollout.backend=vllm"
+        )
+    snapshot = Path(cached).resolve().parent
+    if not (snapshot / "config.json").is_file():
+        raise RuntimeError("resolved vLLM base snapshot has no config.json")
+    return snapshot
+
+
+class _Manager(Protocol):
+    def start(self) -> None: ...
+    def load_adapter(self, name: str, path: Path) -> None: ...
+    def unload_adapter(self, name: str) -> None: ...
+    def complete(self, payload: dict[str, object]) -> dict[str, object]: ...
+    def close(self) -> None: ...
+
+
+class _VLLMServerManager:
+    def __init__(
+        self,
+        *,
+        model_path: Path,
+        config: RolloutEngineConfig,
+        max_model_len: int,
+        workspace: Path,
+    ) -> None:
+        self.model_path = model_path
+        self.config = config
+        self.max_model_len = max_model_len
+        self.workspace = workspace
+        self.port = _free_local_port(config.host)
+        self.base_url = f"http://{config.host}:{self.port}"
+        self.process: subprocess.Popen[bytes] | None = None
+        self._log_handle: Any | None = None
+
+    def start(self) -> None:
+        if self.process is not None and self.process.poll() is None:
+            return
+        if platform.system() != "Linux":
+            raise RuntimeError("the qualified vLLM rollout backend requires Linux or WSL2")
+        try:
+            installed = metadata.version("vllm")
+        except metadata.PackageNotFoundError as exc:
+            raise RuntimeError(
+                "rollout.backend=vllm requires `pip install miniverl[rollout-vllm]`"
+            ) from exc
+        if installed != _QUALIFIED_VLLM_VERSION:
+            raise RuntimeError(
+                f"qualified vLLM version is {_QUALIFIED_VLLM_VERSION}, found {installed}"
+            )
+        self.port = _free_local_port(self.config.host)
+        self.base_url = f"http://{self.config.host}:{self.port}"
+        command, additions = build_vllm_server_command(
+            python_executable=sys.executable,
+            model_path=str(self.model_path),
+            host=self.config.host,
+            port=self.port,
+            memory_fraction=self.config.memory_fraction,
+            max_model_len=self.max_model_len,
+            wsl_compatibility=_is_wsl(),
+        )
+        environment = os.environ.copy()
+        environment.update(additions)
+        self.workspace.mkdir(parents=True, exist_ok=True)
+        self._log_handle = (self.workspace / "server.log").open("ab")
+        self.process = subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=self._log_handle,
+            stderr=subprocess.STDOUT,
+            env=environment,
+            start_new_session=True,
+        )
+        deadline = time.monotonic() + self.config.startup_timeout_seconds
+        while time.monotonic() < deadline:
+            if self.process.poll() is not None:
+                return_code = self.process.returncode
+                self.close()
+                raise RuntimeError(f"managed vLLM exited during startup with code {return_code}")
+            try:
+                _json_request(
+                    self.base_url,
+                    "/health",
+                    payload=None,
+                    timeout=min(1.0, self.config.request_timeout_seconds),
+                )
+                models = _json_request(
+                    self.base_url,
+                    "/v1/models",
+                    payload=None,
+                    timeout=self.config.request_timeout_seconds,
+                )
+                if not isinstance(models, dict) or not isinstance(models.get("data"), list):
+                    raise RuntimeError("managed vLLM model inventory is invalid")
+                return
+            except RuntimeError:
+                time.sleep(0.1)
+        self.close()
+        raise RuntimeError(
+            f"managed vLLM did not become healthy within "
+            f"{self.config.startup_timeout_seconds:g} seconds"
+        )
+
+    def load_adapter(self, name: str, path: Path) -> None:
+        _json_request(
+            self.base_url,
+            "/v1/load_lora_adapter",
+            payload={"lora_name": name, "lora_path": str(path)},
+            timeout=self.config.request_timeout_seconds,
+        )
+
+    def unload_adapter(self, name: str) -> None:
+        _json_request(
+            self.base_url,
+            "/v1/unload_lora_adapter",
+            payload={"lora_name": name},
+            timeout=self.config.request_timeout_seconds,
+        )
+
+    def complete(self, payload: dict[str, object]) -> dict[str, object]:
+        result = _json_request(
+            self.base_url,
+            "/v1/completions",
+            payload=payload,
+            timeout=self.config.request_timeout_seconds,
+        )
+        if not isinstance(result, dict):
+            raise RuntimeError("managed vLLM returned a non-object completion")
+        return result
+
+    def close(self) -> None:
+        process = self.process
+        self.process = None
+        try:
+            if process is not None:
+                with suppress(ProcessLookupError):
+                    os.killpg(process.pid, signal.SIGTERM)  # type: ignore[attr-defined]
+                if process.poll() is None:
+                    try:
+                        process.wait(timeout=10)
+                    except subprocess.TimeoutExpired:
+                        with suppress(ProcessLookupError):
+                            os.killpg(  # type: ignore[attr-defined]
+                                process.pid,
+                                signal.SIGKILL,  # type: ignore[attr-defined]
+                            )
+                        process.wait(timeout=10)
+        finally:
+            if self._log_handle is not None:
+                self._log_handle.close()
+                self._log_handle = None
+
+
+@dataclass(frozen=True)
+class _CompletedRequest:
+    request: GenerationRequest
+    output: GenerationOutput
+    raw_request_id: str | None
+
+
+class VLLMGenerationBackend:
+    """Time-multiplexed vLLM 0.28 backend, qualified for direct GKD only."""
+
+    kind = RolloutBackendKind.VLLM
+    backend_version = _BACKEND_VERSION
+
+    def __init__(
+        self,
+        model_backend: Any,
+        *,
+        engine_config: RolloutEngineConfig,
+        max_model_len: int,
+        workspace: Path | None = None,
+        manager: _Manager | None = None,
+    ) -> None:
+        self.model_backend = model_backend
+        self.engine_config = engine_config
+        parent = workspace or Path(tempfile.gettempdir())
+        parent.mkdir(parents=True, exist_ok=True)
+        self.workspace = Path(tempfile.mkdtemp(prefix="miniverl-vllm-", dir=parent))
+        try:
+            model_path = (
+                _resolve_model_snapshot(
+                    str(getattr(model_backend, "model_id", "")),
+                    getattr(model_backend, "model_revision", None),
+                )
+                if manager is None
+                else Path(str(getattr(model_backend, "model_id", "model")))
+            )
+            self.manager: _Manager = manager or _VLLMServerManager(
+                model_path=model_path,
+                config=engine_config,
+                max_model_len=max_model_len,
+                workspace=self.workspace,
+            )
+        except BaseException:
+            shutil.rmtree(self.workspace, ignore_errors=True)
+            raise
+        self._state = BackendLifecycleState.NEW
+        self._active_identity: RolloutPolicyIdentity | None = None
+        self._active_adapter_name: str | None = None
+        self._server_adapter_name: str | None = None
+        self._lifecycle: dict[str, object] = {
+            "prefix_cache_enabled": False,
+            "numerical_equivalence_class": "unmeasured",
+        }
+
+    @property
+    def state(self) -> BackendLifecycleState:
+        return self._state
+
+    def inspect(self) -> BackendCapabilities:
+        return BackendCapabilities(
+            kind=self.kind,
+            backend_version=self.backend_version,
+            supports_greedy=True,
+            supports_seeded_sampling=True,
+            supports_sampled_token_logprobs=False,
+            supports_text_stops=True,
+            reproducibility=ReproducibilityClass.DETERMINISTIC_GREEDY,
+        )
+
+    def lifecycle_metrics(self) -> dict[str, object]:
+        """Return the latest bounded sync/teardown measurements for event logs."""
+
+        return dict(self._lifecycle)
+
+    @staticmethod
+    def _adapter_name(identity: RolloutPolicyIdentity) -> str:
+        return f"miniverl-p{identity.parameter_version:08d}-{identity.adapter_tensor_digest[:12]}"
+
+    def _materialize_adapter(self, identity: RolloutPolicyIdentity) -> Path:
+        target = self.workspace / self._adapter_name(identity)
+        if (
+            target.is_dir()
+            and (target / "adapter_config.json").is_file()
+            and any(target.glob("*.safetensors"))
+        ):
+            return target
+        if target.exists():
+            shutil.rmtree(target)
+        exporter = getattr(self.model_backend, "export_rollout_adapter", None)
+        try:
+            if callable(exporter):
+                exporter(target)
+            else:
+                model = getattr(self.model_backend, "model", None)
+                save = getattr(model, "save_pretrained", None)
+                if not callable(save):
+                    raise RuntimeError(
+                        "vLLM policy synchronization needs a PEFT actor with save_pretrained()"
+                    )
+                target.mkdir(parents=True)
+                save(target, safe_serialization=True)
+        except BaseException:
+            shutil.rmtree(target, ignore_errors=True)
+            raise
+        if not (target / "adapter_config.json").is_file() or not any(target.glob("*.safetensors")):
+            shutil.rmtree(target, ignore_errors=True)
+            raise RuntimeError("materialized vLLM policy adapter is incomplete")
+        return target
+
+    def synchronize(self, snapshot: PolicySnapshot) -> PolicySyncResult:
+        if self._state is BackendLifecycleState.CLOSED:
+            raise RuntimeError("generation backend is closed")
+        identity = snapshot.identity
+        if identity.generation_backend is not self.kind:
+            raise RuntimeError("policy identity does not select the vLLM backend")
+        if identity.backend_version != self.backend_version:
+            raise RuntimeError("policy identity does not match the qualified vLLM backend version")
+        previous = self._active_identity.digest if self._active_identity is not None else None
+        name = self._adapter_name(identity)
+        sync_started = time.perf_counter()
+        try:
+            adapter = self._materialize_adapter(identity)
+            startup_started = time.perf_counter()
+            self.manager.start()
+            startup_seconds = time.perf_counter() - startup_started
+            adapter_started = time.perf_counter()
+            if self._server_adapter_name != name:
+                old_name = self._server_adapter_name
+                if old_name is not None:
+                    self.manager.unload_adapter(old_name)
+                    self._server_adapter_name = None
+                self.manager.load_adapter(name, adapter)
+                self._server_adapter_name = name
+            adapter_sync_seconds = time.perf_counter() - adapter_started
+        except BaseException:
+            self._server_adapter_name = None
+            self._state = BackendLifecycleState.QUIESCED
+            self.manager.close()
+            raise
+        old_active_name = self._active_adapter_name
+        self._active_identity = identity
+        self._active_adapter_name = name
+        self._state = BackendLifecycleState.SYNCHRONIZED
+        if old_active_name is not None and old_active_name != name:
+            shutil.rmtree(self.workspace / old_active_name, ignore_errors=True)
+        self._lifecycle = {
+            "policy_identity_digest": identity.digest,
+            "policy_version": identity.parameter_version,
+            "adapter_name": name,
+            "startup_seconds": startup_seconds,
+            "adapter_sync_seconds": adapter_sync_seconds,
+            "sync_total_seconds": time.perf_counter() - sync_started,
+            "prefix_cache_enabled": False,
+            "numerical_equivalence_class": (
+                f"bf16-external-vs-{identity.quantization}-actor-direct-gkd"
+            ),
+        }
+        return PolicySyncResult(
+            previous_policy_digest=previous,
+            active_policy_digest=identity.digest,
+            changed=previous != identity.digest,
+            state=self._state,
+        )
+
+    def _validate_requests(self, requests: Sequence[GenerationRequest]) -> RolloutPolicyIdentity:
+        if self._state is not BackendLifecycleState.SYNCHRONIZED:
+            raise RuntimeError("generation backend must be synchronized before generate()")
+        if not requests:
+            raise ValueError("generation request batch cannot be empty")
+        assert self._active_identity is not None
+        seen: set[str] = set()
+        for request in requests:
+            if request.request_id in seen:
+                raise ValueError(f"duplicate generation request id {request.request_id!r}")
+            seen.add(request.request_id)
+            if request.expected_policy_identity != self._active_identity:
+                raise RuntimeError("generation request policy identity is stale")
+            if request.need_sampled_token_logprobs:
+                raise RuntimeError(
+                    "vLLM sampled-token logprobs are not qualified for PG; use direct GKD"
+                )
+        return self._active_identity
+
+    def _complete(self, request: GenerationRequest) -> _CompletedRequest:
+        assert self._active_adapter_name is not None
+        payload: dict[str, object] = {
+            "model": self._active_adapter_name,
+            "prompt": list(request.prompt_token_ids),
+            "max_tokens": request.max_new_tokens,
+            "temperature": request.sampling.temperature,
+            "top_p": request.sampling.top_p,
+            # miniVERL uses zero while vLLM uses -1 for disabled top-k sampling.
+            "top_k": request.sampling.top_k or -1,
+            "seed": request.deterministic_sample_seed,
+            # vLLM encodes exact token ids in this envelope even when the
+            # caller does not consume sampled-token logprobs.
+            "logprobs": 1,
+        }
+        if request.stop_sequences:
+            payload["stop"] = list(request.stop_sequences)
+        raw = self.manager.complete(payload)
+        output = parse_vllm_completion(raw, need_logprobs=False)
+        request_id = raw.get("id")
+        return _CompletedRequest(
+            request=request,
+            output=output,
+            raw_request_id=request_id if isinstance(request_id, str) else None,
+        )
+
+    def generate(self, requests: Sequence[GenerationRequest]) -> GenerationBatch:
+        identity = self._validate_requests(requests)
+        started = time.perf_counter()
+        with ThreadPoolExecutor(max_workers=min(len(requests), 8)) as executor:
+            completed = list(executor.map(self._complete, requests))
+        elapsed = time.perf_counter() - started
+        divisor = len(completed)
+        results = tuple(
+            GenerationResult(
+                request_id=item.request.request_id,
+                group=item.request.group,
+                output_token_ids=tuple(item.output.token_ids),
+                decoded_text=item.output.text,
+                sampled_token_logprobs=tuple(item.output.logprobs),
+                stop_reason=item.output.stop_reason,
+                matched_stop=item.output.matched_stop,
+                policy_identity=identity,
+                backend_metrics=BackendMetrics(
+                    total_seconds=elapsed / divisor,
+                    prompt_tokens=len(item.request.prompt_token_ids),
+                    generated_tokens=len(item.output.token_ids),
+                ),
+                raw_backend_request_id=item.raw_request_id,
+            )
+            for item in completed
+        )
+        return GenerationBatch(
+            results=results,
+            policy_identity=identity,
+            physical_batch_sizes=(len(requests),),
+        )
+
+    def quiesce(self) -> None:
+        if self._state is not BackendLifecycleState.SYNCHRONIZED:
+            raise RuntimeError("only a synchronized generation backend can quiesce")
+        self._state = BackendLifecycleState.QUIESCED
+
+    def release_generation_memory(self) -> None:
+        if self._state is BackendLifecycleState.CLOSED:
+            raise RuntimeError("generation backend is closed")
+        started = time.perf_counter()
+        self.manager.close()
+        self._server_adapter_name = None
+        self._state = BackendLifecycleState.QUIESCED
+        self._lifecycle["teardown_seconds"] = time.perf_counter() - started
+
+    def close(self) -> None:
+        if self._state is BackendLifecycleState.CLOSED:
+            return
+        self.manager.close()
+        self._active_identity = None
+        self._active_adapter_name = None
+        self._server_adapter_name = None
+        shutil.rmtree(self.workspace, ignore_errors=True)
+        self._state = BackendLifecycleState.CLOSED

--- a/src/miniverl/runtime/generation.py
+++ b/src/miniverl/runtime/generation.py
@@ -35,6 +35,7 @@ class RolloutBackendKind(str, Enum):
 
     HF_REFERENCE = "hf_reference"
     HF_CACHED = "hf_cached"
+    VLLM = "vllm"
 
 
 class BackendLifecycleState(str, Enum):

--- a/src/miniverl/runtime/rollout.py
+++ b/src/miniverl/runtime/rollout.py
@@ -11,8 +11,14 @@ from miniverl.config.models import RolloutConfig, VerlParquetSourceConfig
 from miniverl.data.verl_parquet import RenderedPrompt
 from miniverl.errors import GpuMemoryError
 from miniverl.models.base import GenerationOutput
-from miniverl.runtime.backends import HFCachedGenerationBackend, HFReferenceGenerationBackend
+from miniverl.runtime.backends import (
+    HFCachedGenerationBackend,
+    HFReferenceGenerationBackend,
+    VLLMGenerationBackend,
+)
 from miniverl.runtime.generation import (
+    BackendLifecycleState,
+    GenerationBackend,
     GenerationRequest,
     GenerationResult,
     PolicySnapshot,
@@ -104,11 +110,19 @@ class PromptDatasetRolloutRuntime:
         self.config = rollout_config
         self.profile_identity = profile_identity
         self.execution_plan_digest = execution_plan_digest
-        self.generation_backend = (
-            HFCachedGenerationBackend(backend, compile_backend=rollout_config.compile_backend)
-            if rollout_config.backend is RolloutBackendKind.HF_CACHED
-            else HFReferenceGenerationBackend(backend)
-        )
+        self.generation_backend: GenerationBackend
+        if rollout_config.backend is RolloutBackendKind.HF_CACHED:
+            self.generation_backend = HFCachedGenerationBackend(
+                backend, compile_backend=rollout_config.compile_backend
+            )
+        elif rollout_config.backend is RolloutBackendKind.VLLM:
+            self.generation_backend = VLLMGenerationBackend(
+                backend,
+                engine_config=rollout_config.engine,
+                max_model_len=rollout_config.max_total_tokens,
+            )
+        else:
+            self.generation_backend = HFReferenceGenerationBackend(backend)
         self._closed = False
 
     @property
@@ -276,54 +290,64 @@ class PromptDatasetRolloutRuntime:
             profile_identity=self.profile_identity,
             execution_plan_digest=self.execution_plan_digest,
         )
-        self.generation_backend.synchronize(PolicySnapshot(policy_identity))
-        indexed: list[tuple[int, GenerationResult]] = []
-        physical_sizes: list[int] = []
-        downshifts = 0
-        for group in batch.physical_batches:
-            rows, sizes, count = self._generate_group(
-                batch,
-                group,
-                base_seed=seed,
-                policy_version=policy_version,
-                policy_identity=policy_identity,
-            )
-            indexed.extend(rows)
-            physical_sizes.extend(sizes)
-            downshifts += count
-        indexed.sort(key=lambda item: item[0])
-        results = tuple(result for _, result in indexed)
-        return GeneratedPromptBatch(
-            outputs=tuple(
-                GenerationOutput(
-                    token_ids=list(result.output_token_ids),
-                    text=result.decoded_text,
-                    stop_reason=result.stop_reason,
-                    matched_stop=result.matched_stop,
-                    logprobs=list(result.sampled_token_logprobs),
+        try:
+            self.generation_backend.synchronize(PolicySnapshot(policy_identity))
+            indexed: list[tuple[int, GenerationResult]] = []
+            physical_sizes: list[int] = []
+            downshifts = 0
+            for group in batch.physical_batches:
+                rows, sizes, count = self._generate_group(
+                    batch,
+                    group,
+                    base_seed=seed,
+                    policy_version=policy_version,
+                    policy_identity=policy_identity,
                 )
-                for result in results
-            ),
-            groups=tuple(result.group for result in results),
-            generation_seeds=tuple(
-                (
-                    seed * 1_000_003 + index
-                    if self.config.backend is RolloutBackendKind.HF_REFERENCE
-                    and self.config.samples_per_prompt == 1
-                    else derive_sample_seed(
-                        run_seed=seed,
-                        prompt_digest=result.group.prompt_digest,
-                        policy_version=policy_version,
-                        sample_index=result.group.sample_index,
+                indexed.extend(rows)
+                physical_sizes.extend(sizes)
+                downshifts += count
+            indexed.sort(key=lambda item: item[0])
+            results = tuple(result for _, result in indexed)
+            return GeneratedPromptBatch(
+                outputs=tuple(
+                    GenerationOutput(
+                        token_ids=list(result.output_token_ids),
+                        text=result.decoded_text,
+                        stop_reason=result.stop_reason,
+                        matched_stop=result.matched_stop,
+                        logprobs=list(result.sampled_token_logprobs),
                     )
-                )
-                for index, result in enumerate(results)
-            ),
-            rollout_policy_identity_digest=policy_identity.digest,
-            policy_version=policy_version,
-            physical_batch_sizes=tuple(physical_sizes),
-            oom_downshifts=downshifts,
-        )
+                    for result in results
+                ),
+                groups=tuple(result.group for result in results),
+                generation_seeds=tuple(
+                    (
+                        seed * 1_000_003 + index
+                        if self.config.backend is RolloutBackendKind.HF_REFERENCE
+                        and self.config.samples_per_prompt == 1
+                        else derive_sample_seed(
+                            run_seed=seed,
+                            prompt_digest=result.group.prompt_digest,
+                            policy_version=policy_version,
+                            sample_index=result.group.sample_index,
+                        )
+                    )
+                    for index, result in enumerate(results)
+                ),
+                rollout_policy_identity_digest=policy_identity.digest,
+                policy_version=policy_version,
+                physical_batch_sizes=tuple(physical_sizes),
+                oom_downshifts=downshifts,
+            )
+        finally:
+            if self.config.backend is RolloutBackendKind.VLLM:
+                # The actor, teacher and optimizer reuse the same consumer GPU.
+                # Always end the managed process group—even when generation or
+                # synchronization fails—before control returns to the trainer.
+                if self.generation_backend.state is BackendLifecycleState.SYNCHRONIZED:
+                    self.generation_backend.quiesce()
+                if self.generation_backend.state is not BackendLifecycleState.CLOSED:
+                    self.generation_backend.release_generation_memory()
 
     def to_trajectories(
         self,

--- a/src/miniverl/training/trainer.py
+++ b/src/miniverl/training/trainer.py
@@ -1240,6 +1240,20 @@ class OPDTrainer:
                     seed=seed,
                 )
                 self._backend_sync_identity = generated.rollout_policy_identity_digest
+                if self.config.rollout.backend.value == "vllm":
+                    lifecycle = getattr(
+                        self.rollout_runtime.generation_backend,
+                        "lifecycle_metrics",
+                        None,
+                    )
+                    self.events.emit(
+                        "rollout_policy_synchronized",
+                        cycle=self.cycle,
+                        policy_version=self.policy_version,
+                        rollout_backend="vllm",
+                        policy_identity_digest=generated.rollout_policy_identity_digest,
+                        lifecycle=(lifecycle() if callable(lifecycle) else {}),
+                    )
                 self._last_rollout_execution = {
                     "physical_batch_sizes": list(generated.physical_batch_sizes),
                     "physical_generation_batches": len(generated.physical_batch_sizes),

--- a/tests/cli/test_opd_product_cli.py
+++ b/tests/cli/test_opd_product_cli.py
@@ -50,6 +50,54 @@ def test_run_dry_compiles_a_valid_native_recipe() -> None:
     assert payload["resolved_native_config"]["loss"]["mode"] == "forward_kl_topk"
 
 
+def test_run_dry_binds_vllm_as_an_explicit_execution_choice() -> None:
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--profile",
+            "verl-opd-v0.8-single-gpu-v1",
+            "--config",
+            "builtin:qwen3-0.6b-1.7b-opd",
+            "--rollout-backend",
+            "vllm",
+            "--dry-run",
+            "--offline",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    native = payload["resolved_native_config"]
+    assert native["rollout"]["backend"] == "vllm"
+    assert native["rollout"]["record_logprobs"] is False
+
+
+def test_pg_profile_refuses_the_nonconformant_vllm_logprob_path(tmp_path: Path) -> None:
+    from miniverl.bridge.profiles import get_profile
+
+    profile = "verl-opd-v0.8-single-gpu-pg-k1-v1"
+    config = tmp_path / "pg-k1.yaml"
+    config.write_text(get_profile(profile).show()["minimal_yaml"], encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--profile",
+            profile,
+            "--config",
+            str(config),
+            "--accept-local-reinterpretations",
+            "--rollout-backend",
+            "vllm",
+            "--dry-run",
+            "--offline",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "direct GKD" in result.output
+
+
 def test_pg_profile_plans_and_dry_runs_through_public_cli(tmp_path: Path) -> None:
     from miniverl.bridge.profiles import get_profile
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -90,6 +90,34 @@ def test_v2_rollout_config_accepts_cached_backend_and_managed_engine_bounds() ->
     assert rollout.compile_backend is True
 
 
+def test_vllm_rollout_requires_managed_localhost_and_direct_gkd_logprob_policy() -> None:
+    rollout = RolloutConfig.model_validate(
+        {
+            "backend": "vllm",
+            "record_logprobs": False,
+            "engine": {"managed": True, "host": "127.0.0.1"},
+        }
+    )
+    assert rollout.backend is RolloutBackendKind.VLLM
+
+    with pytest.raises(ValidationError, match="managed localhost"):
+        RolloutConfig.model_validate(
+            {"backend": "vllm", "engine": {"managed": False, "host": "127.0.0.1"}}
+        )
+    with pytest.raises(ValidationError, match="managed localhost"):
+        RolloutConfig.model_validate(
+            {"backend": "vllm", "engine": {"managed": True, "host": "0.0.0.0"}}
+        )
+    with pytest.raises(ValidationError, match="direct GKD"):
+        RolloutConfig.model_validate(
+            {
+                "backend": "vllm",
+                "record_logprobs": True,
+                "engine": {"managed": True, "host": "127.0.0.1"},
+            }
+        )
+
+
 def _read_raw(path: Path) -> Any:
     return yaml.safe_load(path.read_text(encoding="utf-8"))
 

--- a/tests/unit/test_opd_immutable_plan.py
+++ b/tests/unit/test_opd_immutable_plan.py
@@ -97,6 +97,53 @@ def test_plan_bytes_are_deterministic_for_unchanged_inputs(tmp_path: Path) -> No
     assert first.read_bytes() == second.read_bytes()
 
 
+def test_vllm_execution_choice_is_bound_into_the_immutable_plan(tmp_path: Path) -> None:
+    default_plan, profile, _, default_payload = _write_plan(tmp_path)
+    external_plan = tmp_path / "vllm-plan.json"
+    planned = runner.invoke(
+        app,
+        [
+            "plan",
+            "--config",
+            str(profile),
+            "--accept-local-reinterpretations",
+            "--rollout-backend",
+            "vllm",
+            "--out",
+            str(external_plan),
+            "--offline",
+            "--json",
+        ],
+    )
+    assert planned.exit_code == 0, planned.output
+    external_payload = json.loads(external_plan.read_text(encoding="utf-8"))
+    assert external_payload["resolved_native_config"]["rollout"]["backend"] == "vllm"
+    assert external_payload["plan_digest"] != default_payload["plan_digest"]
+    assert external_plan.read_bytes() != default_plan.read_bytes()
+
+    dry = runner.invoke(
+        app,
+        ["run", "--plan", str(external_plan), "--dry-run", "--offline", "--json"],
+    )
+    assert dry.exit_code == 0, dry.output
+    assert json.loads(dry.stdout)["resolved_native_config"]["rollout"]["backend"] == "vllm"
+
+    refused_override = runner.invoke(
+        app,
+        [
+            "run",
+            "--plan",
+            str(external_plan),
+            "--rollout-backend",
+            "hf_cached",
+            "--dry-run",
+            "--offline",
+        ],
+    )
+    assert refused_override.exit_code == 1
+    assert "cannot be combined" in refused_override.output
+
+
 def test_run_from_plan_does_not_recompile_and_rejects_plan_tampering(tmp_path: Path) -> None:
     plan, _, _, payload = _write_plan(tmp_path)
     accepted = runner.invoke(

--- a/tests/unit/test_opd_runtime_plan.py
+++ b/tests/unit/test_opd_runtime_plan.py
@@ -54,6 +54,20 @@ def test_native_compilation_preserves_pure_opd_semantics() -> None:
     assert native.eval.enabled is False
 
 
+def test_direct_gkd_can_bind_the_measured_vllm_runtime_without_changing_profile_identity() -> None:
+    compiled = load_verl_opd_v08_source("builtin:qwen3-0.6b-1.7b-opd")
+    default = compile_native_run_config(compiled)
+    external = compile_native_run_config(compiled, rollout_backend="vllm")
+
+    assert default.run.profile_identity == external.run.profile_identity
+    assert default.rollout.backend.value == "hf_reference"
+    assert external.rollout.backend.value == "vllm"
+    assert external.rollout.record_logprobs is False
+    assert external.rollout.engine.managed is True
+    assert external.rollout.engine.host == "127.0.0.1"
+    assert external.rollout.engine.memory_fraction == 0.5
+
+
 def test_runtime_critical_model_settings_are_explicit_and_effective() -> None:
     source = load_verl_opd_v08_source("builtin:qwen3-0.6b-1.7b-opd").source.model_dump(mode="json")
     source["miniverl"]["actor_runtime"]["dtype"] = "float16"

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -108,6 +108,7 @@ TORCH_FREE_MODULES = (
     "miniverl.runtime.backends",
     "miniverl.runtime.backends.hf_reference",
     "miniverl.runtime.backends.hf_cached",
+    "miniverl.runtime.backends.vllm",
     "miniverl.runtime.roles",
     "miniverl.utils",
     "miniverl.utils.env",

--- a/tests/unit/test_vllm_rollout_backend.py
+++ b/tests/unit/test_vllm_rollout_backend.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from miniverl.config.models import RolloutEngineConfig
+from miniverl.runtime.generation import (
+    BackendLifecycleState,
+    GenerationRequest,
+    PolicySnapshot,
+    RolloutBackendKind,
+    RolloutGroupIdentity,
+    RolloutPolicyIdentity,
+    SamplingParameters,
+)
+
+
+def _identity(version: int) -> RolloutPolicyIdentity:
+    return RolloutPolicyIdentity(
+        parameter_version=version,
+        base_model_id="org/model",
+        base_model_revision="revision",
+        tokenizer_structural_identity="1" * 64,
+        student_adapter_manifest_digest="2" * 64,
+        adapter_tensor_digest=f"{version:x}" * 64,
+        quantization="nf4",
+        dtype="bfloat16",
+        generation_backend=RolloutBackendKind.VLLM,
+        backend_version="vllm-0.28.0-direct-gkd-v1",
+        profile_identity="4" * 64,
+        execution_plan_digest="5" * 64,
+    )
+
+
+def _request(identity: RolloutPolicyIdentity, index: int = 0) -> GenerationRequest:
+    return GenerationRequest(
+        request_id=f"request-{index}",
+        group=RolloutGroupIdentity(
+            prompt_group_id="group",
+            prompt_digest="a" * 64,
+            sample_index=index,
+            samples_per_prompt=2,
+        ),
+        deterministic_sample_seed=101 + index,
+        prompt_token_ids=(7, 8, 9),
+        max_new_tokens=2,
+        sampling=SamplingParameters(temperature=0.8, top_p=0.9, top_k=8),
+        need_sampled_token_logprobs=False,
+        expected_policy_identity=identity,
+    )
+
+
+def test_vllm_launch_is_local_managed_and_disables_persistent_prefix_cache() -> None:
+    from miniverl.runtime.backends.vllm import build_vllm_server_command
+
+    command, environment = build_vllm_server_command(
+        python_executable="/venv/bin/python",
+        model_path="/models/snapshot",
+        host="127.0.0.1",
+        port=30123,
+        memory_fraction=0.7,
+        max_model_len=2048,
+        wsl_compatibility=True,
+    )
+
+    assert command[:3] == ["/venv/bin/python", "-m", "vllm.entrypoints.openai.api_server"]
+    assert command[command.index("--host") + 1] == "127.0.0.1"
+    assert "--no-enable-prefix-caching" in command
+    assert "--enable-lora" in command
+    assert environment["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] == "True"
+    assert environment["VLLM_USE_V2_MODEL_RUNNER"] == "0"
+    assert environment["VLLM_USE_FLASHINFER_SAMPLER"] == "0"
+
+
+def test_vllm_completion_parser_requires_raw_ids_and_aligned_logprobs() -> None:
+    from miniverl.runtime.backends.vllm import parse_vllm_completion
+
+    payload = {
+        "id": "cmpl-1",
+        "choices": [
+            {
+                "finish_reason": "length",
+                "stop_reason": None,
+                "text": "ignored",
+                "logprobs": {
+                    "tokens": ["token_id:17", "token_id:19"],
+                    "token_logprobs": [-0.25, -0.5],
+                },
+            }
+        ],
+    }
+    parsed = parse_vllm_completion(payload, need_logprobs=True)
+    assert parsed.token_ids == [17, 19]
+    assert parsed.logprobs == [-0.25, -0.5]
+    assert parsed.stop_reason == "max_new_tokens"
+
+    malformed = json.loads(json.dumps(payload))
+    malformed["choices"][0]["logprobs"]["tokens"][0] = "plain text"
+    with pytest.raises(RuntimeError, match="raw token id"):
+        parse_vllm_completion(malformed, need_logprobs=True)
+
+    unaligned = json.loads(json.dumps(payload))
+    unaligned["choices"][0]["logprobs"]["token_logprobs"] = [-0.25]
+    with pytest.raises(RuntimeError, match="align"):
+        parse_vllm_completion(unaligned, need_logprobs=True)
+
+    nonfinite = json.loads(json.dumps(payload))
+    nonfinite["choices"][0]["logprobs"]["token_logprobs"][0] = math.inf
+    with pytest.raises(RuntimeError, match="non-finite"):
+        parse_vllm_completion(nonfinite, need_logprobs=True)
+
+
+class _FakeManager:
+    def __init__(self) -> None:
+        self.started = 0
+        self.closed = 0
+        self.loaded: list[tuple[str, Path]] = []
+        self.unloaded: list[str] = []
+        self.requests: list[dict[str, object]] = []
+
+    def start(self) -> None:
+        self.started += 1
+
+    def load_adapter(self, name: str, path: Path) -> None:
+        self.loaded.append((name, path))
+
+    def unload_adapter(self, name: str) -> None:
+        self.unloaded.append(name)
+
+    def complete(self, payload: dict[str, object]) -> dict[str, object]:
+        self.requests.append(payload)
+        return {
+            "id": f"cmpl-{len(self.requests)}",
+            "choices": [
+                {
+                    "finish_reason": "length",
+                    "stop_reason": None,
+                    "text": "decoded",
+                    "logprobs": {
+                        "tokens": ["token_id:17", "token_id:19"],
+                        "token_logprobs": [-0.25, -0.5],
+                    },
+                }
+            ],
+        }
+
+    def close(self) -> None:
+        self.closed += 1
+
+
+class _FailingLoadManager(_FakeManager):
+    def load_adapter(self, name: str, path: Path) -> None:
+        if self.loaded:
+            raise RuntimeError("injected adapter load failure")
+        super().load_adapter(name, path)
+
+
+class _FakeModelBackend:
+    model_id = "org/model"
+    model_revision = "revision"
+    capabilities = SimpleNamespace(device="cuda", name="org/model")
+
+    def export_rollout_adapter(self, target: Path) -> None:
+        target.mkdir(parents=True)
+        (target / "adapter_config.json").write_text("{}", encoding="utf-8")
+        (target / "adapter_model.safetensors").write_bytes(b"weights")
+
+
+def test_vllm_backend_uses_unique_content_bound_adapter_names_and_tears_down(
+    tmp_path: Path,
+) -> None:
+    from miniverl.runtime.backends.vllm import VLLMGenerationBackend
+
+    manager = _FakeManager()
+    backend = VLLMGenerationBackend(
+        _FakeModelBackend(),
+        engine_config=RolloutEngineConfig(),
+        max_model_len=2048,
+        workspace=tmp_path,
+        manager=manager,
+    )
+    assert backend.inspect().supports_sampled_token_logprobs is False
+    first = _identity(1)
+    second = _identity(2)
+
+    backend.synchronize(PolicySnapshot(first))
+    first_name = manager.loaded[-1][0]
+    assert "p00000001" in first_name
+    assert first.adapter_tensor_digest[:12] in first_name
+    generated = backend.generate([_request(first, 0), _request(first, 1)])
+    assert [row.output_token_ids for row in generated.results] == [(17, 19), (17, 19)]
+    assert all(not row.sampled_token_logprobs for row in generated.results)
+
+    backend.synchronize(PolicySnapshot(second))
+    second_name = manager.loaded[-1][0]
+    assert second_name != first_name
+    assert manager.unloaded == [first_name]
+    lifecycle = backend.lifecycle_metrics()
+    assert lifecycle["policy_identity_digest"] == second.digest
+    assert lifecycle["adapter_name"] == second_name
+    assert lifecycle["prefix_cache_enabled"] is False
+    assert lifecycle["numerical_equivalence_class"] == "bf16-external-vs-nf4-actor-direct-gkd"
+
+    backend.quiesce()
+    backend.release_generation_memory()
+    assert manager.closed == 1
+    assert backend.state is BackendLifecycleState.QUIESCED
+    assert backend.lifecycle_metrics()["teardown_seconds"] >= 0.0
+    backend.close()
+    assert backend.state is BackendLifecycleState.CLOSED
+
+
+def test_vllm_backend_translates_disabled_top_k_to_engine_sentinel(tmp_path: Path) -> None:
+    from miniverl.runtime.backends.vllm import VLLMGenerationBackend
+
+    manager = _FakeManager()
+    backend = VLLMGenerationBackend(
+        _FakeModelBackend(),
+        engine_config=RolloutEngineConfig(),
+        max_model_len=2048,
+        workspace=tmp_path,
+        manager=manager,
+    )
+    identity = _identity(1)
+    request = _request(identity)
+    request = GenerationRequest(
+        **{
+            **request.__dict__,
+            "sampling": SamplingParameters(temperature=0.8, top_p=0.9, top_k=0),
+        }
+    )
+
+    backend.synchronize(PolicySnapshot(identity))
+    backend.generate([request])
+
+    assert manager.requests[-1]["top_k"] == -1
+    backend.close()
+
+
+def test_vllm_constructor_removes_workspace_when_snapshot_resolution_fails(
+    tmp_path: Path,
+) -> None:
+    from miniverl.runtime.backends.vllm import VLLMGenerationBackend
+
+    before = set(tmp_path.iterdir())
+    with (
+        patch(
+            "miniverl.runtime.backends.vllm._resolve_model_snapshot",
+            side_effect=RuntimeError("injected snapshot failure"),
+        ),
+        pytest.raises(RuntimeError, match="injected snapshot failure"),
+    ):
+        VLLMGenerationBackend(
+            _FakeModelBackend(),
+            engine_config=RolloutEngineConfig(),
+            max_model_len=2048,
+            workspace=tmp_path,
+        )
+
+    assert set(tmp_path.iterdir()) == before
+
+
+def test_vllm_adapter_export_failure_removes_partial_materialization(tmp_path: Path) -> None:
+    from miniverl.runtime.backends.vllm import VLLMGenerationBackend
+
+    class BrokenBackend(_FakeModelBackend):
+        def export_rollout_adapter(self, target: Path) -> None:
+            target.mkdir(parents=True)
+            (target / "adapter_config.json").write_text("{}", encoding="utf-8")
+            raise RuntimeError("injected export failure")
+
+    manager = _FakeManager()
+    backend = VLLMGenerationBackend(
+        BrokenBackend(),
+        engine_config=RolloutEngineConfig(),
+        max_model_len=2048,
+        workspace=tmp_path,
+        manager=manager,
+    )
+    with pytest.raises(RuntimeError, match="injected export failure"):
+        backend.synchronize(PolicySnapshot(_identity(1)))
+
+    assert manager.started == 0
+    assert not list(backend.workspace.glob("miniverl-p*"))
+    backend.close()
+
+
+def test_vllm_failed_policy_refresh_cannot_generate_with_previous_identity(
+    tmp_path: Path,
+) -> None:
+    from miniverl.runtime.backends.vllm import VLLMGenerationBackend
+
+    manager = _FailingLoadManager()
+    backend = VLLMGenerationBackend(
+        _FakeModelBackend(),
+        engine_config=RolloutEngineConfig(),
+        max_model_len=2048,
+        workspace=tmp_path,
+        manager=manager,
+    )
+    first = _identity(1)
+    backend.synchronize(PolicySnapshot(first))
+
+    with pytest.raises(RuntimeError, match="injected adapter load failure"):
+        backend.synchronize(PolicySnapshot(_identity(2)))
+    assert backend.state is BackendLifecycleState.QUIESCED
+    with pytest.raises(RuntimeError, match="synchronized"):
+        backend.generate([_request(first)])
+    backend.close()


### PR DESCRIPTION
## Summary

- add a pinned, miniVERL-managed vLLM 0.28.0 rollout backend for the direct-GKD profile
- bind the selected rollout backend into immutable plans and expose it through `miniverl plan` / `miniverl run`
- synchronize content-bound PEFT adapters, request raw token IDs, and tear down the complete localhost process group before teacher scoring and training updates
- keep PG-k1 on `hf_cached` because the external BF16 rollout engine did not pass the sampled-token log-probability conformance threshold against the NF4 actor

## Qualification

The single-RTX-4080 WSL2 spike compared the two candidate engines before implementation:

- SGLang 0.5.18 could not complete the qualified path without a system CUDA compiler/JIT dependency and was rejected cleanly.
- vLLM 0.28.0 completed health, raw-token, dynamic-LoRA, repeated refresh, teardown, and managed miniVERL end-to-end probes with the WSL2 compatibility flags recorded in the launcher.
- With persistent prefix caching disabled, vLLM measured 238.27 tok/s at response length 256 and 284.18 tok/s at 512, versus 122.44 and 124.70 tok/s for `hf_cached` (1.95x and 2.28x).
- Greedy outputs agreed on 32/32 tokens. Sampled-token log-probability error did not pass the PG gate (max 1.803, mean 0.309, p99 1.592), so the backend fails closed for log-probability-dependent training.

The formal checksummed scorecard and benchmark record remain a separate evidence PR. No frozen task result or scientific conclusion changes here.

## Validation

- `git diff --check`
- `ruff check .`
- `ruff format --check .`
- `mypy src/miniverl`
- `actionlint` 1.7.12
- `pytest -q -m "not gpu and not network" --cov=miniverl`: 2469 passed, 9 skipped, 83% coverage
- `pytest -q -m gpu`: 10 passed
- `pytest -q -m network`: 16 passed
- `mkdocs build --strict`
- generated documentation artifact checks, Markdown links, and text-integrity checks
- `python -m build` and `python -m twine check dist/*`
- clean core wheel install and source/package inventory checks
- frozen calculator JSON SHA-256 remains `53fc1d4d5b7adee09618d77ad62d4086ba56b78569832d6fc7c3bcd5c2695bbc`
