### PR TITLE
Advance development to 0.11.1.dev0

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -6,12 +6,12 @@ current product and evidence state rather than repeating release history.
 
 Last updated: 2026-08-29.
 
-Canonical release state: releasing `v0.11.0`.
+Canonical release state: stable `v0.11.0` (`479695c4980150bc6f7a51bddec2b90c08c8bb98`), development `0.11.1.dev0`.
 
 ## Release state
 
-- Release candidate: `v0.11.0`; the exact release commit is pending.
-- Package version: `0.11.0`.
+- Stable release: `v0.11.0` at `479695c4980150bc6f7a51bddec2b90c08c8bb98`.
+- Development release: `0.11.1.dev0`.
 - Stable docs: <https://daoyuanli2816.github.io/mini-verl/>.
 - Development docs: <https://daoyuanli2816.github.io/mini-verl/dev/>.
 - Historical build log: [v0.1-v0.9 archive](docs/history/project-state-v0.1-v0.9.md).
@@ -31,7 +31,7 @@ Executable compatibility claims are mutation-tested and recorded in
 unknown-size quantized roles require proof instead of receiving an executable
 plan.
 
-Release `0.11.0` has a closed typed profile registry and torch-free
+Development `0.11.1.dev0` has a closed typed profile registry and torch-free
 compatibility introspection. Profile-scoped plans, caches, checkpoints and
 exports bind an independent identity. The direct-GKD and sampled-k1 vanilla
 policy-loss profiles both have pinned conformance and measured RTX 4080 paths.

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.11.0/docs/banner.svg" alt="miniVERL — run verl-style OPD on one consumer GPU" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — run verl-style OPD on one consumer GPU" width="880">
 </p>
 
 <div align="center">
@@ -8,7 +8,7 @@
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE)
 
 </div>
 
@@ -16,7 +16,7 @@
   <a href="https://pypi.org/project/miniverl/"><strong>PyPI</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/"><strong>Stable docs</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/dev/">Development docs</a> ·
-  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/README.zh-CN.md">中文</a>
+  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/main/README.zh-CN.md">中文</a>
 </p>
 
 **Run verl-style on-policy distillation on one NVIDIA GPU, with every config
@@ -49,7 +49,7 @@ run the pinned Qwen3-0.6B actor and Qwen3-1.7B teacher recipe.
 The `[train,cuda]` extra installs the ML and quantization dependencies. Select
 the matching CUDA PyTorch wheel separately with the
 [PyTorch installer](https://pytorch.org/get-started/locally/). The
-[single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/single-gpu-guide.md) covers memory planning from 8 GiB
+[single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) covers memory planning from 8 GiB
 cards upward and includes the maintainer-measured RTX 4080 stack.
 
 ## What a run gives you
@@ -77,8 +77,8 @@ miniverl bridge doctor scaleout --json
 ## How it works
 
 <picture>
-  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.11.0/docs/verl-local-runtime-mobile.svg">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.11.0/docs/verl-local-runtime.svg" alt="Typed verl-style configuration and Parquet prompts compile into sequential actor rollout, teacher scoring and actor update phases on one CUDA GPU, producing inspectable local artifacts and a pinned scale-out bundle.">
+  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime-mobile.svg">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime.svg" alt="Typed verl-style configuration and Parquet prompts compile into sequential actor rollout, teacher scoring and actor update phases on one CUDA GPU, producing inspectable local artifacts and a pinned scale-out bundle.">
 </picture>
 
 miniVERL schedules actor, teacher and optional reference roles in phases inside
@@ -97,10 +97,10 @@ reconstructing intent from console logs.
 
 | Goal | First command | Primary artifact | Next step |
 | --- | --- | --- | --- |
-| **Run local OPD** | `miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml` | immutable execution plan | [OPD quickstart](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/opd-quickstart.md) |
-| **Bring a verl profile** | `miniverl compat check --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml` | field-by-field compatibility report | [For verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/for-verl-users.md) |
-| **Fit your GPU** | `miniverl plan --config verl-opd.yaml --probe` | measured placement plan | [Hardware planning](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/hardware-planning.md) |
-| **Hand off for scale-out** | `miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout` | PEFT + Parquet + config bundle | [Scale-out contract](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/verl-opd-scaleout.md) |
+| **Run local OPD** | `miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml` | immutable execution plan | [OPD quickstart](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/opd-quickstart.md) |
+| **Bring a verl profile** | `miniverl compat check --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml` | field-by-field compatibility report | [For verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/for-verl-users.md) |
+| **Fit your GPU** | `miniverl plan --config verl-opd.yaml --probe` | measured placement plan | [Hardware planning](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/hardware-planning.md) |
+| **Hand off for scale-out** | `miniverl export-verl --run runs/my-opd --target-verl v0.8.0 --out scaleout` | PEFT + Parquet + config bundle | [Scale-out contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-opd-scaleout.md) |
 
 The native recipe system also supports SFT, DPO, offline KD and tool-aware OPD
 over calculator, JSON navigation, read-only SQLite and custom environments.
@@ -131,7 +131,7 @@ profiles are available:
 | `verl-opd-v0.8-single-gpu-pg-k1-v1` | sampled `k1` + vanilla policy loss | sampled-token teacher log-probability |
 
 Use `miniverl profiles show`, `compat explain` and `compat check` to inspect
-the complete mapping. [Compatibility profiles](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/profiles/index.md) explains
+the complete mapping. [Compatibility profiles](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/profiles/index.md) explains
 how profile identity follows plans, caches, checkpoints and exports. Separate
 conformance-only grouped profiles add transactional Parquet `n>1` samples
 without changing either measured `n=1` profile or introducing GRPO semantics.
@@ -152,7 +152,7 @@ tokens/s and was 3.08–5.97× faster than `hf_cached` in the 256/512-token cell
 Both backends passed memory, eight-refresh and teardown gates. vLLM is the
 measured direct-GKD engine; PG-k1 stays on `hf_cached` because its engine
 log-probability probe exceeded the numerical threshold. See the
-[full runtime result](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/benchmarks/rollout-runtime-v2.md) for every cell,
+[full runtime result](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarks/rollout-runtime-v2.md) for every cell,
 the preserved first candidate and artifact hashes.
 
 The Qwen3-0.6B/1.7B developer workload consumed **32 distinct prompts**, used a
@@ -165,8 +165,8 @@ adapter and optimizer tensors.
 A second SmolLM2-360M/1.7B workload completed the same 32-prompt, 8-update
 shape at 1.4961 GiB peak reserved VRAM, including exact resume, PEFT reload and
 scale-out materialization. Read the
-[Qwen3](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/verl-opd-reference-workload.md) and
-[SmolLM2](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/smollm2-opd-workload.md) systems records for configs, hashes and
+[Qwen3](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-opd-reference-workload.md) and
+[SmolLM2](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/smollm2-opd-workload.md) systems records for configs, hashes and
 phase-level measurements.
 
 Other NVIDIA GPUs use the same device-name-agnostic CUDA path. Model fit and
@@ -184,13 +184,13 @@ utility regressions that two sandbox safety checks missed. The preregistered
 External Alignment Gate stopped before continuation because every candidate
 failed the retained-utility threshold.
 
-- [Calculator protocol study](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/benchmarking.md)
-- [RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/recoverybench/recoverybench-v1.md)
-- [Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/alignment-lab/alignment-lab-v1.md)
-- [External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/alignment-external/alignment-external-v1.md)
+- [Calculator protocol study](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md)
+- [RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md)
+- [Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md)
+- [External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-external/alignment-external-v1.md)
 
 These reports answer scoped experimental questions; the
-[limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/limitations.md) page collects the measurement, architecture,
+[limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md) page collects the measurement, architecture,
 security and generalization boundaries in one place.
 
 ## Scope
@@ -198,8 +198,8 @@ security and generalization boundaries in one place.
 miniVERL is designed for one local process, one NVIDIA CUDA GPU and the
 documented OPD profiles above. Scale-out support produces and validates a
 portable bundle against the pinned upstream source. The
-[compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/compatibility.md) lists supported fields, profile
-semantics and handoff readiness states; [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/limitations.md)
+[compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md) lists supported fields, profile
+semantics and handoff readiness states; [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md)
 covers the broader execution and scientific boundaries. miniVERL is an
 independent Apache-2.0 project.
 
@@ -212,7 +212,7 @@ python -m pip install -e ".[dev]"
 pytest -q -m "not gpu and not network"
 ```
 
-See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/CONTRIBUTING.md), [CHANGELOG.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/CHANGELOG.md),
-[CITATION.cff](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/CITATION.cff), the
-[reproducibility guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/docs/reproducibility.md), [SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/SECURITY.md)
-and the [Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.11.0/LICENSE).
+See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md), [CHANGELOG.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md),
+[CITATION.cff](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff), the
+[reproducibility guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/reproducibility.md), [SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md)
+and the [Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE).

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "release": "0.11.0",
-  "status": "candidate",
+  "status": "released",
   "quality_floor": "2,000+ tests and 80%+ branch coverage at v0.11.0",
   "local_validation": {
     "scope": "the maintainer's workstation, including the Windows CUDA and network paths",
@@ -27,21 +27,26 @@
     }
   },
   "release_validation": {
-    "scope": "the exact v0.11.0 release commit after release-prep merge",
-    "commit": "pending",
+    "scope": "the exact published v0.11.0 release commit",
+    "commit": "479695c4980150bc6f7a51bddec2b90c08c8bb98",
     "workflows": {
-      "ci": "pending",
-      "build": "pending",
-      "docs": "pending",
-      "pinned_verl_bridge": "pending",
-      "gpu_full_qualification": "pending",
-      "release_dry_run": "pending",
-      "release": "pending"
+      "ci": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/33288026959",
+      "build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/33288026935",
+      "docs": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/33290669271",
+      "pinned_verl_bridge": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/33290669272",
+      "gpu_full_qualification": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/33288192471",
+      "release_dry_run": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/33290350620",
+      "release": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/33290669280"
     },
-    "conclusion": "pending",
-    "gpu_coverage": "pending exact-SHA attempt-1 full qualification on the WSL2 RTX 4080 runner",
+    "conclusion": "passed",
+    "gpu_coverage": "exact-SHA attempt-1 full qualification passed on the ephemeral WSL2 RTX 4080 runner; runtime correctness only",
     "publication": {
-      "status": "pending"
+      "pypi": "https://pypi.org/project/miniverl/0.11.0/",
+      "github_release": "https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.11.0",
+      "documentation": "https://daoyuanli2816.github.io/mini-verl/",
+      "immutable_documentation_build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/33290669271",
+      "wheel_sha256": "d2fb981987b34bc53dfdefa505ded96d019614c69c4d0509360a414e8ab69aca",
+      "sdist_sha256": "5ee1de64b2eaf82d7076f11add1f897d99668b245ba3635a8f9bb7260f970b13"
     }
   }
 }

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  <div class="docs-channel" data-stable-version="0.11.0" data-dev-version="0.11.0">
+  <div class="docs-channel" data-stable-version="0.11.0" data-dev-version="0.11.1.dev0">
     <strong id="docs-channel-label">Stable documentation</strong>
     <label for="docs-version-selector">Version</label>
     <select id="docs-version-selector" aria-label="Documentation version">
       <option value="stable">Stable 0.11.0</option>
-      <option value="dev">Development 0.11.0</option>
+      <option value="dev">Development 0.11.1.dev0</option>
     </select>
   </div>
 {% endblock %}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,6 +4,11 @@ This is the release gate and publication record for miniVERL. A checked item
 names an invariant exercised on the stated source. Publication begins only
 after the exact release commit and its remote checks are green.
 
+## v0.11.1 development
+
+- [x] Begin from the verified v0.11.0 release and advance only the canonical
+      development state to `0.11.1.dev0`.
+
 ## v0.11.0 development
 
 - [x] Advance the canonical development line to `0.11.0.dev0` while stable
@@ -34,12 +39,24 @@ after the exact release commit and its remote checks are green.
 
 ## Publication record
 
-- [ ] Exact-release-SHA WSL2 full qualification passes on attempt 1.
-- [ ] The non-publishing release dry run accepts the same candidate and full
-      qualification without rebuilding distributions.
-- [ ] The annotated tag workflow verifies PyPI hashes, attestations and clean
-      installation before creating the GitHub Release.
-- [ ] Main advances to `0.11.1.dev0` through a green state-sync PR.
+- [x] Exact-release-SHA WSL2 full qualification run
+      [`33288192471`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/33288192471)
+      passed on attempt 1 for commit
+      `479695c4980150bc6f7a51bddec2b90c08c8bb98`.
+- [x] Non-publishing release dry run
+      [`33290350620`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/33290350620)
+      accepted the same candidate and full qualification without rebuilding.
+- [x] Tag workflow
+      [`33290669280`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/33290669280)
+      verified PyPI hashes, GitHub trusted-publisher attestations and a clean
+      public install before creating the
+      [v0.11.0 GitHub Release](https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.11.0).
+- [x] PyPI and the GitHub Release expose the identical wheel at SHA-256
+      `d2fb981987b34bc53dfdefa505ded96d019614c69c4d0509360a414e8ab69aca`
+      and sdist at SHA-256
+      `5ee1de64b2eaf82d7076f11add1f897d99668b245ba3635a8f9bb7260f970b13`.
+- [x] This state-sync PR advances main to `0.11.1.dev0`; merge only after its
+      required checks pass.
 
 ## v0.10.2 development (superseded by v0.11 scope)
 

--- a/release-state.yaml
+++ b/release-state.yaml
@@ -17,13 +17,13 @@
 # such distinction, which is how its tag shipped a docs selector still
 # advertising "Stable 0.6.1 / Development 0.6.2.dev0".
 schema_version: 1
-phase: release
+phase: development
 
 stable:
   version: "0.11.0"
   tag: "v0.11.0"
-  release_commit: pending
+  release_commit: "479695c4980150bc6f7a51bddec2b90c08c8bb98"
   released_at: "2026-08-29"
 
 development:
-  version: "0.11.0"
+  version: "0.11.1.dev0"

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.11.0"
+__version__ = "0.11.1.dev0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
- record the successful exact-SHA GPU qualification, release dry run, OIDC publication, public hashes and GitHub Release for v0.11.0
- advance the canonical package and development docs state to 0.11.1.dev0 while keeping stable documentation on immutable v0.11.0
- regenerate the PyPI projection so development links resolve through main

## Published evidence
- GPU qualification: https://github.com/DaoyuanLi2816/mini-verl/actions/runs/33288192471
- release dry run: https://github.com/DaoyuanLi2816/mini-verl/actions/runs/33290350620
- release: https://github.com/DaoyuanLi2816/mini-verl/actions/runs/33290669280
- PyPI: https://pypi.org/project/miniverl/0.11.0/
- GitHub Release: https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.11.0

Published distribution hashes:
- wheel: `d2fb981987b34bc53dfdefa505ded96d019614c69c4d0509360a414e8ab69aca`
- sdist: `5ee1de64b2eaf82d7076f11add1f897d99668b245ba3635a8f9bb7260f970b13`

## Validation
- release-state and generated PyPI projections
- 146 focused release-state/packaging tests
- ruff check and format check
- mypy
- Markdown links and text integrity
- strict MkDocs build
- frozen calculator and rollout preregistration hashes unchanged