### PR TITLE
Advance development after v0.12.0 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ title: "miniVERL: A bounded single-GPU runtime for verl-style OPD"
 message: "If you use miniVERL in your work, please cite it as below."
 type: software
 version: 0.12.0
-date-released: 2026-09-07
+date-released: 2026-09-08
 license: Apache-2.0
 repository-code: "https://github.com/DaoyuanLi2816/mini-verl"
 url: "https://github.com/DaoyuanLi2816/mini-verl"

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -4,21 +4,21 @@ Current maintainer handoff for **miniVERL** (`mini-verl` package, `miniverl`
 CLI). `release-state.yaml` is the canonical version source; this page indexes
 current product and evidence state rather than repeating release history.
 
-Last updated: 2026-09-07.
+Last updated: 2026-09-08.
 
-Canonical release state: releasing `v0.12.0`.
+Canonical release state: stable `v0.12.0` (`94216828ecab77d5f87a541563f5c2d8951d5a33`), development `0.12.1.dev0`.
 
 ## Release state
 
-- Release candidate: `v0.12.0`; publication is gated on exact-SHA RTX 4080 qualification.
-- Previous stable release: `v0.11.0` at `479695c4980150bc6f7a51bddec2b90c08c8bb98`.
+- Stable release: `v0.12.0` at `94216828ecab77d5f87a541563f5c2d8951d5a33`.
+- Development line: `0.12.1.dev0`.
 - Stable docs: <https://daoyuanli2816.github.io/mini-verl/>.
 - Development docs: <https://daoyuanli2816.github.io/mini-verl/dev/>.
 - Historical build log: [v0.1-v0.9 archive](docs/history/project-state-v0.1-v0.9.md).
 
 ## Current product boundary
 
-Release `0.12.0` has a closed typed profile compiler and adds
+Development `0.12.1.dev0` has a closed typed profile compiler and adds
 `verl-rl-v0.9-single-gpu-v1`, a typed resolved
 subset of official verl `v0.9.0` at commit
 `483b8a009ba3a97563edee3a19887e4862b8094a`. It compiles GRPO, Dr.GRPO, RLOO

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.12.0/docs/banner.svg" alt="miniVERL — lower verl experiment semantics onto one CUDA GPU" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — lower verl experiment semantics onto one CUDA GPU" width="880">
 </p>
 
 <div align="center">
@@ -8,7 +8,7 @@
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE)
 
 </div>
 
@@ -16,7 +16,7 @@
   <a href="https://pypi.org/project/miniverl/"><strong>PyPI</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/"><strong>Stable docs</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/dev/">Development docs</a> ·
-  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/README.zh-CN.md">中文</a>
+  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/main/README.zh-CN.md">中文</a>
 </p>
 
 **miniVERL runs a validated subset of verl experiment semantics on one NVIDIA
@@ -51,7 +51,7 @@ load the pinned Qwen3-0.6B actor and execute the two-iteration example.
 
 The `[train,cuda]` extra installs the ML and quantization stack; select PyTorch's
 CUDA build separately with the [PyTorch installer](https://pytorch.org/get-started/locally/).
-The [single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/docs/single-gpu-guide.md) covers memory planning and the
+The [single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) covers memory planning and the
 maintainer-measured RTX 4080 environment.
 
 ## What a run gives you
@@ -70,8 +70,8 @@ maintainer-measured RTX 4080 environment.
 ## How it works
 
 <picture>
-  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.12.0/docs/verl-local-runtime-mobile.svg">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.12.0/docs/verl-local-runtime.svg" alt="A resolved verl config compiles into a validated single-GPU execution plan; actor, reference, teacher and reward roles execute in phases and produce portable artifacts plus a readiness report.">
+  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime-mobile.svg">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime.svg" alt="A resolved verl config compiles into a validated single-GPU execution plan; actor, reference, teacher and reward roles execute in phases and produce portable artifacts plus a readiness report.">
 </picture>
 
 One GPU is treated as a temporal scheduler for logical roles. Critic-free RL
@@ -84,10 +84,10 @@ with a teacher-scoring phase in place of outcome-only rewards.
 
 | Goal | First command | Primary artifact | Next step |
 | --- | --- | --- | --- |
-| **Run local RL** | `miniverl import-verl --profile verl-rl-v0.9-single-gpu-v1 --config verl-rl.yaml --out local.yaml` | native recipe + compatibility report | [RL quickstart](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/docs/verl-rl-runtime.md) |
-| **Run local OPD** | `miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml --out plan.json` | immutable execution plan | [OPD quickstart](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/docs/opd-quickstart.md) |
-| **Fit your GPU** | `miniverl plan --config verl-opd.yaml --probe` | measured placement plan | [Hardware planning](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/docs/hardware-planning.md) |
-| **Hand off artifacts** | `miniverl export-verl --run runs/my-run --target-verl v0.8.0 --out scaleout` | PEFT + Parquet + config bundle | [Scale-out contract](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/docs/verl-opd-scaleout.md) |
+| **Run local RL** | `miniverl import-verl --profile verl-rl-v0.9-single-gpu-v1 --config verl-rl.yaml --out local.yaml` | native recipe + compatibility report | [RL quickstart](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-rl-runtime.md) |
+| **Run local OPD** | `miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml --out plan.json` | immutable execution plan | [OPD quickstart](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/opd-quickstart.md) |
+| **Fit your GPU** | `miniverl plan --config verl-opd.yaml --probe` | measured placement plan | [Hardware planning](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/hardware-planning.md) |
+| **Hand off artifacts** | `miniverl export-verl --run runs/my-run --target-verl v0.8.0 --out scaleout` | PEFT + Parquet + config bundle | [Scale-out contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-opd-scaleout.md) |
 
 Native recipes also support SFT, DPO and offline KD, plus calculator, JSON
 navigation, read-only SQLite and custom tool environments.
@@ -105,7 +105,7 @@ navigation, read-only SQLite and custom tool environments.
 | PPO / GAE execution | not implemented | math is conformance-tested; a trainable critic lifecycle is not yet present |
 | Ray, FSDP/FSDP2, Megatron, TP/PP/DP > 1 | distributed-only | these change physical scale, not the local objective |
 
-The generated [v0.9 compatibility record](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/docs/generated/verl-rl-v0.9-compatibility.json)
+The generated [v0.9 compatibility record](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/generated/verl-rl-v0.9-compatibility.json)
 binds every example field to its source value, local target, classification and
 compiler-rule digest. `miniverl import-verl` accepts a resolved documented
 subset, rejects unknown algorithm-changing fields, and never substitutes a
@@ -117,22 +117,22 @@ The published Qwen3-0.6B/1.7B OPD workload consumed 32 distinct prompts and
 completed eight current-policy updates at 3.1914 GiB peak reserved VRAM on an
 RTX 4080. A matched interruption after update four reproduced byte-identical
 trajectories, adapter and optimizer tensors. The SmolLM2-360M/1.7B workload
-completed the same shape at 1.4961 GiB. [System records](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/docs/verl-opd-reference-workload.md)
+completed the same shape at 1.4961 GiB. [System records](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-opd-reference-workload.md)
 contain configs, hashes and phase timings.
 
 Rollout Runtime v2 measured `hf_cached` and managed vLLM across 24 RTX 4080
 cells spanning response length, sampling mode and `n=1/4`. See the
-[runtime report](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/docs/benchmarks/rollout-runtime-v2.md). Evidence for the new
+[runtime report](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarks/rollout-runtime-v2.md). Evidence for the new
 RL family is published through the exact-wheel release qualification rather
 than presented as a task-quality comparison.
 
 ## Research record
 
 The scientific reports preserve their original outcomes and frozen inputs:
-[calculator protocol](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/docs/benchmarking.md),
-[RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/docs/recoverybench/recoverybench-v1.md),
-[Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/docs/alignment-lab/alignment-lab-v1.md), and the
-[External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/docs/alignment-external/alignment-external-v1.md).
+[calculator protocol](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md),
+[RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md),
+[Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md), and the
+[External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-external/alignment-external-v1.md).
 They are scoped studies, separate from runtime qualification.
 
 ## Compatibility boundary
@@ -140,8 +140,8 @@ They are scoped studies, separate from runtime qualification.
 miniVERL targets one local process and one NVIDIA CUDA GPU. The compiler
 distinguishes exact or conformant semantics, local physical lowering,
 distributed-only settings, feasible work not yet implemented, and technically
-unsupported inputs. The [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/docs/compatibility.md) is the
-complete matrix; [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/docs/limitations.md) collects architecture,
+unsupported inputs. The [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md) is the
+complete matrix; [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md) collects architecture,
 measurement, security and generalization boundaries in one place. miniVERL is
 an independent Apache-2.0 project.
 
@@ -154,7 +154,7 @@ python -m pip install -e ".[dev,train]"
 pytest -q -m "not gpu and not network"
 ```
 
-See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/CONTRIBUTING.md), [CHANGELOG.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/CHANGELOG.md),
-[CITATION.cff](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/CITATION.cff), the [guide for verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/docs/for-verl-users.md),
-[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/SECURITY.md) and the
-[Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.12.0/LICENSE).
+See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md), [CHANGELOG.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md),
+[CITATION.cff](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff), the [guide for verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/for-verl-users.md),
+[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md) and the
+[Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE).

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "release": "0.12.0",
-  "status": "candidate",
+  "status": "released",
   "quality_floor": "2,000+ tests and 80%+ branch coverage at v0.12.0",
   "local_validation": {
     "scope": "the maintainer's workstation, including Windows CUDA and network paths plus the exact official verl v0.9 checkout",
@@ -28,25 +28,25 @@
   },
   "release_validation": {
     "scope": "the exact v0.12.0 release commit",
-    "commit": "pending",
+    "commit": "94216828ecab77d5f87a541563f5c2d8951d5a33",
     "workflows": {
-      "ci": "pending",
-      "build": "pending",
-      "docs": "pending",
-      "pinned_verl_bridge": "pending",
-      "gpu_full_qualification": "pending",
-      "release_dry_run": "pending",
-      "release": "pending"
+      "ci": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34193726077",
+      "build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34193726069",
+      "docs": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34198700305",
+      "pinned_verl_bridge": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34198700339",
+      "gpu_full_qualification": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34193785555",
+      "release_dry_run": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34197998778",
+      "release": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34198700279"
     },
-    "conclusion": "pending",
-    "gpu_coverage": "pending exact-SHA attempt-1 full qualification on the WSL2 RTX 4080 runner",
+    "conclusion": "passed",
+    "gpu_coverage": "attempt-1 full qualification of the exact release wheel on one WSL2 RTX 4080; 16 GRPO trajectories and two finite parameter-changing updates passed alongside the v0.11 regression matrix",
     "publication": {
-      "pypi": "pending",
-      "github_release": "pending",
-      "documentation": "pending",
-      "immutable_documentation_build": "pending",
-      "wheel_sha256": "pending",
-      "sdist_sha256": "pending"
+      "pypi": "https://pypi.org/project/miniverl/0.12.0/",
+      "github_release": "https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.12.0",
+      "documentation": "https://daoyuanli2816.github.io/mini-verl/",
+      "immutable_documentation_build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34198700305",
+      "wheel_sha256": "41a7d59b792b977bc4d81d644fc4429e303493b3c4417a6c213c68ad7b0b345f",
+      "sdist_sha256": "38b6f77f27e3986867b5d453c684f7a7b15205809643cfc8470a45e02e3e84ff"
     }
   }
 }

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  <div class="docs-channel" data-stable-version="0.12.0" data-dev-version="0.12.0">
+  <div class="docs-channel" data-stable-version="0.12.0" data-dev-version="0.12.1.dev0">
     <strong id="docs-channel-label">Stable documentation</strong>
     <label for="docs-version-selector">Version</label>
     <select id="docs-version-selector" aria-label="Documentation version">
       <option value="stable">Stable 0.12.0</option>
-      <option value="dev">Development 0.12.0</option>
+      <option value="dev">Development 0.12.1.dev0</option>
     </select>
   </div>
 {% endblock %}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,6 +4,11 @@ This is the release gate and publication record for miniVERL. A checked item
 names an invariant exercised on the stated source. Publication begins only
 after the exact release commit and its remote checks are green.
 
+## v0.12.1 development
+
+- [x] Begin from the verified v0.12.0 release and advance only the canonical
+      development state to `0.12.1.dev0`.
+
 ## v0.12.0 development
 
 - [x] Pin the critic-free RL compiler and conformance fixtures to upstream verl
@@ -60,11 +65,26 @@ after the exact release commit and its remote checks are green.
 
 ## Publication record
 
-### v0.12.0 pending publication
+### v0.12.0
 
-- [ ] Record the exact-release-SHA GPU qualification, dry run and tag workflow.
-- [ ] Verify PyPI, GitHub Release, stable/dev docs and a clean public install.
-- [ ] Advance main to `0.12.1.dev0` in a state-sync PR.
+- [x] Exact-release-SHA WSL2 full qualification run
+      [`34193785555`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34193785555)
+      passed on attempt 1 for commit
+      `94216828ecab77d5f87a541563f5c2d8951d5a33`.
+- [x] Non-publishing release dry run
+      [`34197998778`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34197998778)
+      accepted the same candidate and full qualification without rebuilding.
+- [x] Tag workflow
+      [`34198700279`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34198700279)
+      verified PyPI hashes, trusted-publisher attestations and a clean public
+      install before creating the
+      [v0.12.0 GitHub Release](https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.12.0).
+- [x] PyPI and the GitHub Release expose the identical wheel at SHA-256
+      `41a7d59b792b977bc4d81d644fc4429e303493b3c4417a6c213c68ad7b0b345f`
+      and sdist at SHA-256
+      `38b6f77f27e3986867b5d453c684f7a7b15205809643cfc8470a45e02e3e84ff`.
+- [x] This state-sync PR advances main to `0.12.1.dev0`; merge only after its
+      required checks pass.
 
 - [x] Exact-release-SHA WSL2 full qualification run
       [`33288192471`](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/33288192471)

--- a/release-state.yaml
+++ b/release-state.yaml
@@ -17,13 +17,13 @@
 # such distinction, which is how its tag shipped a docs selector still
 # advertising "Stable 0.6.1 / Development 0.6.2.dev0".
 schema_version: 1
-phase: release
+phase: development
 
 stable:
   version: "0.12.0"
   tag: "v0.12.0"
-  release_commit: pending
-  released_at: "2026-09-07"
+  release_commit: "94216828ecab77d5f87a541563f5c2d8951d5a33"
+  released_at: "2026-09-08"
 
 development:
-  version: "0.12.0"
+  version: "0.12.1.dev0"

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.12.0"
+__version__ = "0.12.1.dev0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

- record v0.12.0 as the stable release at `94216828ecab77d5f87a541563f5c2d8951d5a33`
- bind the quality and publication record to the exact GPU, dry-run, tag, PyPI, docs and GitHub Release evidence
- advance main and development docs to `0.12.1.dev0`

## Published evidence

- [GPU full qualification](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34193785555)
- [non-publishing dry run](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34197998778)
- [OIDC release workflow](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34198700279)
- [PyPI 0.12.0](https://pypi.org/project/miniverl/0.12.0/)
- [GitHub Release v0.12.0](https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.12.0)

Published hashes:

- wheel: `41a7d59b792b977bc4d81d644fc4429e303493b3c4417a6c213c68ad7b0b345f`
- sdist: `38b6f77f27e3986867b5d453c684f7a7b15205809643cfc8470a45e02e3e84ff`

## Validation

- release-state check
- ruff check and format check
- mypy
- 177 focused state/release/assets/docs/packaging tests; 1 Windows symlink skip
- strict MkDocs build
- development wheel/sdist build and twine check
