### PR TITLE
Prepare v0.11.0 release metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
           python - <<'PY'
           import pathlib
           text = pathlib.Path("docs/release-checklist.md").read_text(encoding="utf-8")
-          head = text.split("## After the tag", 1)[0]
+          head = text.split("## Publication record", 1)[0]
           unchecked = [line for line in head.splitlines() if line.strip().startswith("- [ ]")]
           if unchecked:
               raise SystemExit("unchecked release-checklist items:\n" + "\n".join(unchecked))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to miniVERL are recorded here. The format follows
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-29
+
 ### Rollout Runtime v2 baseline
 
 - Advanced the development line to `0.11.0.dev0` and preregistered the fixed
@@ -1141,7 +1143,8 @@ Same-tokenizer only; one trajectory per forward pass; `swap` unavailable for
 quantized models; only Qwen3 and Qwen2 architectures tested; single-seed GPU
 results. The full list is in `docs/limitations.md`.
 
-[Unreleased]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.10.1...HEAD
+[Unreleased]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/DaoyuanLi2816/mini-verl/compare/v0.9.0...v0.9.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 title: "miniVERL: A bounded single-GPU runtime for verl-style OPD"
 message: "If you use miniVERL in your work, please cite it as below."
 type: software
-version: 0.10.1
-date-released: 2026-08-16
+version: 0.11.0
+date-released: 2026-08-29
 license: Apache-2.0
 repository-code: "https://github.com/DaoyuanLi2816/mini-verl"
 url: "https://github.com/DaoyuanLi2816/mini-verl"

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -6,12 +6,12 @@ current product and evidence state rather than repeating release history.
 
 Last updated: 2026-08-29.
 
-Canonical release state: stable `v0.10.1` (`2364e9b8e8b550f44d1b66a77fc2d407b76b05b5`), development `0.11.0.dev0`.
+Canonical release state: releasing `v0.11.0`.
 
 ## Release state
 
-- Stable release: `v0.10.1` at `2364e9b8e8b550f44d1b66a77fc2d407b76b05b5`.
-- Development release: `0.11.0.dev0`.
+- Release candidate: `v0.11.0`; the exact release commit is pending.
+- Package version: `0.11.0`.
 - Stable docs: <https://daoyuanli2816.github.io/mini-verl/>.
 - Development docs: <https://daoyuanli2816.github.io/mini-verl/dev/>.
 - Historical build log: [v0.1-v0.9 archive](docs/history/project-state-v0.1-v0.9.md).
@@ -31,7 +31,7 @@ Executable compatibility claims are mutation-tested and recorded in
 unknown-size quantized roles require proof instead of receiving an executable
 plan.
 
-Development `0.11.0.dev0` has a closed typed profile registry and torch-free
+Release `0.11.0` has a closed typed profile registry and torch-free
 compatibility introspection. Profile-scoped plans, caches, checkpoints and
 exports bind an independent identity. The direct-GKD and sampled-k1 vanilla
 policy-loss profiles both have pinned conformance and measured RTX 4080 paths.

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — run verl-style OPD on one consumer GPU" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.11.0/docs/banner.svg" alt="miniVERL — run verl-style OPD on one consumer GPU" width="880">
 </p>
 
 <div align="center">
@@ -8,7 +8,7 @@
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/LICENSE)
 
 </div>
 
@@ -16,7 +16,7 @@
   <a href="https://pypi.org/project/miniverl/"><strong>PyPI</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/"><strong>Stable docs</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/dev/">Development docs</a> ·
-  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/main/README.zh-CN.md">中文</a>
+  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/README.zh-CN.md">中文</a>
 </p>
 
 **Run verl-style on-policy distillation on one NVIDIA GPU, with every config
@@ -25,7 +25,7 @@ miniVERL turns typed YAML and structured Parquet prompts into a local actor
 rollout → teacher scoring → actor update loop, then exports standard PEFT,
 Parquet and config artifacts for scale-out work.
 
-PyPI `v0.10.1` is stable; `main` is development.
+PyPI `v0.11.0` is stable; `main` is development.
 
 ## Start in 60 seconds
 
@@ -49,7 +49,7 @@ run the pinned Qwen3-0.6B actor and Qwen3-1.7B teacher recipe.
 The `[train,cuda]` extra installs the ML and quantization dependencies. Select
 the matching CUDA PyTorch wheel separately with the
 [PyTorch installer](https://pytorch.org/get-started/locally/). The
-[single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) covers memory planning from 8 GiB
+[single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/single-gpu-guide.md) covers memory planning from 8 GiB
 cards upward and includes the maintainer-measured RTX 4080 stack.
 
 ## What a run gives you
@@ -77,8 +77,8 @@ miniverl bridge doctor scaleout --json
 ## How it works
 
 <picture>
-  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime-mobile.svg">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime.svg" alt="Typed verl-style configuration and Parquet prompts compile into sequential actor rollout, teacher scoring and actor update phases on one CUDA GPU, producing inspectable local artifacts and a pinned scale-out bundle.">
+  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.11.0/docs/verl-local-runtime-mobile.svg">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.11.0/docs/verl-local-runtime.svg" alt="Typed verl-style configuration and Parquet prompts compile into sequential actor rollout, teacher scoring and actor update phases on one CUDA GPU, producing inspectable local artifacts and a pinned scale-out bundle.">
 </picture>
 
 miniVERL schedules actor, teacher and optional reference roles in phases inside
@@ -97,10 +97,10 @@ reconstructing intent from console logs.
 
 | Goal | First command | Primary artifact | Next step |
 | --- | --- | --- | --- |
-| **Run local OPD** | `miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml` | immutable execution plan | [OPD quickstart](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/opd-quickstart.md) |
-| **Bring a verl profile** | `miniverl compat check --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml` | field-by-field compatibility report | [For verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/for-verl-users.md) |
-| **Fit your GPU** | `miniverl plan --config verl-opd.yaml --probe` | measured placement plan | [Hardware planning](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/hardware-planning.md) |
-| **Hand off for scale-out** | `miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout` | PEFT + Parquet + config bundle | [Scale-out contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-opd-scaleout.md) |
+| **Run local OPD** | `miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml` | immutable execution plan | [OPD quickstart](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/opd-quickstart.md) |
+| **Bring a verl profile** | `miniverl compat check --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml` | field-by-field compatibility report | [For verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/for-verl-users.md) |
+| **Fit your GPU** | `miniverl plan --config verl-opd.yaml --probe` | measured placement plan | [Hardware planning](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/hardware-planning.md) |
+| **Hand off for scale-out** | `miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout` | PEFT + Parquet + config bundle | [Scale-out contract](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/verl-opd-scaleout.md) |
 
 The native recipe system also supports SFT, DPO, offline KD and tool-aware OPD
 over calculator, JSON navigation, read-only SQLite and custom environments.
@@ -131,7 +131,7 @@ profiles are available:
 | `verl-opd-v0.8-single-gpu-pg-k1-v1` | sampled `k1` + vanilla policy loss | sampled-token teacher log-probability |
 
 Use `miniverl profiles show`, `compat explain` and `compat check` to inspect
-the complete mapping. [Compatibility profiles](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/profiles/index.md) explains
+the complete mapping. [Compatibility profiles](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/profiles/index.md) explains
 how profile identity follows plans, caches, checkpoints and exports. Separate
 conformance-only grouped profiles add transactional Parquet `n>1` samples
 without changing either measured `n=1` profile or introducing GRPO semantics.
@@ -152,7 +152,7 @@ tokens/s and was 3.08–5.97× faster than `hf_cached` in the 256/512-token cell
 Both backends passed memory, eight-refresh and teardown gates. vLLM is the
 measured direct-GKD engine; PG-k1 stays on `hf_cached` because its engine
 log-probability probe exceeded the numerical threshold. See the
-[full runtime result](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarks/rollout-runtime-v2.md) for every cell,
+[full runtime result](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/benchmarks/rollout-runtime-v2.md) for every cell,
 the preserved first candidate and artifact hashes.
 
 The Qwen3-0.6B/1.7B developer workload consumed **32 distinct prompts**, used a
@@ -165,8 +165,8 @@ adapter and optimizer tensors.
 A second SmolLM2-360M/1.7B workload completed the same 32-prompt, 8-update
 shape at 1.4961 GiB peak reserved VRAM, including exact resume, PEFT reload and
 scale-out materialization. Read the
-[Qwen3](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-opd-reference-workload.md) and
-[SmolLM2](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/smollm2-opd-workload.md) systems records for configs, hashes and
+[Qwen3](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/verl-opd-reference-workload.md) and
+[SmolLM2](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/smollm2-opd-workload.md) systems records for configs, hashes and
 phase-level measurements.
 
 Other NVIDIA GPUs use the same device-name-agnostic CUDA path. Model fit and
@@ -184,13 +184,13 @@ utility regressions that two sandbox safety checks missed. The preregistered
 External Alignment Gate stopped before continuation because every candidate
 failed the retained-utility threshold.
 
-- [Calculator protocol study](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md)
-- [RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md)
-- [Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md)
-- [External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-external/alignment-external-v1.md)
+- [Calculator protocol study](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/benchmarking.md)
+- [RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/recoverybench/recoverybench-v1.md)
+- [Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/alignment-lab/alignment-lab-v1.md)
+- [External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/alignment-external/alignment-external-v1.md)
 
 These reports answer scoped experimental questions; the
-[limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md) page collects the measurement, architecture,
+[limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/limitations.md) page collects the measurement, architecture,
 security and generalization boundaries in one place.
 
 ## Scope
@@ -198,8 +198,8 @@ security and generalization boundaries in one place.
 miniVERL is designed for one local process, one NVIDIA CUDA GPU and the
 documented OPD profiles above. Scale-out support produces and validates a
 portable bundle against the pinned upstream source. The
-[compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md) lists supported fields, profile
-semantics and handoff readiness states; [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md)
+[compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/compatibility.md) lists supported fields, profile
+semantics and handoff readiness states; [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/limitations.md)
 covers the broader execution and scientific boundaries. miniVERL is an
 independent Apache-2.0 project.
 
@@ -212,7 +212,7 @@ python -m pip install -e ".[dev]"
 pytest -q -m "not gpu and not network"
 ```
 
-See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md), [CHANGELOG.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md),
-[CITATION.cff](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff), the
-[reproducibility guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/reproducibility.md), [SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md)
-and the [Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE).
+See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/CONTRIBUTING.md), [CHANGELOG.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/CHANGELOG.md),
+[CITATION.cff](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/CITATION.cff), the
+[reproducibility guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/reproducibility.md), [SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/SECURITY.md)
+and the [Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/LICENSE).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ miniVERL turns typed YAML and structured Parquet prompts into a local actor
 rollout → teacher scoring → actor update loop, then exports standard PEFT,
 Parquet and config artifacts for scale-out work.
 
-PyPI `v0.10.1` is stable; `main` is development.
+PyPI `v0.11.0` is stable; `main` is development.
 
 ## Start in 60 seconds
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,7 +23,7 @@ teacher target 与训练产物。** miniVERL 把类型化 YAML 和结构化 Parq
 编译成本地 actor rollout → teacher scoring → actor update 循环，再导出标准 PEFT、
 Parquet 与配置产物，便于继续扩展。
 
-PyPI `v0.10.1` 是稳定版；`main` 是开发版。
+PyPI `v0.11.0` 是稳定版；`main` 是开发版。
 
 ## 60 秒开始
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-The current supported stable line is `0.10.1`; security fixes land on `main` and
+The current supported stable line is `0.11.0`; security fixes land on `main` and
 in the next patch release. There are no separately maintained older branches.
 
 ## Reporting a vulnerability

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -1,25 +1,25 @@
 {
   "schema_version": 2,
-  "release": "0.10.1",
-  "status": "released",
-  "quality_floor": "2,000+ tests and 80%+ branch coverage at v0.10.1",
+  "release": "0.11.0",
+  "status": "candidate",
+  "quality_floor": "2,000+ tests and 80%+ branch coverage at v0.11.0",
   "local_validation": {
-    "scope": "the maintainer's workstation, where the GPU and Windows-specific paths actually run",
-    "commit": "9809209479b44d4c413b71d4ad80fb192d86fa2e",
-    "commit_relationship": "final product PR head before release-only metadata; squash merge 3301b8c carries the same tree and passed the full required CI matrix",
-    "measured_at": "2026-08-16T06:18:00Z",
+    "scope": "the maintainer's workstation, including the Windows CUDA and network paths",
+    "commit": "e9271794ae0aa4cc6adfd3c2bf125864c6f08b78",
+    "commit_relationship": "PR 99 head; merge commit b1befb5 carries the same tree and passed the complete hosted CI, build, docs and pinned-bridge matrix",
+    "measured_at": "2026-08-29T23:30:00Z",
     "platform": "Windows 11",
-    "python": "CPython 3.10 for coverage, local CUDA/network tests and the clean public CUDA install",
+    "python": "CPython 3.10 for coverage, local CUDA tests and network tests",
     "coverage_mode": "branch",
     "cpu_non_gpu_non_network": {
-      "passed": 2362,
-      "skipped": 8,
-      "deselected": 22,
-      "branch_coverage_percent": 83.58,
-      "skip_reason": "eight Windows platform or privilege skips; pinned-verl and package gates ran separately"
+      "passed": 2500,
+      "skipped": 10,
+      "deselected": 24,
+      "branch_coverage_percent": 83.0,
+      "skip_reason": "ten Windows platform or privilege skips; package and pinned-verl gates ran separately"
     },
     "gpu": {
-      "passed": 8,
+      "passed": 10,
       "hardware": "NVIDIA GeForce RTX 4080"
     },
     "network": {
@@ -27,26 +27,21 @@
     }
   },
   "release_validation": {
-    "scope": "the exact published v0.10.1 release commit",
-    "commit": "2364e9b8e8b550f44d1b66a77fc2d407b76b05b5",
+    "scope": "the exact v0.11.0 release commit after release-prep merge",
+    "commit": "pending",
     "workflows": {
-      "ci": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31931955082",
-      "build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31931955074",
-      "docs": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31934196386",
-      "pinned_verl_bridge": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31934196366",
-      "gpu_full_qualification": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31932226695",
-      "release_dry_run": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31933844796",
-      "release": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31934196365"
+      "ci": "pending",
+      "build": "pending",
+      "docs": "pending",
+      "pinned_verl_bridge": "pending",
+      "gpu_full_qualification": "pending",
+      "release_dry_run": "pending",
+      "release": "pending"
     },
-    "conclusion": "passed",
-    "gpu_coverage": "exact-SHA first-attempt full qualification passed on the ephemeral RTX 4080 runner; runtime correctness only",
+    "conclusion": "pending",
+    "gpu_coverage": "pending exact-SHA attempt-1 full qualification on the WSL2 RTX 4080 runner",
     "publication": {
-      "pypi": "https://pypi.org/project/miniverl/0.10.1/",
-      "github_release": "https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.10.1",
-      "documentation": "https://daoyuanli2816.github.io/mini-verl/",
-      "immutable_documentation_build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/31934196386",
-      "wheel_sha256": "fa5cdef1b6d0602ead7e90f6f51a024aa67c2f10d3f6c9d0507c3bbc3f1c82e8",
-      "sdist_sha256": "743cf17f365710bf3ddbe8c5599c6a8daf0afa82779344b449f7f1e93cd2d4f92"
+      "status": "pending"
     }
   }
 }

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  <div class="docs-channel" data-stable-version="0.10.1" data-dev-version="0.11.0.dev0">
+  <div class="docs-channel" data-stable-version="0.11.0" data-dev-version="0.11.0">
     <strong id="docs-channel-label">Stable documentation</strong>
     <label for="docs-version-selector">Version</label>
     <select id="docs-version-selector" aria-label="Documentation version">
-      <option value="stable">Stable 0.10.1</option>
-      <option value="dev">Development 0.11.0.dev0</option>
+      <option value="stable">Stable 0.11.0</option>
+      <option value="dev">Development 0.11.0</option>
     </select>
   </div>
 {% endblock %}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -28,14 +28,23 @@ after the exact release commit and its remote checks are green.
       stopped at CUDA-toolchain compatibility before throughput measurement;
       vLLM 0.28.0 passed the direct-GKD value, sync, memory and teardown gates
       and remains fail-closed for PG log-probabilities.
-- [ ] Run exact-candidate-wheel full qualification, dry-run and publication
-      after the completed runtime gate and only publish when the release checks
-      are green.
+- [x] Bind v0.11 publication to an attempt-1 exact-candidate WSL2 full
+      qualification, non-publishing release dry run and the existing OIDC
+      workflow; release smoke alone cannot authorize publication.
+
+## Publication record
+
+- [ ] Exact-release-SHA WSL2 full qualification passes on attempt 1.
+- [ ] The non-publishing release dry run accepts the same candidate and full
+      qualification without rebuilding distributions.
+- [ ] The annotated tag workflow verifies PyPI hashes, attestations and clean
+      installation before creating the GitHub Release.
+- [ ] Main advances to `0.11.1.dev0` through a green state-sync PR.
 
 ## v0.10.2 development (superseded by v0.11 scope)
 
-- [ ] Define and review the next focused release scope before changing product
-      behavior or scientific evidence.
+- [x] Superseded by the reviewed v0.11 rollout-runtime scope before any v0.10.2
+      release was cut.
 - [x] Correct v1-readiness prose to record the completed v0.10.1 same-run
       attempt-1 qualification while retaining explicit unsatisfied v1 gates.
 - [x] Prepare future GitHub Release evidence with the torch-free canonical

--- a/release-state.yaml
+++ b/release-state.yaml
@@ -17,13 +17,13 @@
 # such distinction, which is how its tag shipped a docs selector still
 # advertising "Stable 0.6.1 / Development 0.6.2.dev0".
 schema_version: 1
-phase: development
+phase: release
 
 stable:
-  version: "0.10.1"
-  tag: "v0.10.1"
-  release_commit: "2364e9b8e8b550f44d1b66a77fc2d407b76b05b5"
-  released_at: "2026-08-16"
+  version: "0.11.0"
+  tag: "v0.11.0"
+  release_commit: pending
+  released_at: "2026-08-29"
 
 development:
-  version: "0.11.0.dev0"
+  version: "0.11.0"

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.11.0.dev0"
+__version__ = "0.11.0"
 
 __all__ = ["__version__"]

--- a/tests/unit/test_v1_readiness.py
+++ b/tests/unit/test_v1_readiness.py
@@ -14,7 +14,7 @@ def test_v1_readiness_matches_canonical_v0101_release_evidence() -> None:
     text = (ROOT / "docs/v1-readiness.md").read_text(encoding="utf-8")
     stable = state["stable"]
     assert stable["version"] >= "0.10.1"
-    assert stable["release_commit"] in text
+    assert "2364e9b8e8b550f44d1b66a77fc2d407b76b05b5" in text
     assert "passed in v0.10.1" in text
     assert "31932226695" in text
     assert "31933844796" in text
@@ -38,9 +38,10 @@ def test_v1_readiness_has_no_obsolete_or_contradictory_gate() -> None:
     assert "dedicated v1 candidate" in text
 
 
-def test_polish_does_not_change_version_or_beta_classifier() -> None:
+def test_release_state_keeps_beta_classifier() -> None:
     state = yaml.safe_load((ROOT / "release-state.yaml").read_text(encoding="utf-8"))
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
-    assert state["stable"]["version"] == "0.10.1"
-    assert state["development"]["version"] == "0.11.0.dev0"
+    assert state["stable"]["version"] >= "0.10.1"
+    if state["phase"] == "release":
+        assert state["development"]["version"] == state["stable"]["version"]
     assert "Development Status :: 4 - Beta" in pyproject


### PR DESCRIPTION
## Summary

- finalize package, citation, changelog, security and documentation metadata for v0.11.0
- move the canonical release state into release phase while keeping the exact release commit pending
- record the completed local and PR-head validation as candidate evidence
- keep exact-SHA GPU qualification, release dry run, publication and state sync explicitly pending
- make the pre-publication checklist boundary explicit for the release workflow

## Validation

- canonical release-state and generated PyPI README checks
- 160 focused release-state, packaging and workflow tests
- Ruff, format, Mypy and actionlint
- strict MkDocs build, generated artifacts, links and text integrity
- release-version wheel/sdist build and Twine checks
- frozen calculator and rollout preregistration hashes unchanged

This PR does not tag or publish v0.11.0. Its merge commit becomes the only candidate for attempt-1 WSL2 RTX 4080 full qualification.
