### PR TITLE
Keep GPU qualification inside its virtualenv

### DIFF
--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -117,10 +117,13 @@ jobs:
           from pathlib import Path
           manifest = json.loads(Path("candidate/candidate-manifest.json").read_text())
           wheel = (Path("candidate") / manifest["wheel"]["filename"]).resolve()
+          qualification_python = Path.cwd() / ".gpu-qualification-venv/bin/python"
+          if not qualification_python.is_file():
+              raise SystemExit(f"missing qualification interpreter: {qualification_python}")
           with Path(os.environ["GITHUB_ENV"]).open("a", encoding="utf-8") as handle:
               handle.write(f"QUALIFICATION_WHEEL={wheel}\n")
               handle.write(f"QUALIFICATION_WHEEL_SHA256={manifest['wheel']['sha256']}\n")
-              handle.write(f"QUALIFICATION_PYTHON={Path('.gpu-qualification-venv/bin/python').resolve()}\n")
+              handle.write(f"QUALIFICATION_PYTHON={qualification_python}\n")
           PY
       - name: Install the exact candidate wheel
         run: |

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -118,6 +118,8 @@ def test_gpu_workflow_builds_candidate_only_on_hosted_job() -> None:
     assert "runs-on: [self-hosted, cuda, rtx4080, wsl2]" in qualify
     assert "shell: pwsh" not in qualify
     assert 'uv" venv --seed --python 3.12.13' in qualify
+    assert 'Path.cwd() / ".gpu-qualification-venv/bin/python"' in qualify
+    assert "Path('.gpu-qualification-venv/bin/python').resolve()" not in qualify
 
 
 def test_gpu_workflow_refuses_rerun_attempts_and_separates_smoke_from_full() -> None:


### PR DESCRIPTION
## Summary

- keep the GPU qualification interpreter path anchored inside `.gpu-qualification-venv`
- stop resolving the venv `python` symlink to uv's externally managed base interpreter
- add a workflow regression assertion for the interpreter-path contract

## Reproduced failure

Fresh full qualification run 33282021980 failed before candidate installation because `Path.resolve()` converted the venv entry point into the uv-managed base Python and pip correctly refused it under PEP 668. No GPU benchmark or training workload ran in that failed attempt, and it was not rerun.

## Validation

- `pytest -q tests/unit/test_release_workflow.py tests/unit/test_release_candidate.py tests/unit/test_release_gate.py` (26 passed, 1 Windows symlink-permission skip)
- `ruff check tests/unit/test_release_workflow.py`
- `ruff format --check tests/unit/test_release_workflow.py`
- actionlint 1.7.12, official archive SHA-256 verified
- `git diff --check`