### PR TITLE
Record v0.16.0 publication and begin 0.16.1 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to miniVERL are recorded here. The format follows
 
 ## [Unreleased]
 
-## [0.16.0] - 2026-09-11
+## [0.16.0] - 2026-09-12
 
 ### Native verl Hydra ingestion and single-GPU sampling
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ title: "miniVERL: Run verl experiment semantics on one GPU"
 message: "If you use miniVERL in your work, please cite it as below."
 type: software
 version: 0.16.0
-date-released: 2026-09-11
+date-released: 2026-09-12
 license: Apache-2.0
 repository-code: "https://github.com/DaoyuanLi2816/mini-verl"
 url: "https://github.com/DaoyuanLi2816/mini-verl"

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -4,18 +4,34 @@ Current maintainer handoff for **miniVERL** (`mini-verl` package, `miniverl`
 CLI). `release-state.yaml` is the canonical version source; this page indexes
 current product and evidence state rather than repeating release history.
 
-Last updated: 2026-09-11.
+Last updated: 2026-09-12.
 
-Canonical release state: releasing `v0.16.0`.
+Canonical release state: stable `v0.16.0` (`7a6ad7d9fa6e05787dca1b950ba6706c36384382`), development `0.16.1.dev0`.
 
 ## Release state
 
 - The v0.16 work adds native pinned Hydra input and immutable v5 sampling
   semantics. Its 16-case audit has 14 successful compositions and 12 semantic
   acceptances, with explicit composition/semantic rejection cases.
-- Development installed-wheel RTX 4080 rehearsal passed native PPO and GRPO,
-  shuffled epochs, real GRPO filtering, exact tensor replay and handoff. This
-  rehearsal does not replace the mandatory exact-release candidate qualification.
+- v0.16.0 is published on PyPI and GitHub from exact-release-SHA full RTX 4080
+  qualification `34579023220` (attempt 1), non-publishing rehearsal `34679933372`
+  and OIDC publication `34680345232`. No distributions were rebuilt for publication.
+- The installed candidate completed native PPO (4 actor / 4 critic updates)
+  and GRPO (4 actor updates, 4 filtered groups), shuffled epochs, synchronous
+  refill, exact tensor and semantic-journal resume, and inspected handoff.
+  Both workflows reserved at most 1.502 GiB. This is a bounded length-reward
+  systems qualification, not a task-quality or distributed-execution result.
+- Final local regression: 2,814 passed, 10 skipped, 24 deselected; 82.15%
+  combined line/branch coverage (85.26% lines, 72.60% branches). Local GPU and
+  network suites passed 10 and 16 tests. Hosted main CI passed 2,774 CPU tests
+  at 81.96% combined coverage; pinned bridge and four-viewport docs jobs passed.
+- Public PyPI hashes, trusted-publisher attestations, clean core and Hydra
+  installation, and all 13 GitHub Release assets were independently verified.
+  The archive includes `v016/hydra-workflows.json`. All 39 historical result
+  and evidence JSON/JSONL files remain byte-identical.
+- Stable docs: <https://daoyuanli2816.github.io/mini-verl/>. Development docs:
+  <https://daoyuanli2816.github.io/mini-verl/dev/>. The canonical state now
+  advances development to `0.16.1.dev0` while stable content remains tag-pinned.
 
 ### Previous stable release: v0.15.0
 
@@ -35,8 +51,8 @@ Canonical release state: releasing `v0.16.0`.
 - Release asset preparation and its current-version round trip include the
   direct-workflow record at `v015/direct-workflows.json` in the evidence archive.
 - Public PyPI hashes, trusted-publisher attestations, a clean core installation
-  and all 13 GitHub Release assets were verified. The development line is now
-  `0.15.1.dev0`; stable documentation remains tied to `v0.15.0`.
+  and all 13 GitHub Release assets were verified. That release advanced the
+  development line to `0.15.1.dev0`, with stable documentation on `v0.15.0`.
 
 ### Prior stable release (historical)
 
@@ -65,7 +81,7 @@ Canonical release state: releasing `v0.16.0`.
 
 ## Current product boundary
 
-Release `0.16.0` has a closed typed profile compiler: it retains v1/v2/v3/v4 and adds
+Development `0.16.1.dev0` has a closed typed profile compiler: it retains v1/v2/v3/v4 and adds
 `verl-rl-v0.9-single-gpu-v5`, native Hydra ingestion and deterministic sampling from verl
 `v0.9.0` at commit `483b8a009ba3a97563edee3a19887e4862b8094a`.
 It compiles PPO/GAE into phased one-GPU actor, critic, reference and reward

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.16.0/docs/banner.svg" alt="miniVERL — lower verl experiment semantics onto one CUDA GPU" width="880">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/banner.svg" alt="miniVERL — lower verl experiment semantics onto one CUDA GPU" width="880">
 </p>
 
 <div align="center">
@@ -8,7 +8,7 @@
 [![Build](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml/badge.svg)](https://github.com/DaoyuanLi2816/mini-verl/actions/workflows/build.yml)
 [![PyPI](https://img.shields.io/pypi/v/miniverl.svg)](https://pypi.org/project/miniverl/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE)
 
 </div>
 
@@ -16,7 +16,7 @@
   <a href="https://pypi.org/project/miniverl/"><strong>PyPI</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/"><strong>Stable docs</strong></a> ·
   <a href="https://daoyuanli2816.github.io/mini-verl/dev/">Development docs</a> ·
-  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/README.zh-CN.md">中文</a>
+  <a href="https://github.com/DaoyuanLi2816/mini-verl/blob/main/README.zh-CN.md">中文</a>
 </p>
 
 **Run common verl PPO/GRPO configs directly on one NVIDIA GPU.** Hand miniVERL
@@ -66,13 +66,13 @@ miniverl export-verl --run runs/local-ppo --target-verl v0.9.0 --out ppo-handoff
 miniverl bridge doctor ppo-handoff --json
 ```
 
-The [five-minute workflow](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/docs/for-verl-users.md) explains each artifact and
+The [five-minute workflow](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/for-verl-users.md) explains each artifact and
 offers the matching GRPO commands. These are small length-reward exercises;
 their reward is directly inspectable in `rewards.jsonl`.
 
 `[train]` supplies the ML stack, `[hydra]` pins composition, and `[cuda]` adds quantization.
 Select PyTorch's CUDA build with the [PyTorch installer](https://pytorch.org/get-started/locally/).
-The [single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/docs/single-gpu-guide.md) covers memory planning and the
+The [single-GPU guide](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/single-gpu-guide.md) covers memory planning and the
 maintainer-measured RTX 4080 environment.
 
 ## What a run gives you
@@ -91,8 +91,8 @@ maintainer-measured RTX 4080 environment.
 ## How it works
 
 <picture>
-  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.16.0/docs/verl-local-runtime-mobile.svg">
-  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/v0.16.0/docs/verl-local-runtime.svg" alt="A resolved verl config compiles into a validated single-GPU plan; actor, critic, reference, teacher and reward roles run in phases and produce portable artifacts plus a readiness report.">
+  <source media="(max-width: 640px)" srcset="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime-mobile.svg">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/mini-verl/main/docs/verl-local-runtime.svg" alt="A resolved verl config compiles into a validated single-GPU plan; actor, critic, reference, teacher and reward roles run in phases and produce portable artifacts plus a readiness report.">
 </picture>
 
 One GPU is treated as a temporal scheduler for logical roles. RL generates
@@ -106,10 +106,10 @@ the learning signal.
 
 | Goal | First command | Primary artifact | Next step |
 | --- | --- | --- | --- |
-| **Run local RL** | `miniverl run --verl-config-name ppo_trainer --dry-run` | composition + semantic report + local plan | [Direct configs](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/docs/direct-verl-config.md) |
-| **Run local OPD** | `miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml --out plan.json` | immutable execution plan | [OPD quickstart](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/docs/opd-quickstart.md) |
-| **Fit your GPU** | `miniverl plan --config verl-opd.yaml --probe` | measured placement plan | [Hardware planning](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/docs/hardware-planning.md) |
-| **Hand off artifacts** | `miniverl export-verl --run runs/my-run --target-verl v0.9.0 --out scaleout` | actor, critic, Parquet + config bundle | [Compatibility contract](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/docs/compatibility.md) |
+| **Run local RL** | `miniverl run --verl-config-name ppo_trainer --dry-run` | composition + semantic report + local plan | [Direct configs](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/direct-verl-config.md) |
+| **Run local OPD** | `miniverl plan --profile verl-opd-v0.8-single-gpu-v1 --config verl-opd.yaml --out plan.json` | immutable execution plan | [OPD quickstart](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/opd-quickstart.md) |
+| **Fit your GPU** | `miniverl plan --config verl-opd.yaml --probe` | measured placement plan | [Hardware planning](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/hardware-planning.md) |
+| **Hand off artifacts** | `miniverl export-verl --run runs/my-run --target-verl v0.9.0 --out scaleout` | actor, critic, Parquet + config bundle | [Compatibility contract](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md) |
 
 Native recipes also support SFT, DPO and offline KD, plus calculator, JSON
 navigation, read-only SQLite and custom tool environments.
@@ -127,7 +127,7 @@ navigation, read-only SQLite and custom tool environments.
 | Direct GKD / sampled-k1 OPD | supported | pinned verl v0.8 profiles with teacher targets |
 | Ray, FSDP/FSDP2, Megatron, TP/PP/DP > 1 | distributed-only | these change physical scale, not the local objective |
 
-The [upstream compatibility corpus](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/docs/verl-compatibility-corpus.md) resolves
+The [upstream compatibility corpus](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-compatibility-corpus.md) resolves
 real verl examples and records every field's outcome. Native Hydra composition,
 shuffled actor/critic epochs and group filtering/refill use the new v5 profile.
 Composition, semantics and hardware remain separate statuses. Resolved YAML
@@ -139,22 +139,22 @@ The published Qwen3-0.6B/1.7B OPD workload consumed 32 distinct prompts and
 completed eight current-policy updates at 3.1914 GiB peak reserved VRAM on an
 RTX 4080. A matched interruption after update four reproduced byte-identical
 trajectories, adapter and optimizer tensors. The SmolLM2-360M/1.7B workload
-completed the same shape at 1.4961 GiB. [System records](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/docs/verl-opd-reference-workload.md)
+completed the same shape at 1.4961 GiB. [System records](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/verl-opd-reference-workload.md)
 contain configs, hashes and phase timings.
 
 Rollout Runtime v2 measured `hf_cached` and managed vLLM across 24 RTX 4080
 cells spanning response length, sampling mode and `n=1/4`. See the
-[runtime report](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/docs/benchmarks/rollout-runtime-v2.md). Evidence for the new
+[runtime report](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarks/rollout-runtime-v2.md). Evidence for the new
 RL family is published through the exact-wheel release qualification rather
 than presented as a task-quality comparison.
 
 ## Research record
 
 The scientific reports preserve their original outcomes and frozen inputs:
-[calculator protocol](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/docs/benchmarking.md),
-[RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/docs/recoverybench/recoverybench-v1.md),
-[Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/docs/alignment-lab/alignment-lab-v1.md), and the
-[External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/docs/alignment-external/alignment-external-v1.md).
+[calculator protocol](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/benchmarking.md),
+[RecoveryBench](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/recoverybench/recoverybench-v1.md),
+[Alignment Lab](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-lab/alignment-lab-v1.md), and the
+[External Alignment Gate](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/alignment-external/alignment-external-v1.md).
 They are scoped studies, separate from runtime qualification.
 
 ## Compatibility boundary
@@ -162,8 +162,8 @@ They are scoped studies, separate from runtime qualification.
 miniVERL targets one local process and one NVIDIA CUDA GPU. The compiler
 distinguishes exact or conformant semantics, local physical lowering,
 distributed-only settings, feasible work not yet implemented, and technically
-unsupported inputs. The [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/docs/compatibility.md) is the
-complete matrix; [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/docs/limitations.md) collects architecture,
+unsupported inputs. The [compatibility policy](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/compatibility.md) is the
+complete matrix; [limitations](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/limitations.md) collects architecture,
 measurement, security and generalization boundaries in one place. miniVERL is
 an independent Apache-2.0 project.
 
@@ -176,7 +176,7 @@ python -m pip install -e ".[dev,train]"
 pytest -q -m "not gpu and not network"
 ```
 
-See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/CONTRIBUTING.md), [CHANGELOG.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/CHANGELOG.md),
-[CITATION.cff](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/CITATION.cff), the [guide for verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/docs/for-verl-users.md),
-[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/SECURITY.md) and the
-[Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/v0.16.0/LICENSE).
+See [CONTRIBUTING.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CONTRIBUTING.md), [CHANGELOG.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CHANGELOG.md),
+[CITATION.cff](https://github.com/DaoyuanLi2816/mini-verl/blob/main/CITATION.cff), the [guide for verl users](https://github.com/DaoyuanLi2816/mini-verl/blob/main/docs/for-verl-users.md),
+[SECURITY.md](https://github.com/DaoyuanLi2816/mini-verl/blob/main/SECURITY.md) and the
+[Apache-2.0 license](https://github.com/DaoyuanLi2816/mini-verl/blob/main/LICENSE).

--- a/docs/generated/quality.json
+++ b/docs/generated/quality.json
@@ -1,23 +1,23 @@
 {
   "schema_version": 2,
   "release": "0.16.0",
-  "status": "candidate",
-  "quality_floor": "2,800+ tests and 80%+ combined line/branch coverage for the v0.16.0 candidate",
+  "status": "released",
+  "quality_floor": "2,800+ tests and 80%+ combined line/branch coverage for v0.16.0",
   "local_validation": {
-    "scope": "native Hydra and sampling implementation; release metadata changes checked separately",
-    "commit": "cd8be51f74c0fa182ae8ae651a35c813c8b15514",
-    "commit_relationship": "tested runtime plus separately tested composition-path and pending-docs navigation fixes",
-    "measured_at": "2026-09-11T07:56:00Z",
+    "scope": "final native Hydra and sampling PR head before squash merge",
+    "commit": "63e2c268133c1dd731036ca9f0fabde9b2f7e5a6",
+    "commit_relationship": "identical source tree to the release squash commit",
+    "measured_at": "2026-09-11T08:15:55.477Z",
     "platform": "Windows 11",
     "python": "CPython 3.10.11",
     "coverage_mode": "branch",
     "cpu_non_gpu_non_network": {
-      "passed": 2812,
+      "passed": 2814,
       "skipped": 10,
       "deselected": 24,
       "combined_coverage_percent": 82.15,
-      "line_coverage_percent": 85.25,
-      "branch_coverage_percent": 72.59,
+      "line_coverage_percent": 85.26,
+      "branch_coverage_percent": 72.60,
       "skip_reason": "Windows symlink privilege and POSIX-only tests"
     },
     "gpu": {
@@ -55,9 +55,42 @@
     "distributed_execution_tested": false
   },
   "release_validation": {
-    "commit": "pending",
-    "gpu_coverage": "pending exact-release-SHA full qualification",
-    "status": "pending exact-release-SHA full qualification and publication",
-    "scope": "same hosted candidate bytes must pass full GPU qualification, non-publishing gate and OIDC workflow"
+    "commit": "7a6ad7d9fa6e05787dca1b950ba6706c36384382",
+    "gpu_coverage": "exact-release-SHA full qualification on WSL2 RTX 4080; attempt 1",
+    "status": "published on PyPI and GitHub; public hashes, attestations, clean installation and all 13 assets verified",
+    "scope": "same hosted candidate bytes passed full GPU qualification, non-publishing gate and OIDC publication",
+    "qualification_url": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34579023220",
+    "rehearsal_url": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34679933372",
+    "publication_url": "https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34680345232",
+    "wheel_sha256": "072cb36baf9808869094968c2b09a2aae6d3cc05dd108ca7802f290158182ce8",
+    "sdist_sha256": "7b137b66671ef0b1703d0d3fa731a794bf50275eb8858b19cacbd7d060b20278",
+    "hosted_cpu": {
+      "run_id": 34578386179,
+      "passed": 2774,
+      "skipped": 51,
+      "deselected": 18,
+      "combined_coverage_percent": 81.96
+    },
+    "native_hydra": {
+      "evidence_archive_path": "v016/hydra-workflows.json",
+      "ppo_actor_updates": 4,
+      "ppo_critic_updates": 4,
+      "grpo_actor_updates": 4,
+      "grpo_filtered_groups": 4,
+      "ppo_peak_reserved_gib": 1.502,
+      "grpo_peak_reserved_gib": 1.502,
+      "exact_tensor_resume": true,
+      "exact_semantic_journal_resume": true,
+      "journal_comparison": "trajectories and advantages byte-exact; rewards identical excluding top-level measured duration_ms",
+      "handoff": "ok",
+      "distributed_execution_tested": false,
+      "scientific_scope": "bounded length-reward systems qualification; no task-quality claim"
+    },
+    "public_install": {
+      "core_commands": true,
+      "hydra_grpo_semantic_status": "accepted",
+      "hydra_grpo_execution_status": "requires_bindings",
+      "core_and_hydra_torch_free": true
+    }
   }
 }

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  <div class="docs-channel" data-stable-version="0.16.0" data-dev-version="0.16.0">
+  <div class="docs-channel" data-stable-version="0.16.0" data-dev-version="0.16.1.dev0">
     <strong id="docs-channel-label">Stable documentation</strong>
     <label for="docs-version-selector">Version</label>
     <select id="docs-version-selector" aria-label="Documentation version">
       <option value="stable">Stable 0.16.0</option>
-      <option value="dev">Development 0.16.0</option>
+      <option value="dev">Development 0.16.1.dev0</option>
     </select>
   </div>
 {% endblock %}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,5 +1,10 @@
 # Release checklist
 
+## v0.16.1 development
+
+- [x] Advance the canonical development version to `0.16.1.dev0`, retaining
+  stable documentation and package artifacts on the immutable `v0.16.0` tag.
+
 ## v0.16.0 native Hydra release
 
 - [x] Preserve frozen scientific evidence and v1/v2/v3/v4 compiler identities.
@@ -14,8 +19,37 @@
 - [x] Include native Hydra evidence in the versioned release archive and verify
   current-version archive round trips before candidate qualification.
 
-The exact publication run IDs and distribution hashes are added to the
-post-publication state record; development rehearsals are not release evidence.
+Published on 2026-09-12 from `7a6ad7d9fa6e05787dca1b950ba6706c36384382` via
+[full qualification](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34579023220),
+[rehearsal](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34679933372), and
+[OIDC release](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34680345232).
+
+- [x] Verify public PyPI files and cryptographic trusted-publisher attestations;
+  install core and Hydra from PyPI in a fresh environment without PyTorch.
+- [x] Compare all 13 public GitHub assets against the formal workflow artifact;
+  check the canonical archive, including `v016/hydra-workflows.json`.
+- [x] Verify all 39 historical result/evidence JSON/JSONL files are unchanged.
+
+Native installed-wheel qualification completed PPO 4 actor / 4 critic updates
+and GRPO 4 actor updates with 4 filtered groups, exact tensor and semantic-journal
+resume, and inspected handoff. Peak reserved memory was 1.502 GiB in both paths.
+The reward journal comparison excludes only top-level measured `duration_ms`;
+trajectories and advantages remain byte-exact. These are bounded systems checks.
+
+Public distribution SHA-256:
+
+```text
+072cb36baf9808869094968c2b09a2aae6d3cc05dd108ca7802f290158182ce8  miniverl-0.16.0-py3-none-any.whl
+7b137b66671ef0b1703d0d3fa731a794bf50275eb8858b19cacbd7d060b20278  miniverl-0.16.0.tar.gz
+```
+
+[PyPI](https://pypi.org/project/miniverl/0.16.0/) and
+[GitHub Release](https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.16.0)
+serve the same qualified distribution bytes. Local regression passed 2,814 tests
+with 82.15% combined coverage; GPU/network suites passed 10/16 tests. Hosted
+main CPU CI passed 2,774 tests with 81.96% combined coverage. Full build,
+extracted-sdist, clean-install, static, generated-artifact, link/privacy and
+four-viewport browser checks passed before publication.
 
 ## v0.15.1 development
 

--- a/release-state.yaml
+++ b/release-state.yaml
@@ -17,13 +17,13 @@
 # such distinction, which is how its tag shipped a docs selector still
 # advertising "Stable 0.6.1 / Development 0.6.2.dev0".
 schema_version: 1
-phase: release
+phase: development
 
 stable:
   version: "0.16.0"
   tag: "v0.16.0"
-  release_commit: "pending"
-  released_at: "2026-09-11"
+  release_commit: "7a6ad7d9fa6e05787dca1b950ba6706c36384382"
+  released_at: "2026-09-12"
 
 development:
-  version: "0.16.0"
+  version: "0.16.1.dev0"

--- a/src/miniverl/__init__.py
+++ b/src/miniverl/__init__.py
@@ -14,6 +14,6 @@ Public API
 
 from __future__ import annotations
 
-__version__ = "0.16.0"
+__version__ = "0.16.1.dev0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

Record the verified v0.16.0 publication and advance development to 0.16.1.dev0.

- Keep stable artifacts and docs pinned to 7a6ad7d9fa6e05787dca1b950ba6706c36384382.
- Record exact-candidate GPU qualification, rehearsal, OIDC publication and public byte verification.
- Update the release date, quality record, canonical version projections and generated development PyPI links.

## Publication evidence

- [Full RTX 4080 qualification](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34579023220): native PPO/GRPO, shuffled epochs, real filtering/refill, exact tensor and semantic-journal replay, inspected handoff.
- [Non-publishing rehearsal](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34679933372) and [OIDC publication](https://github.com/DaoyuanLi2816/mini-verl/actions/runs/34680345232) passed using the same candidate bytes.
- [PyPI 0.16.0](https://pypi.org/project/miniverl/0.16.0/): public hashes, cryptographic attestations and fresh core/Hydra installation verified.
- [GitHub Release](https://github.com/DaoyuanLi2816/mini-verl/releases/tag/v0.16.0): all 13 downloaded assets match the formal workflow artifact; the evidence archive includes v016/hydra-workflows.json.

No runtime or frozen result changes. All 39 historical result/evidence JSON/JSONL files are byte-identical. The existing v0.16.0 tag and earlier tags are unchanged.

## Validation

Release-state and generated PyPI checks, Ruff, format, mypy (180 modules), actionlint, Markdown/text checks and strict MkDocs build pass.

- Full local CPU regression: 2,786 passed, 38 skipped, 24 deselected; 82.15% combined coverage. The 28 skipped upstream-source checks were then rerun against the exact pinned v0.9.0 checkout and all passed. The remaining 10 skips are Windows symlink/POSIX limitations.
- Generated Hydra/direct compatibility, Alignment Lab and bridge diagram byte checks pass.
- Browser visual gate: 44 rendered SVG instances across four viewports pass; desktop, tablet and mobile screenshots manually reviewed in `.audit/v016-sync-screenshots/`. Hosted screenshots are retained as CI artifacts.
- No frozen scientific bytes changed. No GPU workload was repeated for this metadata-only PR.

Hosted CI/build/docs/bridge must be green before merge.
