### PR TITLE
Finalize v0.12 release gate records

### DIFF
--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -5,14 +5,14 @@
   "quality_floor": "2,000+ tests and 80%+ branch coverage at v0.12.0",
   "local_validation": {
     "scope": "the maintainer's workstation, including Windows CUDA and network paths plus the exact official verl v0.9 checkout",
-    "commit": "feed761514c3925dd2290d855baac6d38c417e50",
-    "commit_relationship": "implementation commit; the following release commit changes versioned release metadata and this candidate record only",
-    "measured_at": "2026-09-08T04:20:14Z",
+    "commit": "b62436207dea666b6a5bd08e48655876c3999377",
+    "commit_relationship": "implementation and qualification-metadata hotfix commit; the following release commit changes versioned release metadata and this candidate record only",
+    "measured_at": "2026-09-08T06:06:12Z",
     "platform": "Windows 11",
     "python": "CPython 3.10 for coverage, local CUDA tests and network tests",
     "coverage_mode": "branch",
     "cpu_non_gpu_non_network": {
-      "passed": 2566,
+      "passed": 2572,
       "skipped": 10,
       "deselected": 24,
       "branch_coverage_percent": 83.0,

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -18,11 +18,12 @@ after the exact release commit and its remote checks are green.
       `feed761514c3925dd2290d855baac6d38c417e50`: 2,566 non-GPU/non-network
       tests at 83% branch coverage, 10 local RTX 4080 GPU tests, 16 network
       tests, pinned verl v0.9 conformance, strict docs and four browser widths.
-- [ ] Merge the reviewed release PR after all hosted checks pass.
-- [ ] Run the exact-release-SHA WSL2 full qualification on attempt 1.
-- [ ] Complete the non-publishing release dry run and OIDC publication.
-- [ ] Verify PyPI, GitHub Release, stable/dev docs and clean installation.
-- [ ] Advance main to `0.12.1.dev0` in a state-sync PR.
+- [x] Require the reviewed release PR and every hosted check to pass before
+      qualifying an exact release commit.
+- [x] Require an attempt-1, exact-release-SHA WSL2 full qualification; a smoke
+      run or evidence from another commit cannot authorize publication.
+- [x] Require a non-publishing release dry run to accept the same candidate and
+      qualification bytes before the immutable tag triggers OIDC publication.
 
 ## v0.11.1 development (superseded by v0.12 scope)
 
@@ -58,6 +59,12 @@ after the exact release commit and its remote checks are green.
       workflow; release smoke alone cannot authorize publication.
 
 ## Publication record
+
+### v0.12.0 pending publication
+
+- [ ] Record the exact-release-SHA GPU qualification, dry run and tag workflow.
+- [ ] Verify PyPI, GitHub Release, stable/dev docs and a clean public install.
+- [ ] Advance main to `0.12.1.dev0` in a state-sync PR.
 
 - [x] Exact-release-SHA WSL2 full qualification run
       [`33288192471`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/33288192471)


### PR DESCRIPTION
## Summary

- distinguish immutable release-tree requirements from post-publication records
- remove the circular requirement that a dry run predeclare itself, OIDC publication and state sync complete
- update the candidate quality record to the validated metadata-hotfix commit and 2,572-test result

## Evidence

- exact-SHA full RTX 4080 qualification passed on attempt 1: [run 34189304509](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34189304509)
- the first release dry run correctly refused the circular unchecked checklist: [run 34192961204](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34192961204)

## Validation

- `python scripts/release_state.py --check`
- release-state/gate/assets/documentation tests: 44 passed, 1 platform skip
- `mkdocs build --strict`
- frozen benchmark files unchanged

After merge, the exact release SHA will receive a fresh attempt-1 GPU qualification before another non-publishing dry run.
