### PR TITLE
chore: synchronize v0.15.0 publication and 0.15.1.dev0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -80,6 +80,8 @@ jobs:
           fi
           test -n "$stable_tag"
           git worktree add --detach "${RUNNER_TEMP}/stable-checkout" "$stable_tag"
+          # Release content stays pinned; navigation names the current channels.
+          python scripts/release_state.py --docs-overlay "${RUNNER_TEMP}/stable-checkout"
           (
             cd "${RUNNER_TEMP}/stable-checkout"
             mkdocs build --strict --site-dir "${GITHUB_WORKSPACE}/site"

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -6,20 +6,28 @@ current product and evidence state rather than repeating release history.
 
 Last updated: 2026-09-10.
 
-Canonical release state: releasing `v0.15.0`.
+Canonical release state: stable `v0.15.0` (`659690d92a9ed92a01d1beec0a75873de8b860d5`), development `0.15.1.dev0`.
 
 ## Release state
 
-- v0.15.0 is preparing the direct-config release. Implementation and installed
-  development-wheel PPO/GRPO rehearsals pass; formal candidate qualification
-  and OIDC publication are pending.
+- v0.15.0 is published on PyPI and GitHub. The release uses the exact candidate
+  from full RTX 4080 qualification `34442828628` (attempt 1), accepted by
+  rehearsal `34447536443` and OIDC publication `34448233909`.
 - v4 semantically accepts all seven complete pinned upstream configurations.
   Five derived stress cases add two accepted and three explicit rejections.
   Exact production-model execution is not claimed by static compilation.
-- The installed direct rehearsal completed four actor updates in both cases,
-  four PPO critic updates, reward validation, exact tensor replay and handoff.
-- Local full regression: 2,725 passed, 82.01% branch coverage, plus 18 pinned
-  upstream conformance cases and four documentation viewports.
+- The installed release wheel completed four actor updates in both direct
+  workflows, four PPO critic updates, reward validation, exact tensor replay
+  and inspected handoff. Original upstream YAML bytes were retained.
+- Local full regression: 2,733 passed, 28 skipped, 24 deselected and 82.21%
+  branch coverage. Eighteen pinned upstream conformance checks, 10 GPU tests,
+  15 network tests (one local upstream-v0.8 skip) and four browser viewports
+  also passed; the dedicated upstream bridge CI covered that local skip.
+- Release asset preparation and its current-version round trip include the
+  direct-workflow record at `v015/direct-workflows.json` in the evidence archive.
+- Public PyPI hashes, trusted-publisher attestations, a clean core installation
+  and all 13 GitHub Release assets were verified. The development line is now
+  `0.15.1.dev0`; stable documentation remains tied to `v0.15.0`.
 
 ### Prior stable release (historical)
 
@@ -39,16 +47,16 @@ Canonical release state: releasing `v0.15.0`.
   coverage; 10 RTX 4080 GPU and 16 network tests passed. Four pinned upstream
   conformance tests and four-viewport documentation browser checks passed.
 
-- Stable release: `v0.14.0` at
+- Prior stable release: `v0.14.0` at
   `60afc63da1257e3e22aa6056607a63a90d4d90f1`.
-- Current development line: `0.14.1.dev0`.
+- Development after that release: `0.14.1.dev0`.
 - Stable docs: <https://daoyuanli2816.github.io/mini-verl/>.
 - Development docs: <https://daoyuanli2816.github.io/mini-verl/dev/>.
 - Historical build log: [v0.1-v0.9 archive](docs/history/project-state-v0.1-v0.9.md).
 
 ## Current product boundary
 
-Release `0.15.0` has a closed typed profile compiler: it retains v1/v2/v3 and adds
+Development `0.15.1.dev0` has a closed typed profile compiler: it retains v1/v2/v3 and adds
 `verl-rl-v0.9-single-gpu-v4`, direct execution of resolved RL inputs from official verl
 `v0.9.0` at commit `483b8a009ba3a97563edee3a19887e4862b8094a`.
 It compiles PPO/GAE into phased one-GPU actor, critic, reference and reward
@@ -94,8 +102,8 @@ v0.8 environment/PPO artifact bridge is migration-only.
 
 | Evidence | Status |
 | --- | --- |
-| Installed PPO product workflow | Qwen3-0.6B, 8 trajectories, 4 actor/4 critic updates, 2.7266 GiB peak reserved, 15.688 s reported train duration; exact tensor replay and handoff passed |
-| Installed GRPO product workflow | Qwen3-0.6B, 8 trajectories, 2 actor updates, 1.502 GiB peak reserved, 8.923 s reported train duration; exact tensor replay and handoff passed |
+| Installed direct PPO workflow (v0.15.0) | Qwen3-0.6B, 8 trajectories, 4 actor/4 critic updates, 1.502 GiB peak reserved; exact tensor replay and handoff passed |
+| Installed direct GRPO workflow (v0.15.0) | Qwen3-0.6B, 8 trajectories, 4 actor updates, 1.5039 GiB peak reserved; exact tensor replay and handoff passed |
 | Qwen3-0.6B/1.7B developer workload | 32 prompts, 8 current-policy updates, 3.1914 GiB peak reserved on one RTX 4080; matched interruption/resume was byte-identical |
 | Qwen3 sampled-k1 PG | 32 prompts, 8 updates, exact interruption/resume, 3.1914 GiB peak reserved; no quality comparison |
 | SmolLM2-360M/1.7B direct GKD | 32 prompts, 8 updates, 1.4961 GiB peak reserved; exact resume, PEFT reload and materialized export passed |

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.15.0/docs/banner.svg" alt="miniVERL — lower verl experiment semantics onto one CUDA GPU" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — lower verl experiment semantics onto one CUDA GPU" width="880">
 </p>
 
 <div align="center">
@@ -8,7 +8,7 @@
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE)
 
 </div>
 
@@ -16,7 +16,7 @@
   <a href="https://pypi.org/project/miniverl/"><strong>PyPI</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/"><strong>Stable docs</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/dev/">Development docs</a> ·
-  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/README.zh-CN.md">中文</a>
+  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/main/README.zh-CN.md">中文</a>
 </p>
 
 **Run common verl PPO/GRPO configs directly on one NVIDIA GPU.** Hand miniVERL
@@ -59,13 +59,13 @@ miniverl export-verl --run runs/local-ppo --target-verl v0.9.0 --out ppo-handoff
 miniverl bridge doctor ppo-handoff --json
 ```
 
-The [five-minute workflow](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/docs/for-verl-users.md) explains each artifact and
+The [five-minute workflow](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/for-verl-users.md) explains each artifact and
 offers the matching GRPO commands. These are small length-reward exercises;
 their reward is directly inspectable in `rewards.jsonl`.
 
 `[train]` supplies the ML stack; `[cuda]` additionally supplies quantization.
 Select PyTorch's CUDA build with the [PyTorch installer](https://pytorch.org/get-started/locally/).
-The [single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/docs/single-gpu-guide.md) covers memory planning and the
+The [single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) covers memory planning and the
 maintainer-measured RTX 4080 environment.
 
 ## What a run gives you
@@ -84,8 +84,8 @@ maintainer-measured RTX 4080 environment.
 ## How it works
 
 <picture>
-  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.15.0/docs/verl-local-runtime-mobile.svg">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.15.0/docs/verl-local-runtime.svg" alt="A resolved verl config compiles into a validated single-GPU plan; actor, critic, reference, teacher and reward roles run in phases and produce portable artifacts plus a readiness report.">
+  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime-mobile.svg">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime.svg" alt="A resolved verl config compiles into a validated single-GPU plan; actor, critic, reference, teacher and reward roles run in phases and produce portable artifacts plus a readiness report.">
 </picture>
 
 One GPU is treated as a temporal scheduler for logical roles. RL generates
@@ -99,10 +99,10 @@ the learning signal.
 
 | Goal | First command | Primary artifact | Next step |
 | --- | --- | --- | --- |
-| **Run local RL** | `miniverl run resolved-verl.yaml --dry-run` | semantic report + local plan | [Direct configs](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/docs/direct-verl-config.md) |
-| **Run local OPD** | `miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml --out plan.json` | immutable execution plan | [OPD quickstart](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/docs/opd-quickstart.md) |
-| **Fit your GPU** | `miniverl plan --config verl-opd.yaml --probe` | measured placement plan | [Hardware planning](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/docs/hardware-planning.md) |
-| **Hand off artifacts** | `miniverl export-verl --run runs/my-run --target-verl v0.9.0 --out scaleout` | actor, critic, Parquet + config bundle | [Compatibility contract](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/docs/compatibility.md) |
+| **Run local RL** | `miniverl run resolved-verl.yaml --dry-run` | semantic report + local plan | [Direct configs](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/direct-verl-config.md) |
+| **Run local OPD** | `miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml --out plan.json` | immutable execution plan | [OPD quickstart](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/opd-quickstart.md) |
+| **Fit your GPU** | `miniverl plan --config verl-opd.yaml --probe` | measured placement plan | [Hardware planning](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/hardware-planning.md) |
+| **Hand off artifacts** | `miniverl export-verl --run runs/my-run --target-verl v0.9.0 --out scaleout` | actor, critic, Parquet + config bundle | [Compatibility contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md) |
 
 Native recipes also support SFT, DPO and offline KD, plus calculator, JSON
 navigation, read-only SQLite and custom tool environments.
@@ -120,7 +120,7 @@ navigation, read-only SQLite and custom tool environments.
 | Direct GKD / sampled-k1 OPD | supported | pinned verl v0.8 profiles with teacher targets |
 | Ray, FSDP/FSDP2, Megatron, TP/PP/DP > 1 | distributed-only | these change physical scale, not the local objective |
 
-The [upstream compatibility corpus](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/docs/verl-compatibility-corpus.md) resolves
+The [upstream compatibility corpus](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-compatibility-corpus.md) resolves
 real verl examples and records every field's outcome. The v4 direct compiler
 adds prompt filtering, epoch scheduling and common loss reductions, separating
 semantic acceptance from missing inputs and hardware capacity. v1/v2/v3 remain
@@ -132,22 +132,22 @@ The published Qwen3-0.6B/1.7B OPD workload consumed 32 distinct prompts and
 completed eight current-policy updates at 3.1914 GiB peak reserved VRAM on an
 RTX 4080. A matched interruption after update four reproduced byte-identical
 trajectories, adapter and optimizer tensors. The SmolLM2-360M/1.7B workload
-completed the same shape at 1.4961 GiB. [System records](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/docs/verl-opd-reference-workload.md)
+completed the same shape at 1.4961 GiB. [System records](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-opd-reference-workload.md)
 contain configs, hashes and phase timings.
 
 Rollout Runtime v2 measured `hf_cached` and managed vLLM across 24 RTX 4080
 cells spanning response length, sampling mode and `n=1/4`. See the
-[runtime report](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/docs/benchmarks/rollout-runtime-v2.md). Evidence for the new
+[runtime report](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarks/rollout-runtime-v2.md). Evidence for the new
 RL family is published through the exact-wheel release qualification rather
 than presented as a task-quality comparison.
 
 ## Research record
 
 The scientific reports preserve their original outcomes and frozen inputs:
-[calculator protocol](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/docs/benchmarking.md),
-[RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/docs/recoverybench/recoverybench-v1.md),
-[Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/docs/alignment-lab/alignment-lab-v1.md), and the
-[External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/docs/alignment-external/alignment-external-v1.md).
+[calculator protocol](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md),
+[RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md),
+[Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md), and the
+[External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-external/alignment-external-v1.md).
 They are scoped studies, separate from runtime qualification.
 
 ## Compatibility boundary
@@ -155,8 +155,8 @@ They are scoped studies, separate from runtime qualification.
 miniVERL targets one local process and one NVIDIA CUDA GPU. The compiler
 distinguishes exact or conformant semantics, local physical lowering,
 distributed-only settings, feasible work not yet implemented, and technically
-unsupported inputs. The [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/docs/compatibility.md) is the
-complete matrix; [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/docs/limitations.md) collects architecture,
+unsupported inputs. The [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md) is the
+complete matrix; [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md) collects architecture,
 measurement, security and generalization boundaries in one place. miniVERL is
 an independent Apache-2.0 project.
 
@@ -169,7 +169,7 @@ python -m pip install -e ".[dev,train]"
 pytest -q -m "not gpu and not network"
 ```
 
-See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/CONTRIBUTING.md), [CHANGELOG.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/CHANGELOG.md),
-[CITATION.cff](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/CITATION.cff), the [guide for verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/docs/for-verl-users.md),
-[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/SECURITY.md) and the
-[Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.15.0/LICENSE).
+See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md), [CHANGELOG.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md),
+[CITATION.cff](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff), the [guide for verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/for-verl-users.md),
+[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md) and the
+[Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE).

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -1,23 +1,31 @@
 {
   "schema_version": 2,
   "release": "0.15.0",
-  "status": "candidate",
+  "status": "released",
   "quality_floor": "2,000+ tests and 80%+ branch coverage at v0.15.0",
   "local_validation": {
-    "scope": "direct-config implementation regression; dirty development tree before candidate freeze",
-    "commit": "1484b27d753500109a68e8d31bbace7e97346f85",
-    "commit_relationship": "development worktree based on this commit; v0.15 candidate changes were uncommitted when measured",
-    "measured_at": "2026-09-10T03:56:32Z",
+    "scope": "full CPU regression after the release-archive fix; unchanged runtime GPU/network/conformance checks from the implementation pass",
+    "commit": "6de1054f998d87f6306f12b88b2a61405f9a321d",
+    "commit_relationship": "final repair PR head; the squash release commit has the same tree",
+    "measured_at": "2026-09-10T05:50:51Z",
     "platform": "Windows 11",
     "python": "CPython 3.10.11",
     "coverage_mode": "branch",
-    "gpu": {"passed": 10, "hardware": "NVIDIA GeForce RTX 4080", "platform": "WSL2 Ubuntu"},
-    "network": {"passed": 15, "skipped": 1, "skip_reason": "official verl v0.8.0 is not installed in the local test environment; dedicated bridge CI covers that pin"},
+    "gpu": {
+      "passed": 10,
+      "hardware": "NVIDIA GeForce RTX 4080",
+      "platform": "WSL2 Ubuntu"
+    },
+    "network": {
+      "passed": 15,
+      "skipped": 1,
+      "skip_reason": "official verl v0.8.0 is not installed in the local test environment; dedicated bridge CI covers that pin"
+    },
     "cpu_non_gpu_non_network": {
-      "passed": 2725,
-      "skipped": 24,
+      "passed": 2733,
+      "skipped": 28,
       "deselected": 24,
-      "branch_coverage_percent": 82.01,
+      "branch_coverage_percent": 82.21,
       "skip_reason": "Windows privilege/platform skips and pinned upstream tests executed separately"
     },
     "pinned_upstream_conformance": {
@@ -27,22 +35,45 @@
     "docs_visual": {
       "viewports": 4,
       "rendered_svg_instances": 44
-    },
-    "direct_installed_rehearsal": {
-      "status": "passed",
-      "release_evidence": false,
-      "ppo_actor_updates": 4,
-      "ppo_critic_updates": 4,
-      "grpo_actor_updates": 4,
-      "exact_tensor_resume": true,
-      "handoff": "ok"
     }
   },
   "release_validation": {
-    "commit": "pending",
-    "gpu_coverage": "pending first-attempt full exact-candidate qualification",
+    "commit": "659690d92a9ed92a01d1beec0a75873de8b860d5",
+    "gpu_coverage": "attempt-1 full qualification: direct upstream-format PPO/GRPO commands, explicit bindings, exact tensor resume, handoff, historical profiles and complete HF cached/vLLM matrices on one WSL2 RTX 4080",
     "scope": "exact release candidate wheel",
-    "conclusion": "pending full GPU qualification and OIDC publication",
-    "workflows": {}
+    "conclusion": "passed",
+    "hosted_cpu": {
+      "passed": 2721,
+      "skipped": 41,
+      "deselected": 18,
+      "branch_coverage_percent": 82.02
+    },
+    "direct_workflows": {
+      "ppo_actor_updates": 4,
+      "ppo_critic_updates": 4,
+      "grpo_actor_updates": 4,
+      "ppo_peak_reserved_gib": 1.502,
+      "grpo_peak_reserved_gib": 1.5039,
+      "exact_tensor_resume": true,
+      "source_bytes_preserved": true,
+      "manual_native_yaml_edits": false,
+      "handoff": "ok",
+      "distributed_execution_tested": false
+    },
+    "workflows": {
+      "ci": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34442426777",
+      "build": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34442426780",
+      "docs": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34442426834",
+      "pinned_verl_bridge": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34436699306",
+      "gpu_full_qualification": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34442828628",
+      "release_dry_run": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34447536443",
+      "release": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34448233909"
+    },
+    "publication": {
+      "pypi": "https://pypi.org/project/miniverl/0.15.0/",
+      "github_release": "https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.15.0",
+      "wheel_sha256": "e9b909a7bb3983e3699ba39b99f424ce215d1f60ecb0c84b07e647d217803ff3",
+      "sdist_sha256": "6a32dcd93fed32df44ba65ca08cd1ecf26001ba65ea32feb39245f289add3577"
+    }
   }
 }

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  <div class="docs-channel" data-stable-version="0.15.0" data-dev-version="0.15.0">
+  <div class="docs-channel" data-stable-version="0.15.0" data-dev-version="0.15.1.dev0">
     <strong id="docs-channel-label">Stable documentation</strong>
     <label for="docs-version-selector">Version</label>
     <select id="docs-version-selector" aria-label="Documentation version">
       <option value="stable">Stable 0.15.0</option>
-      <option value="dev">Development 0.15.0</option>
+      <option value="dev">Development 0.15.1.dev0</option>
     </select>
   </div>
 {% endblock %}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,16 +1,28 @@
 # Release checklist
 
+## v0.15.1 development
+
+- [x] Begin from the verified v0.15.0 release and advance the canonical
+  development version to `0.15.1.dev0`, keeping stable docs on the release tag.
+
 ## v0.15.0 direct-config release
 
-- Preserve all frozen result and task evidence bytes and historical profile identities.
-- Check v4 source schema, packaged direct examples and the 12-case compilation audit.
-- Run full CPU, pinned upstream conformance, GPU/network, packaging, extracted-sdist,
+- [x] Preserve all frozen result and task evidence bytes and historical profile identities.
+- [x] Check v4 source schema, packaged direct examples and the 12-case compilation audit.
+- [x] Run full CPU, pinned upstream conformance, GPU/network, packaging, extracted-sdist,
   privacy/link and four-viewport documentation checks.
-- Qualify the exact hosted candidate wheel: direct PPO/GRPO, explicit bindings,
+- [x] Qualify the exact hosted candidate wheel: direct PPO/GRPO, explicit bindings,
   scheduled validation, exact actor/critic/optimizer resume and inspected handoff.
-- Require green PR/main CI before first-attempt full GPU qualification and OIDC release.
-- Verify public PyPI hashes/attestation/install and GitHub assets, then advance main
-  to 0.15.1.dev0 with stable and development documentation synchronized.
+- [x] Require green PR/main CI before first-attempt full GPU qualification and OIDC release.
+- [x] Verify public PyPI hashes/attestation/install and GitHub assets; prepare the
+  0.15.1.dev0 state-sync with stable and development documentation.
+
+Published from `659690d92a9ed92a01d1beec0a75873de8b860d5` via
+[full qualification](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34442828628),
+[rehearsal](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34447536443), and
+[OIDC release](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34448233909).
+The first rehearsal caught an unregistered evidence role; PR #121 fixed the
+archive mapping and the replacement candidate was fully requalified.
 
 This is the release gate and publication record for miniVERL. A checked item
 names an invariant exercised on the stated source. Publication begins only

--- a/release-state.yaml
+++ b/release-state.yaml
@@ -17,13 +17,13 @@
 # such distinction, which is how its tag shipped a docs selector still
 # advertising "Stable 0.6.1 / Development 0.6.2.dev0".
 schema_version: 1
-phase: release
+phase: development
 
 stable:
   version: "0.15.0"
   tag: "v0.15.0"
-  release_commit: "pending"
+  release_commit: "659690d92a9ed92a01d1beec0a75873de8b860d5"
   released_at: "2026-09-10"
 
 development:
-  version: "0.15.0"
+  version: "0.15.1.dev0"

--- a/scripts/release_state.py
+++ b/scripts/release_state.py
@@ -365,12 +365,33 @@ def apply_release_state(root: Path, state: ReleaseState | None = None) -> list[s
     return sorted(set(changed))
 
 
+def overlay_docs_versions(stable_root: Path, state: ReleaseState) -> None:
+    """Update navigation metadata in a disposable stable-docs checkout only."""
+    state.validate()
+    if load_release_state(stable_root).stable_version != state.stable_version:
+        raise ValueError("stable version differs from the selected release checkout")
+    relative = "docs/overrides/main.html"
+    path = stable_root / relative
+    text = path.read_text(encoding="utf-8")
+    rules, _ = rules_for(state)
+    for rule in rules:
+        if rule.path != relative:
+            continue
+        matches = rule.matches(text)
+        if len(matches) != 1:
+            raise ValueError(f"expected one docs navigation field: {rule.description}")
+        start, end = matches[0].span("value")
+        text = text[:start] + rule.expected + text[end:]
+    path.write_text(text, encoding="utf-8", newline="")
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--check", action="store_true", help="Fail on any disagreement.")
     group.add_argument("--write", action="store_true", help="Regenerate writable claims.")
+    group.add_argument("--docs-overlay", type=Path, help="Refresh a stable checkout's navigation.")
     return parser
 
 
@@ -378,6 +399,9 @@ def main(argv: list[str] | None = None) -> int:
     arguments = _build_parser().parse_args(argv)
     root = arguments.root
     state = load_release_state(root)
+    if arguments.docs_overlay:
+        overlay_docs_versions(arguments.docs_overlay, state)
+        return 0
     if arguments.write:
         changed = apply_release_state(root, state)
         for path in changed:

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.15.0"
+__version__ = "0.15.1.dev0"
 
 __all__ = ["__version__"]

--- a/tests/unit/test_docs_visual_contract.py
+++ b/tests/unit/test_docs_visual_contract.py
@@ -38,6 +38,7 @@ def test_versioned_docs_and_browser_visual_gate_are_wired() -> None:
     workflow = (ROOT / ".github/workflows/docs.yml").read_text(encoding="utf-8")
     assert "mkdocs build --strict" in workflow
     assert "site/dev" in workflow
+    assert 'release_state.py --docs-overlay "${RUNNER_TEMP}/stable-checkout"' in workflow
     assert "playwright install --with-deps chromium" in workflow
     assert "docs-visual-screenshots" in workflow
 

--- a/tests/unit/test_release_state.py
+++ b/tests/unit/test_release_state.py
@@ -64,6 +64,35 @@ def test_docs_selector_matches_both_channels() -> None:
     assert f">Development {state.development_version}<" in html
 
 
+def test_stable_docs_overlay_changes_only_version_navigation(tmp_path: Path) -> None:
+    from scripts.release_state import overlay_docs_versions
+
+    stable = _clone(tmp_path)
+    state = load_release_state(REPO_ROOT)
+    html_path = stable / "docs/overrides/main.html"
+    original = html_path.read_text(encoding="utf-8")
+    stale = original.replace(state.development_version, "0.0.0.dev0")
+    html_path.write_text(stale, encoding="utf-8")
+    before = {p: (stable / p).read_bytes() for p in TRACKED if p != "docs/overrides/main.html"}
+    overlay_docs_versions(stable, state)
+    assert html_path.read_text(encoding="utf-8") == original
+    assert all((stable / p).read_bytes() == content for p, content in before.items())
+
+
+def test_stable_docs_overlay_rejects_a_different_release(tmp_path: Path) -> None:
+    from scripts.release_state import overlay_docs_versions
+
+    stable = _clone(tmp_path)
+    state = load_release_state(REPO_ROOT)
+    html_path = stable / "docs/overrides/main.html"
+    original = html_path.read_bytes()
+    wrong = ReleaseState("99.0.0", "v99.0.0", "b" * 40, "2026-09-10", "99.0.1.dev0")
+    with pytest.raises(ValueError, match="stable version"):
+        overlay_docs_versions(stable, wrong)
+    assert html_path.read_bytes() == original
+    assert state.stable_version != wrong.stable_version
+
+
 def test_quality_record_floor_names_its_own_release() -> None:
     record = json.loads(
         (REPO_ROOT / "docs" / "generated" / "quality.json").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Record published v0.15.0 qualification, rehearsal, OIDC publication and verified public artifacts.
- Advance development to 0.15.1.dev0; keep stable content on immutable v0.15.0.
- Refresh only the stable site's version navigation during deployment, so both channels name the current development version. Tests reject an overlay onto a different stable version and prove all other files stay unchanged.

## Validation
- 49 release-state, archive and documentation contract tests passed (one Windows symlink skip).
- Ruff, formatting, mypy, actionlint, generated state, links and text checks passed.
- Strict development and overlaid stable docs builds passed; browser checks covered 44 SVG instances at four viewports with manual screenshot review.
- PyPI hashes, attestations, clean core install and all 13 GitHub asset digests verified. Frozen evidence and historical compiler bytes remain unchanged.

Release: https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.15.0
PyPI: https://pypi.org/project/miniverl/0.15.0/