### PR TITLE
Fix v0.13 qualification release assets

### DIFF
--- a/src/miniverl/qualification.py
+++ b/src/miniverl/qualification.py
@@ -278,6 +278,27 @@ class GPUQualification(_Strict):
                     raise ValueError(
                         "v0.12 full qualification evidence is missing: " + ", ".join(details)
                     )
+            try:
+                requires_v013 = (int(version_parts[0]), int(version_parts[1])) >= (0, 13)
+            except (IndexError, ValueError):
+                requires_v013 = False
+            if requires_v013:
+                v013_checks = {
+                    "v013_pinned_verl_v09_ppo_compiler",
+                    "v013_independent_actor_critic_updates",
+                    "v013_exact_actor_critic_resume",
+                    "v013_trained_reward_model",
+                    "v013_exact_wheel_ppo_runtime",
+                }
+                missing_v013_checks = sorted(v013_checks - set(self.checks.executed))
+                missing_v013_artifacts = sorted(
+                    {"full_v013_ppo_result"} - {artifact.name for artifact in self.artifacts}
+                )
+                if missing_v013_checks or missing_v013_artifacts:
+                    details = missing_v013_checks + missing_v013_artifacts
+                    raise ValueError(
+                        "v0.13 full qualification evidence is missing: " + ", ".join(details)
+                    )
         return self
 
 

--- a/src/miniverl/release_assets.py
+++ b/src/miniverl/release_assets.py
@@ -57,6 +57,9 @@ V011_ARCHIVE_EVIDENCE = {
 V012_ARCHIVE_EVIDENCE = {
     "full_v012_rl_result": ("v012_rl", "v012/rl-qualification.json"),
 }
+V013_ARCHIVE_EVIDENCE = {
+    "full_v013_ppo_result": ("v013_ppo", "v013/ppo-qualification.json"),
+}
 _SPECIAL_EVIDENCE = {"candidate-manifest.json"}
 QUALIFICATION_SUM_FILES = (
     "candidate-manifest.json",
@@ -138,6 +141,7 @@ def _validate_archive_mapping() -> None:
         **ARCHIVE_EVIDENCE,
         **V011_ARCHIVE_EVIDENCE,
         **V012_ARCHIVE_EVIDENCE,
+        **V013_ARCHIVE_EVIDENCE,
     }.items():
         if (
             not original_name
@@ -161,17 +165,15 @@ def _archive_evidence_for_version(version: str) -> dict[str, tuple[str, str]]:
     mapping = dict(ARCHIVE_EVIDENCE)
     version_parts = version.split(".", 2)
     try:
-        is_v011 = (int(version_parts[0]), int(version_parts[1])) >= (0, 11)
+        release_series = (int(version_parts[0]), int(version_parts[1]))
     except (IndexError, ValueError):
-        is_v011 = False
-    if is_v011:
+        return mapping
+    if release_series >= (0, 11):
         mapping.update(V011_ARCHIVE_EVIDENCE)
-    try:
-        is_v012 = (int(version_parts[0]), int(version_parts[1])) >= (0, 12)
-    except (IndexError, ValueError):
-        is_v012 = False
-    if is_v012:
+    if release_series >= (0, 12):
         mapping.update(V012_ARCHIVE_EVIDENCE)
+    if release_series >= (0, 13):
+        mapping.update(V013_ARCHIVE_EVIDENCE)
     return mapping
 
 

--- a/tests/unit/test_release_assets.py
+++ b/tests/unit/test_release_assets.py
@@ -83,10 +83,16 @@ def _fixture(tmp_path: Path, *, version: str = "0.11.0.dev0") -> tuple[Path, Pat
             b'{"kind":"vllm-runtime"}\n',
         ),
     }
-    if version.startswith("0.12."):
+    version_key = tuple(int(part) for part in version.split(".")[:2])
+    if version_key >= (0, 12):
         evidence["full_v012_rl_result"] = (
             "full/v012-rl.json",
             b'{"kind":"v012-rl"}\n',
+        )
+    if version_key >= (0, 13):
+        evidence["full_v013_ppo_result"] = (
+            "full/v013-ppo.json",
+            b'{"kind":"v013-ppo"}\n',
         )
     artifacts = []
     for name, (relative, content) in evidence.items():
@@ -199,12 +205,22 @@ def _fixture(tmp_path: Path, *, version: str = "0.11.0.dev0") -> tuple[Path, Pat
             "other_hardware_measured": False,
         },
     }
-    if version.startswith("0.12."):
+    if version_key >= (0, 12):
         payload["checks"]["executed"].extend(
             [
                 "v012_pinned_verl_v09_compiler",
                 "v012_grpo_nonconstant_reward_update",
                 "v012_exact_wheel_rl_runtime",
+            ]
+        )
+    if version_key >= (0, 13):
+        payload["checks"]["executed"].extend(
+            [
+                "v013_pinned_verl_v09_ppo_compiler",
+                "v013_independent_actor_critic_updates",
+                "v013_exact_actor_critic_resume",
+                "v013_trained_reward_model",
+                "v013_exact_wheel_ppo_runtime",
             ]
         )
     qualification_path = qualification / "qualification.json"
@@ -282,6 +298,7 @@ def test_release_evidence_mapping_is_versioned_for_historical_records() -> None:
     historical = _archive_evidence_for_version("0.10.1")
     current = _archive_evidence_for_version("0.11.0")
     v012 = _archive_evidence_for_version("0.12.0")
+    v013 = _archive_evidence_for_version("0.13.0")
     assert "full_v011_profiles_result" not in historical
     assert set(current) - set(historical) == {
         "full_v011_profiles_result",
@@ -289,6 +306,7 @@ def test_release_evidence_mapping_is_versioned_for_historical_records() -> None:
         "full_vllm_runtime_result",
     }
     assert set(v012) - set(current) == {"full_v012_rl_result"}
+    assert set(v013) - set(v012) == {"full_v013_ppo_result"}
 
 
 def test_v012_release_archive_includes_rl_qualification(tmp_path: Path) -> None:
@@ -299,6 +317,46 @@ def test_v012_release_archive_includes_rl_qualification(tmp_path: Path) -> None:
 
     assert "v012_rl" in {member["semantic_role"] for member in manifest["members"]}
     assert check_release_assets(output) == []
+
+
+def test_v013_release_archive_includes_ppo_qualification(tmp_path: Path) -> None:
+    from miniverl.release_assets import check_release_assets
+
+    output = _build(tmp_path, version="0.13.0")
+    manifest = json.loads((output / "qualification-evidence-manifest.json").read_text())
+
+    assert "v013_ppo" in {member["semantic_role"] for member in manifest["members"]}
+    assert check_release_assets(output) == []
+
+
+@pytest.mark.parametrize(
+    ("remove_artifact", "remove_check", "match"),
+    [
+        ("full_v013_ppo_result", None, "v0.13 full qualification evidence is missing"),
+        (None, "v013_exact_actor_critic_resume", "v0.13 full qualification evidence is missing"),
+    ],
+)
+def test_v013_qualification_requires_ppo_evidence_and_checks(
+    tmp_path: Path,
+    remove_artifact: str | None,
+    remove_check: str | None,
+    match: str,
+) -> None:
+    from pydantic import ValidationError
+
+    from miniverl.qualification import GPUQualification
+
+    _, _, qualification, _ = _fixture(tmp_path, version="0.13.0")
+    payload = json.loads((qualification / "qualification.json").read_text())
+    if remove_artifact is not None:
+        payload["artifacts"] = [
+            artifact for artifact in payload["artifacts"] if artifact["name"] != remove_artifact
+        ]
+    if remove_check is not None:
+        payload["checks"]["executed"].remove(remove_check)
+
+    with pytest.raises(ValidationError, match=match):
+        GPUQualification.model_validate(payload)
 
 
 def test_archive_and_manifest_are_reproducible_and_explicit(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- archive the new v0.13 PPO qualification evidence under a versioned semantic role
- require the complete v0.13 PPO check set and evidence in full qualification records
- add release-archive and fail-closed regression coverage

## Reproduced failure

The v0.13.0 non-publishing release dry run reached the accepted exact-SHA qualification chain, then failed while preparing release assets with `unknown evidence role: full_v013_ppo_result`. The qualification promoter emitted the role correctly, but the release-asset version map ended at v0.12.

## Validation

- 76 focused release/qualification tests passed; 1 Windows symlink test skipped
- full non-GPU/non-network suite: 2,587 passed, 14 skipped, 24 deselected, 83% branch coverage; the sole initial failure was stale local editable-package metadata and passed after reinstalling this checkout
- Ruff check and format check passed
- mypy passed for 166 source files
- package build and Twine checks passed
- generated qualification schema, release state, PyPI README, Markdown links, text integrity, and frozen calculator SHA-256 checks passed

This PR does not change runtime behavior, benchmark data, release version, or scientific claims.
